### PR TITLE
增加直播间列表置顶功能

### DIFF
--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -902,6 +902,7 @@ type LiveRoom struct {
 	Url         string       `yaml:"url" json:"url"`
 	IsListening bool         `yaml:"is_listening" json:"is_listening"`
 	LiveId      types.LiveID `yaml:"-" json:"live_id,omitempty"`
+	Pinned      bool         `yaml:"pinned,omitempty" json:"pinned,omitempty"`
 	Quality     int          `yaml:"quality,omitempty" json:"quality,omitempty"`
 	AudioOnly   bool         `yaml:"audio_only,omitempty" json:"audio_only,omitempty"`
 	NickName    string       `yaml:"nick_name,omitempty" json:"nick_name,omitempty"`

--- a/src/configs/config_test.go
+++ b/src/configs/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -119,6 +120,32 @@ live_rooms:
 	resolved := cfg.ResolveConfigForRoom(&cfg.LiveRooms[0], "bilibili")
 	assert.Equal(t, 30, resolved.Interval)
 	assert.Equal(t, "./", resolved.OutPutPath)
+}
+
+func TestLiveRoomPinnedConfigCompatibility(t *testing.T) {
+	configYAML := `
+rpc:
+  enable: true
+  bind: :8080
+interval: 30
+out_put_path: ./
+live_rooms:
+- url: https://live.bilibili.com/100
+  is_listening: true
+  pinned: true
+- url: https://live.bilibili.com/200
+  is_listening: true
+`
+
+	cfg, err := NewConfigWithBytes([]byte(configYAML))
+	assert.NoError(t, err)
+	assert.True(t, cfg.LiveRooms[0].Pinned)
+	assert.False(t, cfg.LiveRooms[1].Pinned)
+
+	encoded, err := yaml.Marshal(cfg.LiveRooms)
+	assert.NoError(t, err)
+	assert.Contains(t, string(encoded), "pinned: true")
+	assert.NotContains(t, string(encoded), "pinned: false")
 }
 
 func TestGetPlatformKeyFromUrl(t *testing.T) {

--- a/src/live/info.go
+++ b/src/live/info.go
@@ -61,6 +61,7 @@ type Info struct {
 	CustomLiveId         string
 	AudioOnly            bool
 	NotifyOnly           bool // 仅开播提醒模式
+	Pinned               bool // 是否在直播间列表中置顶
 	// 最近一次 API 请求的错误信息（用于前端显示错误提示）
 	LastError string
 	// 可用流列表（最近一次获取的）
@@ -91,6 +92,7 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 		LastStartTimeUnix         int64                  `json:"last_start_time_unix,omitempty"`
 		AudioOnly                 bool                   `json:"audio_only"`
 		NotifyOnly                bool                   `json:"notify_only"`
+		Pinned                    bool                   `json:"pinned"`
 		NickName                  string                 `json:"nick_name"`
 		LastError                 string                 `json:"last_error,omitempty"`
 		AvailableStreams          []*AvailableStreamInfo `json:"available_streams,omitempty"`
@@ -108,6 +110,7 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 		Initializing:              i.Initializing,
 		AudioOnly:                 i.AudioOnly,
 		NotifyOnly:                i.NotifyOnly,
+		Pinned:                    i.Pinned,
 		NickName:                  i.Live.GetOptions().NickName,
 		LastError:                 i.LastError,
 		AvailableStreams:          i.AvailableStreams,

--- a/src/live/info_test.go
+++ b/src/live/info_test.go
@@ -1,0 +1,34 @@
+package live_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bililive-go/bililive-go/src/live"
+	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	"github.com/bililive-go/bililive-go/src/types"
+)
+
+func TestInfoMarshalJSONIncludesPinnedState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	liveObj := livemock.NewMockLive(ctrl)
+	liveObj.EXPECT().GetLiveId().Return(types.LiveID("test-room"))
+	liveObj.EXPECT().GetRawUrl().Return("https://example.com/room")
+	liveObj.EXPECT().GetPlatformCNName().Return("测试平台")
+	liveObj.EXPECT().GetOptions().Return(&live.Options{})
+	liveObj.EXPECT().GetLastStartTime().Return(time.Time{})
+
+	data, err := json.Marshal(&live.Info{
+		Live:   liveObj,
+		Pinned: true,
+	})
+	assert.NoError(t, err)
+
+	var result map[string]any
+	assert.NoError(t, json.Unmarshal(data, &result))
+	assert.Equal(t, true, result["pinned"])
+}

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -91,9 +91,11 @@ func parseInfo(ctx context.Context, l live.Live) *live.Info {
 
 	// 设置 NotifyOnly 状态
 	info.NotifyOnly = false
+	info.Pinned = false
 	if cfg := configs.GetCurrentConfig(); cfg != nil {
 		if room, err := cfg.GetLiveRoomByUrl(l.GetRawUrl()); err == nil {
 			info.NotifyOnly = room.NotifyOnly
+			info.Pinned = room.Pinned
 		}
 	}
 
@@ -2006,6 +2008,9 @@ func updateRoomConfigById(writer http.ResponseWriter, r *http.Request) {
 		if isListening, ok := updates["is_listening"].(bool); ok {
 			room.IsListening = isListening
 		}
+		if pinned, ok := updates["pinned"].(bool); ok {
+			room.Pinned = pinned
+		}
 		if quality, ok := updates["quality"].(float64); ok {
 			room.Quality = int(quality)
 		}
@@ -2068,6 +2073,13 @@ func updateRoomConfigById(writer http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+	}
+
+	if pinned, ok := updates["pinned"].(bool); ok {
+		GetSSEHub().BroadcastListChange(types.LiveID(liveId), "pin_change", map[string]interface{}{
+			"live_id": string(liveId),
+			"pinned":  pinned,
+		})
 	}
 
 	writeJSON(writer, commonResp{
@@ -2289,6 +2301,9 @@ func updateRoomConfig(writer http.ResponseWriter, r *http.Request) {
 		}
 		if audioOnly, ok := updates["audio_only"].(bool); ok {
 			room.AudioOnly = audioOnly
+		}
+		if pinned, ok := updates["pinned"].(bool); ok {
+			room.Pinned = pinned
 		}
 		if notifyOnly, ok := updates["notify_only"].(bool); ok {
 			room.NotifyOnly = notifyOnly

--- a/src/servers/handler_test.go
+++ b/src/servers/handler_test.go
@@ -1,13 +1,18 @@
 package servers
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/bililive-go/bililive-go/src/configs"
+	"github.com/bililive-go/bililive-go/src/instance"
+	"github.com/bililive-go/bililive-go/src/types"
 )
 
 func TestGetSoopLiveAuthConfigDoesNotExposeSavedPassword(t *testing.T) {
@@ -31,4 +36,32 @@ func TestGetSoopLiveAuthConfigDoesNotExposeSavedPassword(t *testing.T) {
 	assert.Equal(t, true, data["has_saved_credentials"])
 	_, exists := data["password"]
 	assert.False(t, exists)
+}
+
+func TestUpdateRoomConfigByIDUpdatesPinnedState(t *testing.T) {
+	cfg := configs.NewConfig()
+	cfg.File = ""
+	cfg.LiveRooms = []configs.LiveRoom{{
+		Url:    "https://example.com/room",
+		LiveId: types.LiveID("test-room"),
+	}}
+	cfg.RefreshLiveRoomIndexCache()
+	configs.SetCurrentConfig(cfg)
+
+	request := httptest.NewRequest(
+		"PATCH",
+		"/api/config/rooms/id/test-room",
+		bytes.NewBufferString(`{"pinned":true}`),
+	)
+	inst := &instance.Instance{Ctx: context.Background()}
+	request = request.WithContext(context.WithValue(request.Context(), instance.Key, inst))
+	request = mux.SetURLVars(request, map[string]string{"id": "test-room"})
+	recorder := httptest.NewRecorder()
+
+	updateRoomConfigById(recorder, request)
+
+	assert.Equal(t, 200, recorder.Code)
+	room, err := configs.GetCurrentConfig().GetLiveRoomByUrl("https://example.com/room")
+	assert.NoError(t, err)
+	assert.True(t, room.Pinned)
 }

--- a/src/servers/models.go
+++ b/src/servers/models.go
@@ -21,6 +21,9 @@ func (c liveSlice) Swap(i, j int) {
 	c[i], c[j] = c[j], c[i]
 }
 func (c liveSlice) Less(i, j int) bool {
+	if c[i].Pinned != c[j].Pinned {
+		return c[i].Pinned
+	}
 	return c[i].Live.GetLiveId() < c[j].Live.GetLiveId()
 }
 

--- a/src/servers/models_test.go
+++ b/src/servers/models_test.go
@@ -1,0 +1,40 @@
+package servers
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bililive-go/bililive-go/src/live"
+	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	"github.com/bililive-go/bililive-go/src/types"
+)
+
+func TestLiveSliceSortsPinnedRoomsFirst(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	newInfo := func(id string, pinned bool) *live.Info {
+		liveObj := livemock.NewMockLive(ctrl)
+		liveObj.EXPECT().GetLiveId().Return(types.LiveID(id)).AnyTimes()
+		return &live.Info{
+			Live:   liveObj,
+			Pinned: pinned,
+		}
+	}
+
+	lives := liveSlice{
+		newInfo("normal-b", false),
+		newInfo("pinned-b", true),
+		newInfo("pinned-a", true),
+		newInfo("normal-a", false),
+	}
+
+	sort.Sort(lives)
+
+	ids := make([]types.LiveID, 0, len(lives))
+	for _, info := range lives {
+		ids = append(ids, info.Live.GetLiveId())
+	}
+	assert.Equal(t, []types.LiveID{"pinned-a", "pinned-b", "normal-a", "normal-b"}, ids)
+}

--- a/src/webapp/src/component/live-list/index.tsx
+++ b/src/webapp/src/component/live-list/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Divider, Table, Tag, Tabs, Row, Col, Tooltip, message, List, Typography, Switch, Space, Popconfirm, Select, Spin } from 'antd';
-import { EditOutlined, SyncOutlined, CloudSyncOutlined, ReloadOutlined, SwapOutlined, CheckCircleOutlined, ExclamationCircleOutlined, CommentOutlined } from '@ant-design/icons';
+import { EditOutlined, SyncOutlined, CloudSyncOutlined, ReloadOutlined, SwapOutlined, CheckCircleOutlined, ExclamationCircleOutlined, CommentOutlined, PushpinOutlined, PushpinFilled } from '@ant-design/icons';
 import PopDialog from '../pop-dialog/index';
 import BatchAddRoomDialog from '../batch-add-room-dialog/index';
 import LogPanel from '../log-panel/index';
@@ -15,6 +15,7 @@ import { useNavigate, NavigateFunction } from "react-router-dom";
 import EditCookieDialog from "../edit-cookie/index";
 import { RoomConfigForm } from "../config-info";
 import { StreamAttributes } from '../../types/stream';
+import { comparePinnedForTable, TableSortOrder } from './pinning';
 
 const api = new API();
 const { Text } = Typography;
@@ -330,6 +331,7 @@ interface ItemData {
     notifyOnly: boolean
     isLive: boolean
     isRecording: boolean
+    pinned: boolean
 }
 interface CookieItemData {
     Platform_cn_name: string,
@@ -392,14 +394,19 @@ class LiveList extends React.Component<Props, IState> {
                 })}
             </span>
         ),
-        sorter: (a: ItemData, b: ItemData) => {
+        sorter: (a: ItemData, b: ItemData, sortOrder?: TableSortOrder) => {
             // 录制中 > 录制准备中 > 其他
             const getRecordingPriority = (tags: string[]) => {
                 if (tags.includes('录制中')) return 2;
                 if (tags.includes('录制准备中')) return 1;
                 return 0;
             };
-            return getRecordingPriority(a.tags) - getRecordingPriority(b.tags);
+            return comparePinnedForTable(
+                a,
+                b,
+                sortOrder,
+                () => getRecordingPriority(a.tags) - getRecordingPriority(b.tags)
+            );
         },
         defaultSortOrder: 'descend',
     };
@@ -410,6 +417,17 @@ class LiveList extends React.Component<Props, IState> {
         dataIndex: 'listening',
         render: (listening: boolean, data: ItemData) => (
             <span onClick={(e) => e.stopPropagation()}>
+                <Tooltip title={data.pinned ? "取消后该直播间将恢复普通排序" : "将该直播间固定在列表顶部"}>
+                    <Button
+                        type="link"
+                        size="small"
+                        icon={data.pinned ? <PushpinFilled /> : <PushpinOutlined />}
+                        onClick={() => this.toggleRoomPinned(data)}
+                    >
+                        {data.pinned ? "取消置顶" : "置顶"}
+                    </Button>
+                </Tooltip>
+                <Divider type="vertical" />
                 <PopDialog
                     title={listening ? "确定停止监控？" : "确定开启监控？"}
                     onConfirm={(e) => {
@@ -514,10 +532,19 @@ class LiveList extends React.Component<Props, IState> {
             title: '主播名称',
             dataIndex: 'name',
             key: 'name',
-            sorter: (a: ItemData, b: ItemData) => {
-                return a.name.localeCompare(b.name);
+            sorter: (a: ItemData, b: ItemData, sortOrder?: TableSortOrder) => {
+                return comparePinnedForTable(a, b, sortOrder, () => a.name.localeCompare(b.name));
             },
-            render: (name: string) => <span>{name}</span>
+            render: (name: string, data: ItemData) => (
+                <span>
+                    {data.pinned && (
+                        <Tooltip title="已置顶">
+                            <PushpinFilled style={{ color: '#faad14', marginRight: 6 }} />
+                        </Tooltip>
+                    )}
+                    {name}
+                </span>
+            )
         },
         {
             title: '直播间名称',
@@ -538,8 +565,8 @@ class LiveList extends React.Component<Props, IState> {
             title: '直播平台',
             dataIndex: 'address',
             key: 'address',
-            sorter: (a: ItemData, b: ItemData) => {
-                return a.address.localeCompare(b.address);
+            sorter: (a: ItemData, b: ItemData, sortOrder?: TableSortOrder) => {
+                return comparePinnedForTable(a, b, sortOrder, () => a.address.localeCompare(b.address));
             },
             render: (address: string) => <span>{address}</span>
         },
@@ -554,6 +581,11 @@ class LiveList extends React.Component<Props, IState> {
             key: 'name',
             render: (name: string, data: ItemData) => (
                 <span>
+                    {data.pinned && (
+                        <Tooltip title="已置顶">
+                            <PushpinFilled style={{ color: '#faad14', marginRight: 6 }} />
+                        </Tooltip>
+                    )}
                     <a href={data.room.url} rel="noopener noreferrer" target="_blank" onClick={(e) => e.stopPropagation()}>{name}</a>
                     {data.room.lastError && (
                         <Tooltip title={data.room.lastError}>
@@ -924,6 +956,22 @@ class LiveList extends React.Component<Props, IState> {
     }
 
     /**
+     * 切换直播间置顶状态。
+     * 置顶属于服务端房间配置，刷新页面或从其他浏览器访问时仍会保留。
+     */
+    toggleRoomPinned = async (data: ItemData) => {
+        const nextPinned = !data.pinned;
+        try {
+            await api.setRoomPinned(data.roomId, nextPinned);
+            message.success(nextPinned ? '直播间已置顶' : '已取消置顶');
+            this.requestListData();
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            message.error(`${nextPinned ? '置顶' : '取消置顶'}失败: ${reason}`);
+        }
+    }
+
+    /**
      * 加载列表数据
      */
     requestListData() {
@@ -971,6 +1019,7 @@ class LiveList extends React.Component<Props, IState> {
                         notifyOnly: item.notify_only || false,
                         isLive: item.status || false,
                         isRecording: (item.recording || item.recording_preparing) || false,
+                        pinned: item.pinned || false,
                     };
                 });
             })
@@ -2120,6 +2169,7 @@ class LiveList extends React.Component<Props, IState> {
                                     }
                                 }
                             })}
+                            rowClassName={(record) => record.pinned ? 'pinned-live-row' : ''}
                             onChange={this.handleTableChange}
                         />
                     </Tabs.TabPane>

--- a/src/webapp/src/component/live-list/live-list.css
+++ b/src/webapp/src/component/live-list/live-list.css
@@ -18,3 +18,11 @@
         text-overflow: ellipsis;
     }
 }
+
+.pinned-live-row > td {
+    background-color: #fffbe6 !important;
+}
+
+.pinned-live-row:hover > td {
+    background-color: #fff7cc !important;
+}

--- a/src/webapp/src/component/live-list/pinning.test.ts
+++ b/src/webapp/src/component/live-list/pinning.test.ts
@@ -1,0 +1,21 @@
+import { comparePinnedForTable } from './pinning';
+
+describe('comparePinnedForTable', () => {
+    const pinned = { pinned: true };
+    const normal = { pinned: false };
+
+    test('升序时直接将置顶项排在前面', () => {
+        expect(comparePinnedForTable(pinned, normal, 'ascend', () => 0)).toBeLessThan(0);
+        expect(comparePinnedForTable(normal, pinned, 'ascend', () => 0)).toBeGreaterThan(0);
+    });
+
+    test('降序时预先反转结果以抵消 Table 的反转', () => {
+        expect(comparePinnedForTable(pinned, normal, 'descend', () => 0)).toBeGreaterThan(0);
+        expect(comparePinnedForTable(normal, pinned, 'descend', () => 0)).toBeLessThan(0);
+    });
+
+    test('置顶状态相同时使用原字段比较结果', () => {
+        expect(comparePinnedForTable(pinned, pinned, 'ascend', () => 3)).toBe(3);
+        expect(comparePinnedForTable(normal, normal, 'descend', () => -2)).toBe(-2);
+    });
+});

--- a/src/webapp/src/component/live-list/pinning.ts
+++ b/src/webapp/src/component/live-list/pinning.ts
@@ -1,0 +1,24 @@
+export type TableSortOrder = 'ascend' | 'descend' | null | undefined;
+
+interface Pinnable {
+    pinned: boolean;
+}
+
+/**
+ * 为 Ant Design Table 的比较器增加“置顶优先”规则。
+ *
+ * Table 会在降序时反转比较器的返回值，因此这里也要预先反转置顶结果，
+ * 才能保证无论用户选择升序还是降序，置顶项始终位于列表顶部。
+ */
+export function comparePinnedForTable<T extends Pinnable>(
+    a: T,
+    b: T,
+    sortOrder: TableSortOrder,
+    compareValues: () => number
+): number {
+    if (a.pinned !== b.pinned) {
+        const pinnedFirst = a.pinned ? -1 : 1;
+        return sortOrder === 'descend' ? -pinnedFirst : pinnedFirst;
+    }
+    return compareValues();
+}

--- a/src/webapp/src/utils/api.ts
+++ b/src/webapp/src/utils/api.ts
@@ -260,6 +260,15 @@ class API {
     }
 
     /**
+     * 设置直播间置顶状态
+     * @param liveId 直播间ID
+     * @param pinned 是否置顶
+     */
+    setRoomPinned(liveId: string, pinned: boolean) {
+        return this.updateRoomConfigById(liveId, { pinned });
+    }
+
+    /**
      * 预览输出模板生成的路径
      * @param template 模板字符串
      * @param outPutPath 输出路径
@@ -485,4 +494,3 @@ class API {
 }
 
 export default API;
-


### PR DESCRIPTION
## 变更内容

- 在直播间列表“操作”列增加“置顶 / 取消置顶”操作，并为置顶行增加图标和背景提示
- 将置顶状态保存到 `live_rooms[].pinned`，确保刷新页面、重启服务或更换浏览器后仍然保留
- 在直播间列表 API 中返回置顶状态，并让服务端默认顺序优先展示置顶房间
- 保证用户按主播、平台或运行状态进行升降序排序时，置顶房间仍然位于顶部
- 通过 `list_change` SSE 事件同步置顶状态变更
- 补充配置兼容、API 序列化、PATCH 更新、服务端排序和前端排序测试

## 兼容性与影响

- 旧配置不包含 `pinned` 时默认不置顶
- 未置顶房间不会在 YAML 中写入 `pinned: false`，避免无意义配置膨胀
- 不改变监听、录制、删除等现有操作逻辑

## 本地 Code Review

创建 PR 前已从项目整体视角检查配置原子更新与序列化、API 数据流、SSE、前端排序/筛选/响应式展示、测试隔离及补丁边界，并修复审查中发现的问题；当前无剩余阻断项。

## 验证

- `make build-web dev`
- `make lint`
- `make test`
- `CI=true yarn test --watchAll=false --runTestsByPath src/component/live-list/pinning.test.ts`

Closes #1163