### PR TITLE
修复 0.8.0-rc.2 版本中的内存泄露问题

### DIFF
--- a/src/pkg/iostats/collector.go
+++ b/src/pkg/iostats/collector.go
@@ -165,6 +165,9 @@ func (c *Collector) collectNetworkStats(timestamp int64, elapsed float64) []*IOS
 	c.lastNetworkBytesLock.Lock()
 	defer c.lastNetworkBytesLock.Unlock()
 
+	// 准备新映射以清理不再活跃的主机
+	newLastNetworkBytes := make(map[string]int64, len(allStats))
+
 	for _, connStat := range allStats {
 		// 计算速度
 		lastBytes, exists := c.lastNetworkBytes[connStat.Host]
@@ -175,10 +178,13 @@ func (c *Collector) collectNetworkStats(timestamp int64, elapsed float64) []*IOS
 			speed = int64(float64(currentBytes-lastBytes) / elapsed)
 		}
 
-		c.lastNetworkBytes[connStat.Host] = currentBytes
+		newLastNetworkBytes[connStat.Host] = currentBytes
 		totalBytes += currentBytes
 		totalSpeed += speed
 	}
+
+	// 替换旧映射，实现过期清理
+	c.lastNetworkBytes = newLastNetworkBytes
 
 	// 记录全局网络统计
 	if totalBytes > 0 || totalSpeed > 0 {
@@ -198,15 +204,15 @@ func (c *Collector) collectNetworkStats(timestamp int64, elapsed float64) []*IOS
 // collectRecordStats 收集录制统计数据
 func (c *Collector) collectRecordStats(timestamp int64, elapsed float64) []*IOStat {
 	recorderStatuses := getRecorderStatuses()
-	if len(recorderStatuses) == 0 {
-		return nil
-	}
 
 	var stats []*IOStat
 	var totalWriteSpeed int64
 
 	c.lastRecordBytesLock.Lock()
 	defer c.lastRecordBytesLock.Unlock()
+
+	// 准备新映射以清理不再录制的直播间
+	newLastRecordBytes := make(map[string]int64, len(recorderStatuses))
 
 	for _, rs := range recorderStatuses {
 		// 使用 TotalSize 或 FileSize
@@ -223,7 +229,7 @@ func (c *Collector) collectRecordStats(timestamp int64, elapsed float64) []*IOSt
 			speed = int64(float64(currentBytes-lastBytes) / elapsed)
 		}
 
-		c.lastRecordBytes[key] = currentBytes
+		newLastRecordBytes[key] = currentBytes
 		totalWriteSpeed += speed
 
 		// 记录单个直播间的统计
@@ -238,6 +244,9 @@ func (c *Collector) collectRecordStats(timestamp int64, elapsed float64) []*IOSt
 			})
 		}
 	}
+
+	// 替换旧映射，实现过期清理
+	c.lastRecordBytes = newLastRecordBytes
 
 	// 记录全局录制写入速度
 	if totalWriteSpeed > 0 {

--- a/src/pkg/utils/conn_counter.go
+++ b/src/pkg/utils/conn_counter.go
@@ -66,6 +66,11 @@ func (m *ConnCounterManagerType) GetOrCreateConnCounter(url string) *ByteCounter
 	defer m.mapLock.Unlock()
 	bc, ok := m.bcMap[url]
 	if !ok {
+		// 简单的内存泄露保护：如果记录的主机数量过多（可能是遇到了大量随机变化的 CDN 域名），
+		// 则清空映射以释放内存。虽然这会导致旧的非活跃连接统计丢失，但能保证系统稳定性。
+		if len(m.bcMap) > 1000 {
+			m.bcMap = make(map[string]*ByteCounter)
+		}
 		bc = &ByteCounter{}
 		m.bcMap[url] = bc
 	}


### PR DESCRIPTION
本次修改主要解决了 bililive-go 在长时间运行过程中观察到的内存泄露问题，重点修复了 IO 统计模块中 unbounded map 的增长。

主要更改：
- **iostats/collector.go**: 重构了 `collectNetworkStats` 和 `collectRecordStats` 函数。原本使用永久存在的 map 存储所有历史主机/直播间的字节计数，现在改为每次采集时只保留当前活跃的条目。
- **utils/conn_counter.go**: 针对 `ConnCounterManager` 记录的 `bcMap` 增加了 1000 条记录的阈值限制。一旦超出，将重置 map 以释放因频繁更换 CDN 节点产生的域名记录内存。
- **代码审查**: 确认了 `WrappedLive` 的调度器 `waiters` 清理逻辑和 SSE 管理器的 `RemoveClient` 调用均正常工作。

这些优化能有效控制程序在多直播间、高频率重连场景下的内存占用。

Fixes #1078

---
*PR created automatically by Jules for task [11459182778992057032](https://jules.google.com/task/11459182778992057032) started by @kira1928*