### PR TITLE
修正 Docker 内置工具的 remotetools 目录结构

### DIFF
--- a/scripts/docker-prepare-tools.mjs
+++ b/scripts/docker-prepare-tools.mjs
@@ -304,12 +304,12 @@ async function main() {
     process.exit(1);
   }
 
-  mkdirSync(outputDir, { recursive: true });
-
   // remotetools 会按 <root>/<goos>/<goarch>/<tool>/<version> 查找工具。
   // Docker 将 outputDir 复制为只读工具根目录，因此这里必须保留平台目录层级。
   const platformOutputDir = join(outputDir, 'linux', arch);
-  mkdirSync(platformOutputDir, { recursive: true });
+  if (!dryRun) {
+    mkdirSync(platformOutputDir, { recursive: true });
+  }
 
   console.log(`=== 为 linux/${arch} 预下载 Docker 内置工具${dryRun ? ' (dry-run)' : ''} ===`);
   console.log(`配置来源: ${configPath}`);
@@ -351,10 +351,10 @@ async function main() {
   console.log(`\n=== 所有工具下载完成 (下载: ${downloadCount}, 跳过: ${skipCount}) ===`);
 
   // 列出下载结果
-  if (existsSync(outputDir)) {
-    const toolDirs = readdirSync(outputDir);
+  if (existsSync(platformOutputDir)) {
+    const toolDirs = readdirSync(platformOutputDir);
     for (const dir of toolDirs) {
-      const dirPath = join(outputDir, dir);
+      const dirPath = join(platformOutputDir, dir);
       if (statSync(dirPath).isDirectory()) {
         console.log(`  ${dir}/`);
       }

--- a/scripts/docker-prepare-tools.mjs
+++ b/scripts/docker-prepare-tools.mjs
@@ -11,7 +11,8 @@
  * 此脚本在 CI 的原生 x86/ARM runner 上运行，避免在 QEMU 中解压大文件
  *
  * 版本号和下载 URL 自动从 src/tools/remote-tools-config.json 读取，
- * 无需手动维护版本号的一致性。
+ * 无需手动维护版本号的一致性。输出目录遵循 remotetools 的
+ * <root>/<goos>/<goarch>/<tool>/<version> 布局。
  *
  * 重要: 解压逻辑必须与 remotetools 的 extractDownloadedFile() 行为一致：
  *   1. 先解压到临时目录
@@ -206,7 +207,7 @@ function downloadFile(url, destPath) {
  * 下载并解压工具到目标目录
  * 模拟 remotetools 的 extractDownloadedFile() 行为
  * @param {string} url
- * @param {string} dest - 最终目标目录（例如 tools/ffmpeg/n8.1-latest）
+ * @param {string} dest - 最终目标目录（例如 tools/linux/amd64/ffmpeg/n8.1-latest）
  */
 async function downloadAndExtract(url, dest) {
   const filename = basename(new URL(url).pathname);
@@ -305,6 +306,11 @@ async function main() {
 
   mkdirSync(outputDir, { recursive: true });
 
+  // remotetools 会按 <root>/<goos>/<goarch>/<tool>/<version> 查找工具。
+  // Docker 将 outputDir 复制为只读工具根目录，因此这里必须保留平台目录层级。
+  const platformOutputDir = join(outputDir, 'linux', arch);
+  mkdirSync(platformOutputDir, { recursive: true });
+
   console.log(`=== 为 linux/${arch} 预下载 Docker 内置工具${dryRun ? ' (dry-run)' : ''} ===`);
   console.log(`配置来源: ${configPath}`);
 
@@ -330,7 +336,7 @@ async function main() {
 
     console.log(`  版本: ${result.version}`);
     console.log(`  URL: ${result.url}`);
-    const destDir = join(outputDir, toolName, result.version);
+    const destDir = join(platformOutputDir, toolName, result.version);
     console.log(`  目标: ${destDir}`);
 
     if (dryRun) {


### PR DESCRIPTION
## 变更内容

- 确认发布构建读取的 `src/tools/remote-tools-config.json` 与程序内嵌配置一致，FFmpeg 均为 `n8.1-latest`
- 将 Docker 预下载工具的输出结构从 `<root>/<tool>/<version>` 修正为 `<root>/linux/<arch>/<tool>/<version>`
- 补充目录布局注释，避免后续再次偏离 remotetools 的查找规则

## 问题原因与回归范围

remotetools 会按 `<root>/<goos>/<goarch>/<tool>/<version>` 查找工具。

此前的 Docker 构建会在镜像内调用 `bililive-go --sync-built-in-tools-to-path`，因此能生成正确的平台目录；Docker Hub 当前 `latest`（v0.7.39）仍采用该旧流程，预装工具可以正常识别。

2026-02-22 引入 CI 原生环境预下载优化后，预下载脚本直接写入 `<root>/<tool>/<version>`，省略了 `linux/<arch>` 层级。该问题影响采用新策略构建的版本，而不是所有历史 Docker 镜像。

实测 v0.8.0-rc.8 linux/amd64 镜像中的 FFmpeg 位于：

```
/opt/bililive/tools/ffmpeg/n8.1-latest/bin/ffmpeg
```

全新容器启动时程序仍会下载到：

```
/srv/bililive/.appdata/external_tools/linux/amd64/ffmpeg/n8.1-latest
```

说明新策略打入的扁平目录未被 remotetools 识别。

## 影响

amd64 和 arm64 Docker 镜像现在可以直接识别 CI 预装的 FFmpeg 8.1 及其他内置工具，避免启动后重复下载。arm/v7 的 FFmpeg 仍按原逻辑由 apt 安装。

## 验证

- `node --check scripts/docker-prepare-tools.mjs`
- amd64 dry-run，确认目标为 `<output>/linux/amd64/ffmpeg/n8.1-latest`
- 对比 Docker Hub `latest`（v0.7.39）和 `v0.8.0-rc.8` 的镜像目录
- 启动全新的 v0.8.0-rc.8 linux/amd64 容器，确认其重新下载 FFmpeg 到带平台层级的可写目录
- `make build-web dev`
- `make lint`
- `make test`