### PR TITLE
兼容克拉直播分享链接格式

### DIFF
--- a/src/live/hongdoufm/hongdoufm.go
+++ b/src/live/hongdoufm/hongdoufm.go
@@ -1,6 +1,9 @@
 package hongdoufm
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,14 +17,18 @@ import (
 )
 
 const (
-	domain = "www.hongdoufm.com"
-	cnName = "克拉克拉"
+	domain    = "www.hongdoufm.com"
+	domain1   = "live.kilakila.cn"
+	cnName    = "克拉克拉"
+	secretkey = "c98be79a4347bc97" //密钥
+	iv        = "93x0ue23c2c9h8km" //偏移量
 
 	roomInitUrl = "https://live.hongdoulive.com/LiveRoom/getRoomInfo?roomId="
 )
 
 func init() {
 	live.Register(domain, new(builder))
+	live.Register(domain1, new(builder))
 }
 
 type builder struct{}
@@ -40,20 +47,44 @@ type Live struct {
 // 克拉克拉平台直播间连接有两种格式
 // 1、https://www.hongdoufm.com/room/roomid 这是直播间列表中的房间地址
 // 2、http://www.hongdoufm.com/PcLive/index/detail?id=roomid 这是实际直播间地址，上述地址会经过302跳转
+// 3、https://www.hongdoufm.com/room/T8T5c0UGXrpW97cbsVP1Qnr5keKGA07wvyC6hdebJXGnGxP91VOt_nFQNhDdKna1SFfDdDECfH46UeFIyPfW3Q==
+//
+//	room后的路径需要aes解密才能得到2081356094101258743?sign=64840db0d2bfc7f8d23c224a898cefa4问号前面的是直播间id
+//
+// 4、https://www.hongdoufm.com/PcLive/index/detail?_specific_parameter=W3-Fy88x1VpVp8SIOS_9_Jwt52fAj7OCm07pIritnjzILTCoJjkQLLp7zsPU60cJtrzVgdwx66LiAu0-7IggJQ%3D%3D
+// 由3的链接302跳转得到 经3的方式解密得到 id=2081356094101258743&sign=b217a4dcfe2d2b188b0f72196e7636de
 func (l *Live) getRoomInfo() ([]byte, error) {
 	if strings.Contains(l.Url.String(), "?") {
 		//实际直播间地址
 		result, _ := url.ParseQuery(l.Url.RawQuery)
-		roomid := result.Get("id")
-		l.roomID = roomid
+		if result.Get("_specific_parameter") != "" {
+			urlparam := result.Get("_specific_parameter")
+			unescapestr, err := url.QueryUnescape(urlparam)
+			decryptresult, err := decrypt(restoreBase64Standard(unescapestr))
+			if err != nil {
+				return nil, err
+			}
+			newresult, _ := url.ParseQuery(decryptresult)
+			l.roomID = newresult.Get("id")
+		} else {
+			roomid := result.Get("id")
+			l.roomID = roomid
+		}
 	} else {
 		//列表直播间地址
 		paths := strings.Split(l.Url.Path, "/")
 		if len(paths) < 2 {
 			return nil, live.ErrRoomUrlIncorrect
 		}
-		roomid := paths[2]
-		l.roomID = roomid
+		urlparam := paths[2]
+		//直接对roomid进行aes解密，解密成功则得到roomid，失败表示无需解密
+		result, err := decrypt(restoreBase64Standard(urlparam))
+		if err == nil {
+			//需要截取 2081356094101258743?sign=64840db0d2bfc7f8d23c224a898cefa4
+			l.roomID = strings.Split(result, "?")[0]
+		} else {
+			l.roomID = urlparam
+		}
 	}
 
 	resp, err := requests.Get(roomInitUrl + l.roomID)
@@ -95,4 +126,37 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 
 func (l *Live) GetPlatformCNName() string {
 	return cnName
+}
+
+// aes解密
+//
+//	@param ciphertext 待解密字符串
+//	@return string 解密后字符串
+//	@return error
+func decrypt(ciphertext string) (string, error) {
+	block, err := aes.NewCipher([]byte(secretkey))
+	if err != nil {
+		return "", err
+	}
+	decodedCiphertext, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	decryptedData := make([]byte, len(decodedCiphertext))
+	mode := cipher.NewCBCDecrypter(block, []byte(iv))
+	mode.CryptBlocks(decryptedData, decodedCiphertext)
+	return string(pkcs7Unpadding(decryptedData)), nil
+}
+
+func restoreBase64Standard(encryptstr string) string {
+	tmp := strings.ReplaceAll(encryptstr, "-", "+")
+	tmp = strings.ReplaceAll(tmp, "_", "/")
+	return tmp
+}
+
+// 对使用PKCS7填充方式的数据进行去填充
+func pkcs7Unpadding(data []byte) []byte {
+	length := len(data)
+	unpadding := int(data[length-1])
+	return data[:(length - unpadding)]
 }


### PR DESCRIPTION
Closes #854 
兼容以下克拉直播间分享链接
- https://www.hongdoufm.com/room/T8T5c0UGXrpW97cbsVP1Qnr5keKGA07wvyC6hdebJXGnGxP91VOt_nFQNhDdKna1SFfDdDECfH46UeFIyPfW3Q==
	room后的路径需要aes解密才能得到`2081356094101258743?sign=64840db0d2bfc7f8d23c224a898cefa4` `2081356094101258743`是直播间id
- https://www.hongdoufm.com/PcLive/index/detail?_specific_parameter=W3-Fy88x1VpVp8SIOS_9_Jwt52fAj7OCm07pIritnjzILTCoJjkQLLp7zsPU60cJtrzVgdwx66LiAu0-7IggJQ%3D%3D
	由3的链接302跳转得到 `_specific_parameter`参数先url解码，再经3的方式解密得到 `id=2081356094101258743&sign=b217a4dcfe2d2b188b0f72196e7636de` `2081356094101258743`是直播间id

aes密钥是`c98be79a4347bc97` 偏移量是`93x0ue23c2c9h8km`