### PR TITLE
修复 custom_commandline 仅处理首个分段文件的问题

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -46,7 +46,45 @@ on_record_finished:
     upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02" }}.{{ .Ext }}
     delete_after_upload: false
   upload_timing: after_process
+  # 是否将 ASS 弹幕字幕硬编码（烧录）到视频中
+  # 开启后会使用 FFmpeg 重编码视频，将字幕叠加到画面上
+  # 需要同时开启弹幕录制（danmaku_enable）才有 ASS 文件可烧录
+  burn_subtitles: false
+  # 烧录字幕时使用的视频编码器
+  # 默认 libx264（H.264），兼容性最好
+  # 可选 libx265（H.265，压缩率更高但编码更慢）
+  burn_subtitles_codec: libx264
+  # 烧录字幕时的 CRF（恒定速率因子）质量值
+  # 范围 0-51，数值越小画质越好，文件越大
+  # 默认 18（视觉无损），推荐范围 15-23
+  burn_subtitles_crf: "18"
+  # 烧录字幕时的编码预设
+  # 影响编码速度和压缩率的平衡
+  # 可选: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow
+  # 默认 medium，越慢画质越好但耗时越长
+  burn_subtitles_preset: medium
+  # 烧录完成后是否删除原始 ASS 字幕文件
+  # 默认 false（保留 ASS 文件）
+  burn_delete_ass: false
+  # 烧录完成后是否删除源视频文件（如 MP4/FLV）
+  # 默认 false（保留源文件，同时存在源文件和烧录后的 MKV）
+  # 开启后仅保留烧录完成的 MKV 文件
+  burn_delete_source: false
 timeout_in_us: 60000000
+danmaku_enable: false
+danmaku:
+  font_size: 36
+  font_name: Microsoft YaHei
+  scroll_area: full
+  scroll_time: 10
+  resolution: 1920x1080
+  outline: 1
+  opacity: 128
+  record_gift: true
+  record_guard: true
+  record_super_chat: true
+  guard_position: bottom-left
+  sc_position: bottom-left
 live_rooms:
   # quality参数目前仅B站启用，默认为0
   # (B站)0代表原画PRO(HEVC)优先, 其他数值为原画(AVC)

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -579,19 +579,65 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		}
 	}
 
-	if err != nil {
-		r.getLogger().WithError(err).Error("failed to parse live stream")
-		return
-	}
 	r.getLogger().Debugln("End ParseLiveStream(" + url.String() + ", " + fileName + ")")
 	removeEmptyFile(fileName)
+
+	// 确定实际输出的文件列表
+	// 如果使用录播姬下载器，检查是否有分段文件
+	var outputFiles []string
+	if downloaderType == configs.DownloaderBililiveRecorder {
+		partFiles := findBililiveRecorderOutputFiles(fileName)
+		if len(partFiles) > 0 {
+			outputFiles = partFiles
+			r.getLogger().Infof("检测到录播姬分段文件: %d 个", len(partFiles))
+			for i, f := range partFiles {
+				r.getLogger().Debugf("  分段 %d: %s", i, f)
+			}
+
+			// 单文件重命名逻辑：
+			// 1. 只有一个分段文件（_PART000）
+			// 2. 未启用 FixFlvAtFirst（因为录播姬会在修复时自动分段，修复后的文件名已经是正确的）
+			if len(partFiles) == 1 && !resolvedConfig.OnRecordFinished.FixFlvAtFirst {
+				originalFileName := fileName // 原始期望的文件名，不带 _PART000
+				partFileName := partFiles[0] // 录播姬实际输出的文件名，带 _PART000
+
+				// 尝试重命名
+				if err := os.Rename(partFileName, originalFileName); err != nil {
+					r.getLogger().WithError(err).Warnf("无法将 %s 重命名为 %s，保留原文件名", partFileName, originalFileName)
+				} else {
+					r.getLogger().Infof("录播姬单文件重命名: %s -> %s", filepath.Base(partFileName), filepath.Base(originalFileName))
+					outputFiles = []string{originalFileName}
+				}
+			}
+		}
+	}
+	// 如果没有检测到分段文件，使用原始文件名
+	if len(outputFiles) == 0 {
+		// 检查原始文件是否存在
+		if _, statErr := os.Stat(fileName); statErr == nil {
+			outputFiles = []string{fileName}
+		}
+	}
+
+	if err != nil {
+		r.getLogger().WithError(err).Error("failed to parse live stream")
+		if len(outputFiles) == 0 {
+			return
+		}
+		r.getLogger().Info("检测到已生成录制文件，将继续执行后处理")
+	}
+
+	if len(outputFiles) == 0 {
+		r.getLogger().Warn("没有找到任何输出文件，跳过后处理")
+		return
+	}
+
+	// 累积录制文件信息，待录制结束后统一推送摘要
+	r.accumulateRecordedFiles(outputFiles...)
 
 	// 使用层级配置的 OnRecordFinished
 	cmdStr := strings.Trim(resolvedConfig.OnRecordFinished.CustomCommandline, "")
 	if len(cmdStr) > 0 {
-		// 累积录制文件信息（legacy 路径），待录制结束后统一推送摘要
-		r.accumulateRecordedFiles(fileName)
-
 		ffmpegPath, ffmpegErr := utils.GetFFmpegPathForLive(ctx, r.Live)
 		if ffmpegErr != nil {
 			r.getLogger().WithError(ffmpegErr).Error("failed to find ffmpeg")
@@ -603,91 +649,48 @@ func (r *recorder) tryRecord(ctx context.Context) {
 			return
 		}
 
-		buf := new(bytes.Buffer)
-		if execErr := customTmpl.Execute(buf, struct {
-			*live.Info
-			FileName string
-			Ffmpeg   string
-		}{
-			Info:     info,
-			FileName: fileName,
-			Ffmpeg:   ffmpegPath,
-		}); execErr != nil {
-			r.getLogger().WithError(execErr).Errorln("failed to render custom commandline")
-			return
+		for _, f := range outputFiles {
+			buf := new(bytes.Buffer)
+			if execErr := customTmpl.Execute(buf, struct {
+				*live.Info
+				FileName string
+				Ffmpeg   string
+			}{
+				Info:     info,
+				FileName: f,
+				Ffmpeg:   ffmpegPath,
+			}); execErr != nil {
+				r.getLogger().WithError(execErr).Errorf("failed to render custom commandline for %s", f)
+				continue
+			}
+			bash := ""
+			args := []string{}
+			switch runtime.GOOS {
+			case "linux":
+				bash = "sh"
+				args = []string{"-c"}
+			case "windows":
+				bash = "cmd"
+				args = []string{"/C"}
+			default:
+				r.getLogger().Warnln("Unsupport system ", runtime.GOOS)
+			}
+			args = append(args, buf.String())
+			r.getLogger().Debugf("start executing custom_commandline: %s", args[1])
+			cmd := exec.Command(bash, args...)
+			// 跟随全局 Debug 开关输出
+			cmd.Stdout = utils.NewDebugControlledWriter(os.Stdout)
+			cmd.Stderr = utils.NewDebugControlledWriter(os.Stderr)
+			if runErr := cmd.Run(); runErr != nil {
+				r.getLogger().WithError(runErr).Debugf("custom commandline execute failure (%s %s)\n", bash, strings.Join(args, " "))
+			} else if resolvedConfig.OnRecordFinished.DeleteFlvAfterConvert {
+				os.Remove(f)
+			}
+			r.getLogger().Debugf("end executing custom_commandline: %s", args[1])
 		}
-		bash := ""
-		args := []string{}
-		switch runtime.GOOS {
-		case "linux":
-			bash = "sh"
-			args = []string{"-c"}
-		case "windows":
-			bash = "cmd"
-			args = []string{"/C"}
-		default:
-			r.getLogger().Warnln("Unsupport system ", runtime.GOOS)
-		}
-		args = append(args, buf.String())
-		r.getLogger().Debugf("start executing custom_commandline: %s", args[1])
-		cmd := exec.Command(bash, args...)
-		// 跟随全局 Debug 开关输出
-		cmd.Stdout = utils.NewDebugControlledWriter(os.Stdout)
-		cmd.Stderr = utils.NewDebugControlledWriter(os.Stderr)
-		if err = cmd.Run(); err != nil {
-			r.getLogger().WithError(err).Debugf("custom commandline execute failure (%s %s)\n", bash, strings.Join(args, " "))
-		} else if resolvedConfig.OnRecordFinished.DeleteFlvAfterConvert {
-			os.Remove(fileName)
-		}
-		r.getLogger().Debugf("end executing custom_commandline: %s", args[1])
 	} else {
 		// 使用新的 Pipeline 系统处理后处理任务
 		inst := instance.GetInstance(ctx)
-
-		// 确定实际输出的文件列表
-		// 如果使用录播姬下载器，检查是否有分段文件
-		var outputFiles []string
-		if downloaderType == configs.DownloaderBililiveRecorder {
-			partFiles := findBililiveRecorderOutputFiles(fileName)
-			if len(partFiles) > 0 {
-				outputFiles = partFiles
-				r.getLogger().Infof("检测到录播姬分段文件: %d 个", len(partFiles))
-				for i, f := range partFiles {
-					r.getLogger().Debugf("  分段 %d: %s", i, f)
-				}
-
-				// 单文件重命名逻辑：
-				// 1. 只有一个分段文件（_PART000）
-				// 2. 未启用 FixFlvAtFirst（因为录播姬会在修复时自动分段，修复后的文件名已经是正确的）
-				if len(partFiles) == 1 && !resolvedConfig.OnRecordFinished.FixFlvAtFirst {
-					originalFileName := fileName // 原始期望的文件名，不带 _PART000
-					partFileName := partFiles[0] // 录播姬实际输出的文件名，带 _PART000
-
-					// 尝试重命名
-					if err := os.Rename(partFileName, originalFileName); err != nil {
-						r.getLogger().WithError(err).Warnf("无法将 %s 重命名为 %s，保留原文件名", partFileName, originalFileName)
-					} else {
-						r.getLogger().Infof("录播姬单文件重命名: %s -> %s", filepath.Base(partFileName), filepath.Base(originalFileName))
-						outputFiles = []string{originalFileName}
-					}
-				}
-			}
-		}
-		// 如果没有检测到分段文件，使用原始文件名
-		if len(outputFiles) == 0 {
-			// 检查原始文件是否存在
-			if _, err := os.Stat(fileName); err == nil {
-				outputFiles = []string{fileName}
-			}
-		}
-
-		if len(outputFiles) == 0 {
-			r.getLogger().Warn("没有找到任何输出文件，跳过后处理")
-			return
-		}
-
-		// 累积录制文件信息，待录制结束后统一推送摘要
-		r.accumulateRecordedFiles(outputFiles...)
 
 		// 获取 PipelineManager
 		pipelineManager := pipeline.GetManager(inst)


### PR DESCRIPTION
修复了 `custom_commandline` 仅处理分段后第一个文件的问题。

主要更改：
1. **统一文件检测逻辑**：将原先仅在 Pipeline 系统中使用的分段文件检测逻辑（支持录播姬等产生的分段）提取到公共位置，确保无论是 `custom_commandline` 还是 Pipeline 系统都能识别到所有产生的视频分段。
2. **容忍录制中断错误**：在分段重启等场景下，录制进程可能会被杀掉并返回错误。更改后的逻辑会检查是否已经产生了有效的录制文件，如果有，则即使录制过程报错也会继续执行后处理（如 `custom_commandline`）。
3. **支持多文件循环处理**：重构了 `custom_commandline` 的执行逻辑，使其能够循环遍历所有检测到的输出文件并逐一执行命令。
4. **优化空文件清理**：确保在检查录制错误之前先尝试清理可能产生的空文件。

这些改进确保了在开启分段录制或录制因分段而重启时，用户定义的自定义命令能够正确作用于每一个视频分段。

Fixes #1135

---
*PR created automatically by Jules for task [14732007974512427310](https://jules.google.com/task/14732007974512427310) started by @kira1928*