### PR TITLE
[codex] 修复录播姬 PART 文件录制状态误判

### DIFF
--- a/src/live/douyin/douyin_btools.go
+++ b/src/live/douyin/douyin_btools.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/bililive-go/bililive-go/src/live"
 )
+
+const btoolsRequestTimeout = 20 * time.Second
 
 var btoolsConsts = struct {
 	port      int
@@ -15,6 +19,10 @@ var btoolsConsts = struct {
 }{
 	port:      18110,
 	authToken: "Basic YTph",
+}
+
+var btoolsHTTPClient = &http.Client{
+	Timeout: btoolsRequestTimeout,
 }
 
 type ChannelInfo struct {
@@ -38,7 +46,7 @@ type streamInfoResp struct {
 func NewBtoolsLive(live *Live) btoolsLive {
 	return btoolsLive{
 		Live:     live,
-		roomId:   "",
+		roomId:   extractRoomIDFromURL(live.GetRawUrl()),
 		hostName: "",
 		roomName: "",
 	}
@@ -70,29 +78,8 @@ func (l *btoolsLive) updateChannelInfo() (err error) {
 func (l *btoolsLive) fetchChannelInfo() (channelInfo ChannelInfo, err error) {
 	// 使用自定义请求以便添加认证Header
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d/bgo/channel-info?url=%s", btoolsConsts.port, url.QueryEscape(l.Url.String()))
-	req, reqErr := http.NewRequest(http.MethodGet, endpoint, nil)
-	if reqErr != nil {
-		err = reqErr
-		return
-	}
-	req.Header.Set("Authorization", btoolsConsts.authToken)
-
-	resp, doErr := http.DefaultClient.Do(req)
-	if doErr != nil {
-		err = doErr
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("请求失败: %s", resp.Status)
-		return
-	}
-
-	if err = json.NewDecoder(resp.Body).Decode(&channelInfo); err != nil {
-		return
-	}
-	return
+	err = fetchBtoolsJSON(endpoint, &channelInfo)
+	return channelInfo, err
 }
 
 func (l *btoolsLive) fetchLiveInfo() (liveInfo liveInfoResp, err error) {
@@ -104,24 +91,8 @@ func (l *btoolsLive) fetchLiveInfo() (liveInfo liveInfoResp, err error) {
 	}
 
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d/bgo/live-info?platform=douyin&roomId=%s", btoolsConsts.port, url.QueryEscape(l.roomId))
-	req, reqErr := http.NewRequest(http.MethodGet, endpoint, nil)
-	if reqErr != nil {
-		return liveInfo, reqErr
-	}
-	req.Header.Set("Authorization", btoolsConsts.authToken)
-
-	resp, doErr := http.DefaultClient.Do(req)
-	if doErr != nil {
-		return liveInfo, doErr
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return liveInfo, fmt.Errorf("请求失败: %s", resp.Status)
-	}
-	if err = json.NewDecoder(resp.Body).Decode(&liveInfo); err != nil {
-		return liveInfo, err
-	}
-	return liveInfo, nil
+	err = fetchBtoolsJSON(endpoint, &liveInfo)
+	return liveInfo, err
 }
 
 func (l *btoolsLive) fetchStreamInfo() (streamInfo streamInfoResp, err error) {
@@ -133,24 +104,8 @@ func (l *btoolsLive) fetchStreamInfo() (streamInfo streamInfoResp, err error) {
 	}
 
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d/bgo/stream-info?platform=douyin&roomId=%s", btoolsConsts.port, url.QueryEscape(l.roomId))
-	req, reqErr := http.NewRequest(http.MethodGet, endpoint, nil)
-	if reqErr != nil {
-		return streamInfo, reqErr
-	}
-	req.Header.Set("Authorization", btoolsConsts.authToken)
-
-	resp, doErr := http.DefaultClient.Do(req)
-	if doErr != nil {
-		return streamInfo, doErr
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return streamInfo, fmt.Errorf("请求失败: %s", resp.Status)
-	}
-	if err = json.NewDecoder(resp.Body).Decode(&streamInfo); err != nil {
-		return streamInfo, err
-	}
-	return streamInfo, nil
+	err = fetchBtoolsJSON(endpoint, &streamInfo)
+	return streamInfo, err
 }
 
 func (l *btoolsLive) GetInfo() (info *live.Info, err error) {
@@ -185,9 +140,17 @@ func (l *btoolsLive) GetStreamInfos() (us []*live.StreamUrlInfo, err error) {
 	if err != nil {
 		return
 	}
+	if strings.TrimSpace(streamInfo.Stream) == "" {
+		err = fmt.Errorf("无法获取直播流地址")
+		return
+	}
 	u, parseErr := url.Parse(streamInfo.Stream)
 	if parseErr != nil {
 		err = parseErr
+		return
+	}
+	if u.Scheme == "" || u.Host == "" {
+		err = fmt.Errorf("直播流地址无效: %q", streamInfo.Stream)
 		return
 	}
 
@@ -196,4 +159,41 @@ func (l *btoolsLive) GetStreamInfos() (us []*live.StreamUrlInfo, err error) {
 			Url: u,
 		},
 	}, nil
+}
+
+func fetchBtoolsJSON(endpoint string, out interface{}) error {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", btoolsConsts.authToken)
+
+	resp, err := btoolsHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("请求失败: %s", resp.Status)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func extractRoomIDFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	if u.Hostname() != domain {
+		return ""
+	}
+	roomID := strings.Trim(strings.Split(strings.Trim(u.Path, "/"), "/")[0], " ")
+	for _, r := range roomID {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return roomID
 }

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -171,6 +171,33 @@ func findBililiveRecorderOutputFiles(expectedFileName string) []string {
 	return validFiles
 }
 
+func fileSize(path string) (int64, bool) {
+	fileInfo, err := os.Stat(path)
+	if err != nil || fileInfo.IsDir() {
+		return 0, false
+	}
+	return fileInfo.Size(), true
+}
+
+func inspectBililiveRecorderOutputFiles(expectedFileName string) (latestPath string, latestSize int64, exists bool, hasData bool) {
+	partFiles := findBililiveRecorderOutputFiles(expectedFileName)
+	for i := len(partFiles) - 1; i >= 0; i-- {
+		size, ok := fileSize(partFiles[i])
+		if !ok {
+			continue
+		}
+		if !exists {
+			latestPath = partFiles[i]
+			latestSize = size
+			exists = true
+		}
+		if size > 0 {
+			hasData = true
+		}
+	}
+	return
+}
+
 // resolveParserName 根据下载器类型返回实际使用的 parser 名称
 // 实现回退逻辑：bililive-recorder -> ffmpeg -> native
 func resolveParserName(downloaderType configs.DownloaderType, isFLV bool, logger *livelogger.LiveLogger) string {
@@ -1082,14 +1109,8 @@ func (r *recorder) StartTime() time.Time {
 // 仅有 parser（如 ffmpeg 进程）不代表真正在录制 —— ffmpeg 可能因为流 URL 404 等原因
 // 启动后立即失败，没有写入任何视频数据
 func (r *recorder) IsRecording() bool {
-	filePath := r.getCurrentFilePath()
-	if filePath == "" {
-		return false
-	}
-	if fileInfo, err := os.Stat(filePath); err == nil {
-		return fileInfo.Size() > 0
-	}
-	return false
+	_, _, _, hasData := r.getCurrentOutputFile()
+	return hasData
 }
 
 func (r *recorder) Close() {
@@ -1155,6 +1176,37 @@ func (r *recorder) getCurrentFilePath() string {
 	return r.currentFilePath
 }
 
+func (r *recorder) isUsingBililiveRecorderParser() bool {
+	p := r.getParser()
+	if p == nil {
+		return false
+	}
+	_, ok := p.(*bililive_recorder.Parser)
+	return ok
+}
+
+func (r *recorder) getCurrentOutputFile() (path string, size int64, exists bool, hasData bool) {
+	expectedPath := r.getCurrentFilePath()
+	if expectedPath == "" {
+		return "", 0, false, false
+	}
+
+	// BililiveRecorder downloader 会把传入的 output.flv 实际写成
+	// output_PART000.flv、output_PART001.flv……。如果仍只检查 output.flv，
+	// 前端会一直显示“录制准备中”，但磁盘上其实已经在正常写入 PART 文件。
+	if r.isUsingBililiveRecorderParser() {
+		if partPath, partSize, partExists, partHasData := inspectBililiveRecorderOutputFiles(expectedPath); partExists {
+			return partPath, partSize, true, partHasData
+		}
+	}
+
+	if expectedSize, ok := fileSize(expectedPath); ok {
+		return expectedPath, expectedSize, true, expectedSize > 0
+	}
+
+	return expectedPath, 0, false, false
+}
+
 func (r *recorder) GetStatus() (map[string]interface{}, error) {
 	var status map[string]interface{}
 
@@ -1174,12 +1226,15 @@ func (r *recorder) GetStatus() (map[string]interface{}, error) {
 	}
 
 	// 添加文件路径和文件大小信息
-	filePath := r.getCurrentFilePath()
+	filePath, fileSize, fileExists, _ := r.getCurrentOutputFile()
 	if filePath != "" {
 		status["file_path"] = filePath
+		if expectedPath := r.getCurrentFilePath(); expectedPath != "" && expectedPath != filePath {
+			status["expected_file_path"] = expectedPath
+		}
 		// 获取文件大小
-		if fileInfo, err := os.Stat(filePath); err == nil {
-			status["file_size"] = strconv.FormatInt(fileInfo.Size(), 10)
+		if fileExists {
+			status["file_size"] = strconv.FormatInt(fileSize, 10)
 		}
 	}
 

--- a/src/tools/tools.go
+++ b/src/tools/tools.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -598,16 +599,52 @@ func startBTools() error {
 
 	blog.GetLogger().Infoln("Starting bililive-tools server…")
 
-	// 设置状态为已就绪（服务已启动）
-	currentBToolsStatus.Store(int32(BToolsStatusReady))
-
 	// 在 Windows 下使用 Job Object，确保主进程退出时子进程被一并终止
 	// 使用 runWithKillOnCloseAndGetPID 来获取进程 PID
-	return runWithKillOnCloseAndGetPID(cmd, func(pid int) {
+	err = runWithKillOnCloseAndGetPID(cmd, func(pid int) {
 		// 使用通用的进程跟踪器注册子进程
 		RegisterProcess("bililive-tools", pid, ProcessCategoryBTools)
 		blog.GetLogger().Infof("bililive-tools process started with PID: %d", pid)
+		if readyErr := waitForBToolsHTTPReady(15 * time.Second); readyErr != nil {
+			currentBToolsStatus.Store(int32(BToolsStatusFailed))
+			blog.GetLogger().WithError(readyErr).Error("bililive-tools server did not become ready")
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			return
+		}
+		currentBToolsStatus.Store(int32(BToolsStatusReady))
+		blog.GetLogger().Info("bililive-tools server is ready")
 	})
+	if err != nil {
+		currentBToolsStatus.Store(int32(BToolsStatusFailed))
+	}
+	return err
+}
+
+func waitForBToolsHTTPReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: time.Second}
+	endpoint := "http://127.0.0.1:18110/"
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(endpoint)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusInternalServerError {
+				return nil
+			}
+			lastErr = fmt.Errorf("unexpected status: %s", resp.Status)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = context.DeadlineExceeded
+	}
+	return lastErr
 }
 
 func AsyncDownloadIfNecessary(toolName string) {


### PR DESCRIPTION
## 变更

- 修复 BililiveRecorder/录播姬下载器写入 `_PART000.flv` 时，前端仍显示“录制准备中”的问题。
- `IsRecording()` 现在会在录播姬下载器场景下识别 `xxx_PART000.flv`、`xxx_PART001.flv` 等实际输出文件。
- `GetStatus()` 会返回实际写入的 PART 文件路径，并通过 `expected_file_path` 保留原始期望文件名，便于调试。
- 增强抖音 bililive-tools 调用：请求超时、数字房间号预提取、空/非法流地址报错。
- bililive-tools 启动后等待 HTTP 服务真正可用，再标记为 ready。

## 根因

录播姬 CLI 的 downloader 模式会把传入的 `xxx.flv` 实际写成 `xxx_PART000.flv`。原来的录制状态判断只检查 `xxx.flv` 是否存在且大小大于 0，因此录制文件实际已经增长，但 API 仍返回未录制，前端显示为“录制准备中”。

## 验证

- `go test ./src/recorders ./src/live/douyin ./src/tools`
- `make dev`
- `git diff --check`
- 使用 `https://live.douyin.com/581937288414` 本地复测：录播姬生成 `_PART000.flv` 时，`/api/lives` 已返回 `recording: true`。