### PR TITLE
fix(parser): rm ffmpeg bsf:a aac_adtstoasc

### DIFF
--- a/src/pkg/parser/ffmpeg/ffmpeg.go
+++ b/src/pkg/parser/ffmpeg/ffmpeg.go
@@ -149,7 +149,11 @@ func (p *Parser) ParseLiveStream(ctx context.Context, streamUrlInfo *live.Stream
 		"-rw_timeout", p.timeoutInUs,
 		"-i", url.String(),
 		"-c", "copy",
-		"-bsf:a", "aac_adtstoasc",
+		// No need for `.ts` output: will cause audio error
+		// No need for `.mp4` output:
+		// 	-	view log via `-v verbose`
+		// 	-	Automatically inserted bitstream filter 'aac_adtstoasc'; args=''
+		// "-bsf:a", "aac_adtstoasc",
 	}
 	for k, v := range headers {
 		if k == "User-Agent" || k == "Referer" {


### PR DESCRIPTION
.ts 文件本身就是使用 ADTS 封装 AAC 音频，如果你对音频使用了 aac_adtstoasc，结果就会变成不兼容的音频流，播放器
无法正确解析，就出现了“刺耳”的声音。

---

btw, 
- 在 ffmpeg 输出的时候可以输出 .mp4, 不需要后面再次转码. `on_record_finished.convert_to_mp4`
- .m3u8 url, 存储为 .ts, 不能有 `"-bsf:a", "aac_adtstoasc"`, 否则声音无法播放
- .flv url, 存储为 .flv, 不需要 aac_adtstoasc





