### PR TITLE
Fix "Unknown Host" in Settings Interface

### DIFF
--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -51,10 +51,28 @@ func parseInfo(ctx context.Context, l live.Live) *live.Info {
 	if err != nil || obj == nil {
 		// 缓存中没有信息，可能是 InitializingLive 还未初始化
 		// 创建一个基础信息
+		hostName := "初始化中..."
+		roomName := l.GetRawUrl()
+
+		// 尝试从 InitializingLive 获取数据库缓存的信息
+		target := l
+		if wrapped, ok := l.(*live.WrappedLive); ok {
+			target = wrapped.Live
+		}
+		if setter, ok := target.(live.CachedInfoSetter); ok {
+			h, r := setter.GetCachedInfo()
+			if h != "" {
+				hostName = h
+			}
+			if r != "" {
+				roomName = r
+			}
+		}
+
 		info = &live.Info{
 			Live:         l,
-			HostName:     "初始化中...",
-			RoomName:     l.GetRawUrl(),
+			HostName:     hostName,
+			RoomName:     roomName,
 			Status:       false,
 			Initializing: true,
 		}
@@ -1055,15 +1073,12 @@ func getPlatformStats(writer http.ResponseWriter, r *http.Request) {
 			"live_id":      string(room.LiveId),
 		}
 
-		// 从缓存获取直播间信息（不触发网络请求）
+		// 获取直播间信息（不触发网络请求，使用 parseInfo 处理缓存和默认值）
 		if liveInstance, ok := inst.Lives.Get(room.LiveId); ok {
-			if obj, err := inst.Cache.Get(liveInstance); err == nil {
-				if info, ok := obj.(*live.Info); ok && info != nil {
-					roomInfo["host_name"] = info.HostName
-					roomInfo["room_name"] = info.RoomName
-					roomInfo["status"] = info.Status
-				}
-			}
+			info := parseInfo(r.Context(), liveInstance)
+			roomInfo["host_name"] = info.HostName
+			roomInfo["room_name"] = info.RoomName
+			roomInfo["status"] = info.Status
 		}
 
 		platformRooms[platformKey] = append(platformRooms[platformKey], roomInfo)


### PR DESCRIPTION
This change fixes a bug where the settings interface would display "Unknown Host" (未知主播) for live rooms, particularly during application startup or when adding new rooms.

The issue was caused by the `/api/config/platforms` endpoint manually accessing the runtime cache and omitting `host_name` and `room_name` if they weren't found. This triggered a fallback in the React frontend.

The fix unifies the information retrieval logic by using the `parseInfo` helper. Furthermore, `parseInfo` was enhanced to check the underlying live object for previously known names (cached in the database) even if the live room hasn't finished its first refresh in the current session. This ensures a smoother UX by displaying previously known information immediately.

Fixes #1096

---
*PR created automatically by Jules for task [8951583708823142334](https://jules.google.com/task/8951583708823142334) started by @kira1928*