### PR TITLE
修复外部工具页面加载失败和 SSE 断连

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hr3lxphr6j/requests v0.0.1
 	github.com/joho/godotenv v1.5.1
-	github.com/kira1928/remotetools v0.3.6-0.20260726101040-0f5f534cfafa
+	github.com/kira1928/remotetools v0.3.6
 	github.com/prometheus/client_golang v1.11.0
 	github.com/robertkrimen/otto v0.5.1
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hr3lxphr6j/requests v0.0.1
 	github.com/joho/godotenv v1.5.1
-	github.com/kira1928/remotetools v0.3.5
+	github.com/kira1928/remotetools v0.3.6-0.20260725161653-b8ca5d74daf9
 	github.com/prometheus/client_golang v1.11.0
 	github.com/robertkrimen/otto v0.5.1
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hr3lxphr6j/requests v0.0.1
 	github.com/joho/godotenv v1.5.1
-	github.com/kira1928/remotetools v0.3.6-0.20260725161653-b8ca5d74daf9
+	github.com/kira1928/remotetools v0.3.6-0.20260726101040-0f5f534cfafa
 	github.com/prometheus/client_golang v1.11.0
 	github.com/robertkrimen/otto v0.5.1
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kira1928/remotetools v0.3.5 h1:FJa4j3qIVJBL9GkPdnwmLe4YEfUoqeM9tLK4mfjhSS4=
-github.com/kira1928/remotetools v0.3.5/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
-github.com/kira1928/remotetools v0.3.6-0.20260726101040-0f5f534cfafa h1:3tnbnAnGS3Q9N4HulmcROsT5XmKk6uSoFQIhH5bRnWU=
-github.com/kira1928/remotetools v0.3.6-0.20260726101040-0f5f534cfafa/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
+github.com/kira1928/remotetools v0.3.6 h1:tY1g0AsnZKp3WgaEw742RoKiOeYwseTh6hHg7qb/oEU=
+github.com/kira1928/remotetools v0.3.6/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kira1928/remotetools v0.3.5 h1:FJa4j3qIVJBL9GkPdnwmLe4YEfUoqeM9tLK4mfjhSS4=
 github.com/kira1928/remotetools v0.3.5/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
-github.com/kira1928/remotetools v0.3.6-0.20260725161653-b8ca5d74daf9 h1:jzvcNzEmEC+SRMzkmgiylmY3Pcc8+wMSznBfjODNclw=
-github.com/kira1928/remotetools v0.3.6-0.20260725161653-b8ca5d74daf9/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
+github.com/kira1928/remotetools v0.3.6-0.20260726101040-0f5f534cfafa h1:3tnbnAnGS3Q9N4HulmcROsT5XmKk6uSoFQIhH5bRnWU=
+github.com/kira1928/remotetools v0.3.6-0.20260726101040-0f5f534cfafa/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kira1928/remotetools v0.3.5 h1:FJa4j3qIVJBL9GkPdnwmLe4YEfUoqeM9tLK4mfjhSS4=
 github.com/kira1928/remotetools v0.3.5/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
+github.com/kira1928/remotetools v0.3.6-0.20260725161653-b8ca5d74daf9 h1:jzvcNzEmEC+SRMzkmgiylmY3Pcc8+wMSznBfjODNclw=
+github.com/kira1928/remotetools v0.3.6-0.20260725161653-b8ca5d74daf9/go.mod h1:2fqah92kvzy8eFn9BAyrbrANHH6auVE+JU0y9D1qh6w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
## 概述

升级 `github.com/kira1928/remotetools` 到已发布的 `v0.3.6`，解决外部工具页面在 GitHub 首选下载源不可达时显示“加载工具失败”，以及外层反向代理周期性记录 `unexpected EOF` 的问题。

Fixes #1156

上游修复：[kira1928/remotetools#10](https://github.com/kira1928/remotetools/pull/10)（已合并并发布为 [`v0.3.6`](https://github.com/kira1928/remotetools/releases/tag/v0.3.6)）

## 根因

这不是应用代理未传递导致的单一问题，而是 remotetools WebUI 中两条错误链路叠加：

1. `/api/status` 查询部分下载进度时同步、无超时地向首选下载源发送 HEAD。GitHub 不可达时，该请求拖到前端 15 秒超时，整个初始化 `Promise.all` 失败。
2. WebUI Server 的全局 15 秒 `WriteTimeout` 会截断长连接 SSE，bililive-go 的 `/tools/` 反向代理因而记录 `ReverseProxy read error during body copy: unexpected EOF`。

## 上游修复

- 新增纯本地的 `GetCachedDownloadInfo`，WebUI 状态查询使用该快速路径。
- 保留公开 `GetPartialDownloadInfo` 原有的 HEAD 远端尺寸探测能力，避免影响其他调用方。
- 实际下载开始后，文件总大小继续通过进度元数据和 SSE 更新到前端。
- 仅为 SSE 清除写截止时间，保留普通 API 的超时保护。
- SSE 注册后立即刷新响应头并定期发送 keepalive。
- 前端只将工具列表视为必需数据，辅助状态接口失败时降级展示。
- 增加快速查询不联网、旧方法远端尺寸兼容性和 SSE 生命周期回归测试。
- 同步重新构建嵌入式前端。

没有在每次页面刷新时异步启动远端 HEAD，因为这会对所有工具重复创建请求。若以后要在未下载时预取尺寸，应增加带 TTL、并发去重和上下文取消的缓存层。

## 全局代码审查

提交前不仅检查了依赖差异，还沿以下完整链路做了本地审查：

- bililive-go：RemoteTools 初始化、异步下载、动态端口发现、`/tools/` 反向代理、清理/重启流程，以及所有 remotetools API 调用点。
- remotetools：公开 API 兼容性、HTTP Server 超时策略、SSE 客户端注册与注销、状态查询调用链、下载元数据锁、前端初始化和操作后刷新流程。

审查中发现并修正了三点设计问题：

- 没有全局移除 `WriteTimeout`，而是只对 SSE 清除截止时间，避免降低普通 API 的慢客户端保护。
- 调整 SSE 注册和首包顺序，避免连接建立窗口遗漏进度事件；辅助请求也不再延迟必需工具列表的展示。
- 将快速状态查询做成新增方法，恢复并测试 `GetPartialDownloadInfo` 的既有远端尺寸语义，公开 `APIAdapter` 也保持兼容。

## 验证

bililive-go：

- `make build-web dev`
- `make lint`：0 issues
- `make test`
- `git diff --check`

remotetools：

- `go run ./build.go build`
- `make test`
- `go vet ./...`
- `cd web && npm run build`
- `git diff --check`

额外最小集成验证：

- 下载源接受连接但不响应时，`/api/status` 在约 3ms 返回 200，且没有连接该下载源。
- SSE 经 bililive-go 同型反向代理保持 16 秒以上，超过原 `WriteTimeout` 后仍能收到第二条事件，没有 `unexpected EOF`。
- `GetPartialDownloadInfo` 回归测试确认仍会发送 HEAD 并返回远端 `Content-Length`。

上游 `go test -race ./...` 因当前环境未安装 gcc 无法运行；常规测试及 vet 均通过。

## 依赖状态

上游修复已经合并并正式发布为 `v0.3.6`。本 PR 已从临时 pseudo-version 切换到该正式版本，并确认发布包源码与此前通过验证的 pseudo-version 源码一致。