### PR TITLE
修复：主播名称中的“/”导致文件链接失效

### DIFF
--- a/src/webapp/src/component/live-list/index.tsx
+++ b/src/webapp/src/component/live-list/index.tsx
@@ -146,7 +146,7 @@ class LiveList extends React.Component<Props, IState> {
                 </PopDialog>
                 <Divider type="vertical" />
                 <Button type="link" size="small" onClick={(e) => {
-                    this.props.history.push(`/fileList/${data.address}/${data.name}`);
+                    this.props.history.push(`/fileList/${data.address}/${data.name.replace(/\//g, '_')}`);
                 }}>文件</Button>
             </span>
         ),


### PR DESCRIPTION
此更改修复了主播名称中的“/”导致文件链接失效的问题。通过在生成链接时将“/”替换为“_”，可以确保链接的正确解析。

Fixes #1067

---
*PR created automatically by Jules for task [3112430792983799892](https://jules.google.com/task/3112430792983799892) started by @kira1928*