### PR TITLE
修复关闭 RPC 时监听任务启动后立即退出

### DIFF
--- a/src/listeners/manager.go
+++ b/src/listeners/manager.go
@@ -84,9 +84,9 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 
 func (m *manager) Start(ctx context.Context) error {
 	inst := instance.GetInstance(ctx)
-	if cfg := configs.GetCurrentConfig(); (cfg != nil && cfg.RPC.Enable) || inst.Lives.Len() > 0 {
-		inst.WaitGroup.Add(1)
-	}
+	// manager 在直播间初始化前启动，不能用此时仍为空的 Lives 判断是否需要阻塞主进程。
+	// 配置校验已经保证 RPC 关闭时至少存在一个直播间，因此 manager 启动后始终参与生命周期等待。
+	inst.WaitGroup.Add(1)
 	m.registryListener(ctx, inst.EventDispatcher.(events.Dispatcher))
 	return nil
 }

--- a/src/listeners/manager.go
+++ b/src/listeners/manager.go
@@ -32,8 +32,24 @@ type Manager interface {
 }
 
 type manager struct {
-	lock   sync.RWMutex
-	savers map[types.LiveID]Listener
+	lock              sync.RWMutex
+	savers            map[types.LiveID]Listener
+	blocksMainProcess bool
+}
+
+func shouldBlockMainProcess(cfg *configs.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.RPC.Enable {
+		return true
+	}
+	for _, room := range cfg.LiveRooms {
+		if room.IsListening {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
@@ -84,9 +100,12 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 
 func (m *manager) Start(ctx context.Context) error {
 	inst := instance.GetInstance(ctx)
-	// manager 在直播间初始化前启动，不能用此时仍为空的 Lives 判断是否需要阻塞主进程。
-	// 配置校验已经保证 RPC 关闭时至少存在一个直播间，因此 manager 启动后始终参与生命周期等待。
-	inst.WaitGroup.Add(1)
+	// manager 在直播间初始化前启动，因此应从配置判断是否存在监听任务，
+	// 不能使用此时仍为空的 Lives。没有 RPC 和监听任务时允许进程自然退出。
+	m.blocksMainProcess = shouldBlockMainProcess(configs.GetCurrentConfig())
+	if m.blocksMainProcess {
+		inst.WaitGroup.Add(1)
+	}
 	m.registryListener(ctx, inst.EventDispatcher.(events.Dispatcher))
 	return nil
 }
@@ -98,8 +117,9 @@ func (m *manager) Close(ctx context.Context) {
 		listener.Close()
 		delete(m.savers, id)
 	}
-	inst := instance.GetInstance(ctx)
-	inst.WaitGroup.Done()
+	if m.blocksMainProcess {
+		instance.GetInstance(ctx).WaitGroup.Done()
+	}
 }
 
 func (m *manager) AddListener(ctx context.Context, live live.Live) error {

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -51,13 +51,16 @@ func TestManagerStartAndClose(t *testing.T) {
 	defer ctrl.Finish()
 	ed := evtmock.NewMockDispatcher(ctrl)
 	ed.EXPECT().AddEventListener(RoomInitializingFinished, gomock.Any())
+	oldCfg := configs.GetCurrentConfig()
+	defer configs.SetCurrentConfig(oldCfg)
 	configs.SetCurrentConfig(&configs.Config{
 		RPC:       configs.RPC{Enable: false},
 		LiveRooms: []configs.LiveRoom{{Url: "https://live.bilibili.com/1", IsListening: true}},
 	})
-	ctx := context.WithValue(context.Background(), instance.Key, &instance.Instance{
+	inst := &instance.Instance{
 		EventDispatcher: ed,
-	})
+	}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
 	backup := newListener
 	newListener = func(ctx context.Context, live live.Live) Listener {
 		ln := NewMockListener(ctrl)
@@ -68,16 +71,14 @@ func TestManagerStartAndClose(t *testing.T) {
 	defer func() { newListener = backup }()
 	m := NewManager(ctx)
 	assert.NoError(t, m.Start(ctx))
+	// 确定性验证 Start 已注册生命周期计数，再恢复计数供 Close 解除。
+	inst.WaitGroup.Add(-1)
+	inst.WaitGroup.Add(1)
 	waitDone := make(chan struct{})
 	go func() {
-		ctx.Value(instance.Key).(*instance.Instance).WaitGroup.Wait()
+		inst.WaitGroup.Wait()
 		close(waitDone)
 	}()
-	select {
-	case <-waitDone:
-		t.Fatal("RPC 关闭且 Lives 尚未初始化时，manager 未阻塞主进程")
-	case <-time.After(50 * time.Millisecond):
-	}
 	for i := 0; i < 3; i++ {
 		l := livemock.NewMockLive(ctrl)
 		id := types.LiveID(fmt.Sprintf("test_%d", i))
@@ -90,4 +91,35 @@ func TestManagerStartAndClose(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("manager 关闭后仍未解除主进程等待")
 	}
+}
+
+func TestShouldBlockMainProcess(t *testing.T) {
+	assert.False(t, shouldBlockMainProcess(nil))
+	assert.False(t, shouldBlockMainProcess(&configs.Config{
+		LiveRooms: []configs.LiveRoom{{IsListening: false}},
+	}))
+	assert.True(t, shouldBlockMainProcess(&configs.Config{RPC: configs.RPC{Enable: true}}))
+	assert.True(t, shouldBlockMainProcess(&configs.Config{
+		LiveRooms: []configs.LiveRoom{{IsListening: true}},
+	}))
+}
+
+func TestManagerCloseWithoutBlockingMainProcess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ed := evtmock.NewMockDispatcher(ctrl)
+	ed.EXPECT().AddEventListener(RoomInitializingFinished, gomock.Any())
+	oldCfg := configs.GetCurrentConfig()
+	defer configs.SetCurrentConfig(oldCfg)
+	configs.SetCurrentConfig(&configs.Config{
+		LiveRooms: []configs.LiveRoom{{IsListening: false}},
+	})
+	inst := &instance.Instance{EventDispatcher: ed}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	m := NewManager(ctx)
+
+	assert.NoError(t, m.Start(ctx))
+	assert.False(t, m.(*manager).blocksMainProcess)
+	assert.NotPanics(t, func() { m.Close(ctx) })
 }

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
@@ -51,7 +52,8 @@ func TestManagerStartAndClose(t *testing.T) {
 	ed := evtmock.NewMockDispatcher(ctrl)
 	ed.EXPECT().AddEventListener(RoomInitializingFinished, gomock.Any())
 	configs.SetCurrentConfig(&configs.Config{
-		RPC: configs.RPC{Enable: true},
+		RPC:       configs.RPC{Enable: false},
+		LiveRooms: []configs.LiveRoom{{Url: "https://live.bilibili.com/1", IsListening: true}},
 	})
 	ctx := context.WithValue(context.Background(), instance.Key, &instance.Instance{
 		EventDispatcher: ed,
@@ -66,6 +68,16 @@ func TestManagerStartAndClose(t *testing.T) {
 	defer func() { newListener = backup }()
 	m := NewManager(ctx)
 	assert.NoError(t, m.Start(ctx))
+	waitDone := make(chan struct{})
+	go func() {
+		ctx.Value(instance.Key).(*instance.Instance).WaitGroup.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		t.Fatal("RPC 关闭且 Lives 尚未初始化时，manager 未阻塞主进程")
+	case <-time.After(50 * time.Millisecond):
+	}
 	for i := 0; i < 3; i++ {
 		l := livemock.NewMockLive(ctrl)
 		id := types.LiveID(fmt.Sprintf("test_%d", i))
@@ -73,4 +85,9 @@ func TestManagerStartAndClose(t *testing.T) {
 		assert.NoError(t, m.AddListener(ctx, l))
 	}
 	m.Close(ctx)
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("manager 关闭后仍未解除主进程等待")
+	}
 }

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -81,11 +81,12 @@ var (
 )
 
 type manager struct {
-	lock         sync.RWMutex
-	savers       map[types.LiveID]Recorder
-	statusTicker *time.Ticker
-	statusStopCh chan struct{}
-	statusWg     sync.WaitGroup // 用于等待广播 goroutine 退出
+	lock              sync.RWMutex
+	savers            map[types.LiveID]Recorder
+	statusTicker      *time.Ticker
+	statusStopCh      chan struct{}
+	statusWg          sync.WaitGroup // 用于等待广播 goroutine 退出
+	blocksMainProcess bool
 	// restartingCount 追踪正在执行 CloseForRestart 的旧 recorder 数量。
 	// RestartRecorder 在释放锁后才执行 oldRecorder.CloseForRestart()，
 	// 此期间 map 中只有新 recorder，但旧 recorder 仍在收尾运行。
@@ -93,6 +94,21 @@ type manager struct {
 	// 会误判为"无活跃录制"导致优雅更新被提前触发。
 	// 通过 restartingCount 将收尾中的旧 recorder 也计入活跃数量。
 	restartingCount atomic.Int32
+}
+
+func shouldBlockMainProcess(cfg *configs.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.RPC.Enable {
+		return true
+	}
+	for _, room := range cfg.LiveRooms {
+		if room.IsListening {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
@@ -137,9 +153,12 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 
 func (m *manager) Start(ctx context.Context) error {
 	inst := instance.GetInstance(ctx)
-	// manager 在直播间初始化前启动，不能用此时仍为空的 Lives 判断是否需要阻塞主进程。
-	// 配置校验已经保证 RPC 关闭时至少存在一个直播间，因此 manager 启动后始终参与生命周期等待。
-	inst.WaitGroup.Add(1)
+	// manager 在直播间初始化前启动，因此应从配置判断是否存在监听任务，
+	// 不能使用此时仍为空的 Lives。没有 RPC 和监听任务时允许进程自然退出。
+	m.blocksMainProcess = shouldBlockMainProcess(configs.GetCurrentConfig())
+	if m.blocksMainProcess {
+		inst.WaitGroup.Add(1)
+	}
 	m.registryListener(ctx, inst.EventDispatcher.(events.Dispatcher))
 
 	// 启动定期广播录制器状态的 goroutine
@@ -165,8 +184,9 @@ func (m *manager) Close(ctx context.Context) {
 		recorder.Close()
 		delete(m.savers, id)
 	}
-	inst := instance.GetInstance(ctx)
-	inst.WaitGroup.Done()
+	if m.blocksMainProcess {
+		instance.GetInstance(ctx).WaitGroup.Done()
+	}
 }
 
 func (m *manager) AddRecorder(ctx context.Context, live live.Live) error {

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -137,9 +137,9 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 
 func (m *manager) Start(ctx context.Context) error {
 	inst := instance.GetInstance(ctx)
-	if cfg := configs.GetCurrentConfig(); (cfg != nil && cfg.RPC.Enable) || inst.Lives.Len() > 0 {
-		inst.WaitGroup.Add(1)
-	}
+	// manager 在直播间初始化前启动，不能用此时仍为空的 Lives 判断是否需要阻塞主进程。
+	// 配置校验已经保证 RPC 关闭时至少存在一个直播间，因此 manager 启动后始终参与生命周期等待。
+	inst.WaitGroup.Add(1)
 	m.registryListener(ctx, inst.EventDispatcher.(events.Dispatcher))
 
 	// 启动定期广播录制器状态的 goroutine

--- a/src/recorders/manager_test.go
+++ b/src/recorders/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
@@ -12,9 +13,44 @@ import (
 	"github.com/bililive-go/bililive-go/src/instance"
 	"github.com/bililive-go/bililive-go/src/live"
 	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	evtmock "github.com/bililive-go/bililive-go/src/pkg/events/mock"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 	"github.com/bililive-go/bililive-go/src/types"
 )
+
+func TestManagerStartAndCloseWithRPCDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ed := evtmock.NewMockDispatcher(ctrl)
+	ed.EXPECT().AddEventListener(gomock.Any(), gomock.Any()).Times(4)
+	configs.SetCurrentConfig(&configs.Config{
+		RPC:       configs.RPC{Enable: false},
+		LiveRooms: []configs.LiveRoom{{Url: "https://live.bilibili.com/1", IsListening: true}},
+	})
+	inst := &instance.Instance{EventDispatcher: ed}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	m := NewManager(ctx)
+
+	assert.NoError(t, m.Start(ctx))
+	waitDone := make(chan struct{})
+	go func() {
+		inst.WaitGroup.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		t.Fatal("RPC 关闭且 Lives 尚未初始化时，manager 未阻塞主进程")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	m.Close(ctx)
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("manager 关闭后仍未解除主进程等待")
+	}
+}
 
 func TestManagerAddAndRemoveRecorder(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/src/recorders/manager_test.go
+++ b/src/recorders/manager_test.go
@@ -24,6 +24,8 @@ func TestManagerStartAndCloseWithRPCDisabled(t *testing.T) {
 
 	ed := evtmock.NewMockDispatcher(ctrl)
 	ed.EXPECT().AddEventListener(gomock.Any(), gomock.Any()).Times(4)
+	oldCfg := configs.GetCurrentConfig()
+	defer configs.SetCurrentConfig(oldCfg)
 	configs.SetCurrentConfig(&configs.Config{
 		RPC:       configs.RPC{Enable: false},
 		LiveRooms: []configs.LiveRoom{{Url: "https://live.bilibili.com/1", IsListening: true}},
@@ -33,23 +35,51 @@ func TestManagerStartAndCloseWithRPCDisabled(t *testing.T) {
 	m := NewManager(ctx)
 
 	assert.NoError(t, m.Start(ctx))
+	// 确定性验证 Start 已注册生命周期计数，再恢复计数供 Close 解除。
+	inst.WaitGroup.Add(-1)
+	inst.WaitGroup.Add(1)
 	waitDone := make(chan struct{})
 	go func() {
 		inst.WaitGroup.Wait()
 		close(waitDone)
 	}()
-	select {
-	case <-waitDone:
-		t.Fatal("RPC 关闭且 Lives 尚未初始化时，manager 未阻塞主进程")
-	case <-time.After(50 * time.Millisecond):
-	}
-
 	m.Close(ctx)
 	select {
 	case <-waitDone:
 	case <-time.After(time.Second):
 		t.Fatal("manager 关闭后仍未解除主进程等待")
 	}
+}
+
+func TestShouldBlockMainProcess(t *testing.T) {
+	assert.False(t, shouldBlockMainProcess(nil))
+	assert.False(t, shouldBlockMainProcess(&configs.Config{
+		LiveRooms: []configs.LiveRoom{{IsListening: false}},
+	}))
+	assert.True(t, shouldBlockMainProcess(&configs.Config{RPC: configs.RPC{Enable: true}}))
+	assert.True(t, shouldBlockMainProcess(&configs.Config{
+		LiveRooms: []configs.LiveRoom{{IsListening: true}},
+	}))
+}
+
+func TestManagerCloseWithoutBlockingMainProcess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ed := evtmock.NewMockDispatcher(ctrl)
+	ed.EXPECT().AddEventListener(gomock.Any(), gomock.Any()).Times(4)
+	oldCfg := configs.GetCurrentConfig()
+	defer configs.SetCurrentConfig(oldCfg)
+	configs.SetCurrentConfig(&configs.Config{
+		LiveRooms: []configs.LiveRoom{{IsListening: false}},
+	})
+	inst := &instance.Instance{EventDispatcher: ed}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	m := NewManager(ctx)
+
+	assert.NoError(t, m.Start(ctx))
+	assert.False(t, m.(*manager).blocksMainProcess)
+	assert.NotPanics(t, func() { m.Close(ctx) })
 }
 
 func TestManagerAddAndRemoveRecorder(t *testing.T) {


### PR DESCRIPTION
## 问题原因

listener manager 和 recorder manager 在直播间初始化之前启动。此时 `inst.Lives` 仍为空；当 RPC 同时被禁用时，原逻辑不会向主进程的 `WaitGroup` 注册，导致存在监听任务时主函数末尾的 `Wait()` 立即返回，进程随即退出。与此同时，`Close()` 原本无条件调用 `Done()`，与有条件的 `Add()` 不对称。

## 修改内容

- listener manager 和 recorder manager 改为从配置判断是否需要阻塞主进程：RPC 已启用，或至少有一个 `IsListening` 直播间
- 不再依赖 manager 启动时尚未填充的 `inst.Lives`
- 记录 manager 是否加入主 `WaitGroup`，仅在已加入时调用 `Done()`，保持生命周期计数对称
- RPC 关闭且所有直播间均不监听时，保留自然退出行为
- 增加 RPC 关闭、监听房间尚未写入 `inst.Lives` 场景的回归测试
- 使用确定性的 `Add(-1)` / `Add(1)` 验证生命周期计数，避免依赖 50ms goroutine 调度
- 测试结束后恢复全局配置，避免污染其他测试

## 用户影响

关闭 HTTP/RPC 服务后，只要配置了正在监听的直播间，程序会持续监听和录制，直到收到退出信号，不再在启动后立即打印 `Bye~` 并退出。若所有直播间均设置为 `is_listening: false`，程序仍可自然退出。

## 验证

- `go test ./src/listeners ./src/recorders`
- `make build-web dev`
- `make lint`
- `make test`

Closes #1161