### PR TITLE
修正启动时配置提示中的 “exe” 表述为 “程序”

### DIFF
--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -94,7 +94,7 @@ func getConfigBesidesExecutable() (*configs.Config, error) {
 
 	// 回退：在当前 exe 旁边查找（用户直接双击运行的场景）
 	configPath := filepath.Join(filepath.Dir(exePath), "config.yml")
-	fmt.Fprintf(os.Stderr, "[Config] 使用当前 exe 目录的配置文件: %s\n", configPath)
+	fmt.Fprintf(os.Stderr, "[Config] 使用当前程序目录的配置文件: %s\n", configPath)
 	config, err := configs.NewConfigWithFile(configPath)
 	if err != nil {
 		return nil, err

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -88,13 +88,13 @@ func getConfigBesidesExecutable() (*configs.Config, error) {
 			fmt.Fprintf(os.Stderr, "[Config] 使用 Launcher 目录的配置文件: %s\n", launcherConfigPath)
 			return config, nil
 		} else {
-			fmt.Fprintf(os.Stderr, "[Config] Launcher 配置文件加载失败 (%s): %v，回退到 exe 目录\n", launcherConfigPath, loadErr)
+			fmt.Fprintf(os.Stderr, "[Config] Launcher 配置文件加载失败 (%s): %v，回退到程序所在目录\n", launcherConfigPath, loadErr)
 		}
 	}
 
-	// 回退：在当前 exe 旁边查找（用户直接双击运行的场景）
+	// 回退：在当前程序所在目录查找（用户直接双击运行的场景）
 	configPath := filepath.Join(filepath.Dir(exePath), "config.yml")
-	fmt.Fprintf(os.Stderr, "[Config] 使用当前程序目录的配置文件: %s\n", configPath)
+	fmt.Fprintf(os.Stderr, "[Config] 使用当前程序所在目录的配置文件: %s\n", configPath)
 	config, err := configs.NewConfigWithFile(configPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Motivation

- 修正启动时控制台提示的措辞，将不准确的“当前 exe 目录”改为更通用的“当前程序目录”，避免在 Linux/arm 等平台造成误导（修改点：`src/cmd/bililive/bililive.go`）。

### Description

- 将 `getConfigBesidesExecutable` 中的提示字符串从 `"[Config] 使用当前 exe 目录的配置文件: %s\n"` 改为 `"[Config] 使用当前程序目录的配置文件: %s\n"`（文件：`src/cmd/bililive/bililive.go`，1 行替换）。

### Testing

- 运行了 `make dev` 和 `make build-web dev`，两者均成功；`make lint` 在当前环境失败（`golangci-lint` 由 Go 1.24 构建，与项目目标 Go 1.25 不兼容），`make test` 失败（若干单元测试返回 403/空指针，与本次文案修改无关）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a7bc0e4088324bfe3e4c0d85d839a)