### PR TITLE
fix: 修复快速停止并重新监控时录制器被误删

### DIFF
--- a/.agent/rules/gemini-guide.md
+++ b/.agent/rules/gemini-guide.md
@@ -21,16 +21,18 @@
 3. **提交前检查**：确保 `make build-web dev`、`make lint`、`make test` 全部通过
 4. **禁止擅自提交**：不要主动执行 `git commit`、`git push` 等 git 操作，除非用户明确要求
 
-## 详细指南（Skills）
+## 领域知识沉淀（Skills）
 
-更多详细信息请查阅 `.agent/skills/` 目录下的相关指南：
+`.agent/skills/` 用于沉淀可复用的项目领域知识。执行任务时，如果遇到下表领域相关、对后续开发具有普遍参考价值的信息，应将其总结并写入对应的 `SKILL.md`；文件不存在时再创建，不要为了填充目录而编造内容。
 
-| Skill | 说明 |
-|-------|------|
-| `build` | 编译命令、build tags、代码检查 |
-| `config-modification` | 配置修改同步、层级配置系统 |
-| `test-e2e` | Playwright E2E 测试 |
-| `version-switching` | 不停机版本切换设计规范（Docker/独立运行） |
+写入前必须去除本机绝对路径、用户名、邮箱、密钥、Cookie、Token、内网地址、私有部署信息、个人配置和用户数据等本地或隐私内容，只保留可公开、与具体环境无关且具有公共性的技能知识。
+
+| Skill | 文件 | 说明 |
+|-------|------|------|
+| `build` | `.agent/skills/build/SKILL.md` | 编译命令、build tags、代码检查 |
+| `config-modification` | `.agent/skills/config-modification/SKILL.md` | 配置修改同步、层级配置系统 |
+| `test-e2e` | `.agent/skills/test-e2e/SKILL.md` | Playwright E2E 测试 |
+| `version-switching` | `.agent/skills/version-switching/SKILL.md` | 不停机版本切换设计规范（Docker/独立运行） |
 
 ## 快速参考
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -21,16 +21,18 @@
 3. **提交前检查**：确保 `make build-web dev`、`make lint`、`make test` 全部通过
 4. **禁止擅自提交**：不要主动执行 `git commit`、`git push` 等 git 操作，除非用户明确要求
 
-## 详细指南（Skills）
+## 领域知识沉淀（Skills）
 
-更多详细信息请查阅 `.agent/skills/` 目录下的相关指南：
+`.agent/skills/` 用于沉淀可复用的项目领域知识。执行任务时，如果遇到下表领域相关、对后续开发具有普遍参考价值的信息，应将其总结并写入对应的 `SKILL.md`；文件不存在时再创建，不要为了填充目录而编造内容。
 
-| Skill | 说明 |
-|-------|------|
-| `build` | 编译命令、build tags、代码检查 |
-| `config-modification` | 配置修改同步、层级配置系统 |
-| `test-e2e` | Playwright E2E 测试 |
-| `version-switching` | 不停机版本切换设计规范（Docker/独立运行） |
+写入前必须去除本机绝对路径、用户名、邮箱、密钥、Cookie、Token、内网地址、私有部署信息、个人配置和用户数据等本地或隐私内容，只保留可公开、与具体环境无关且具有公共性的技能知识。
+
+| Skill | 文件 | 说明 |
+|-------|------|------|
+| `build` | `.agent/skills/build/SKILL.md` | 编译命令、build tags、代码检查 |
+| `config-modification` | `.agent/skills/config-modification/SKILL.md` | 配置修改同步、层级配置系统 |
+| `test-e2e` | `.agent/skills/test-e2e/SKILL.md` | Playwright E2E 测试 |
+| `version-switching` | `.agent/skills/version-switching/SKILL.md` | 不停机版本切换设计规范（Docker/独立运行） |
 
 ## 快速参考
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,16 +21,18 @@
 3. **提交前检查**：确保 `make build-web dev`、`make lint`、`make test` 全部通过
 4. **禁止擅自提交**：不要主动执行 `git commit`、`git push` 等 git 操作，除非用户明确要求
 
-## 详细指南（Skills）
+## 领域知识沉淀（Skills）
 
-更多详细信息请查阅 `.agent/skills/` 目录下的相关指南：
+`.agent/skills/` 用于沉淀可复用的项目领域知识。执行任务时，如果遇到下表领域相关、对后续开发具有普遍参考价值的信息，应将其总结并写入对应的 `SKILL.md`；文件不存在时再创建，不要为了填充目录而编造内容。
 
-| Skill | 说明 |
-|-------|------|
-| `build` | 编译命令、build tags、代码检查 |
-| `config-modification` | 配置修改同步、层级配置系统 |
-| `test-e2e` | Playwright E2E 测试 |
-| `version-switching` | 不停机版本切换设计规范（Docker/独立运行） |
+写入前必须去除本机绝对路径、用户名、邮箱、密钥、Cookie、Token、内网地址、私有部署信息、个人配置和用户数据等本地或隐私内容，只保留可公开、与具体环境无关且具有公共性的技能知识。
+
+| Skill | 文件 | 说明 |
+|-------|------|------|
+| `build` | `.agent/skills/build/SKILL.md` | 编译命令、build tags、代码检查 |
+| `config-modification` | `.agent/skills/config-modification/SKILL.md` | 配置修改同步、层级配置系统 |
+| `test-e2e` | `.agent/skills/test-e2e/SKILL.md` | Playwright E2E 测试 |
+| `version-switching` | `.agent/skills/version-switching/SKILL.md` | 不停机版本切换设计规范（Docker/独立运行） |
 
 ## 快速参考
 

--- a/.gitignore
+++ b/.gitignore
@@ -166,9 +166,11 @@ node_modules
 .vscode/*
 !.vscode/*.example.json
 
-# AI agent 临时文件（保留 rules 目录）
+# AI agent 临时文件（保留 rules 和可公开的 skills 目录）
 .agent/*
 !.agent/rules/
+!.agent/skills/
+!.agent/skills/**
 
 !src/cmd/build/
 .appdata/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,16 +21,18 @@
 3. **提交前检查**：确保 `make build-web dev`、`make lint`、`make test` 全部通过
 4. **禁止擅自提交**：不要主动执行 `git commit`、`git push` 等 git 操作，除非用户明确要求
 
-## 详细指南（Skills）
+## 领域知识沉淀（Skills）
 
-更多详细信息请查阅 `.agent/skills/` 目录下的相关指南：
+`.agent/skills/` 用于沉淀可复用的项目领域知识。执行任务时，如果遇到下表领域相关、对后续开发具有普遍参考价值的信息，应将其总结并写入对应的 `SKILL.md`；文件不存在时再创建，不要为了填充目录而编造内容。
 
-| Skill | 说明 |
-|-------|------|
-| `build` | 编译命令、build tags、代码检查 |
-| `config-modification` | 配置修改同步、层级配置系统 |
-| `test-e2e` | Playwright E2E 测试 |
-| `version-switching` | 不停机版本切换设计规范（Docker/独立运行） |
+写入前必须去除本机绝对路径、用户名、邮箱、密钥、Cookie、Token、内网地址、私有部署信息、个人配置和用户数据等本地或隐私内容，只保留可公开、与具体环境无关且具有公共性的技能知识。
+
+| Skill | 文件 | 说明 |
+|-------|------|------|
+| `build` | `.agent/skills/build/SKILL.md` | 编译命令、build tags、代码检查 |
+| `config-modification` | `.agent/skills/config-modification/SKILL.md` | 配置修改同步、层级配置系统 |
+| `test-e2e` | `.agent/skills/test-e2e/SKILL.md` | Playwright E2E 测试 |
+| `version-switching` | `.agent/skills/version-switching/SKILL.md` | 不停机版本切换设计规范（Docker/独立运行） |
 
 ## 快速参考
 

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -407,7 +407,7 @@ func main() {
 		servers.RegisterSSEEventListeners(inst)
 		// 注册直播间状态持久化事件监听器
 		if liveStateManager != nil {
-			livestate.RegisterEventListeners(ed, liveStateManager, inst.Cache)
+			livestate.RegisterEventListeners(ctx, ed, liveStateManager, inst.Cache, lm, rm)
 		}
 		// 设置日志回调，将日志推送到 SSE
 		livelogger.SetLogCallback(func(roomID string, logLine string) {

--- a/src/listeners/listener.go
+++ b/src/listeners/listener.go
@@ -72,7 +72,7 @@ func (l *listener) start(initialInfo *live.Info) error {
 	}
 	defer atomic.CompareAndSwapUint32(&l.state, pending, running)
 
-	l.ed.DispatchEvent(events.NewEvent(ListenStart, l.Live))
+	l.ed.DispatchEvent(events.NewEventWithSource(ListenStart, l.Live, l))
 
 	// 首次信息获取放到后台执行。调用方 manager.AddListener 全程持有管理器的全局锁，
 	// 而 refresh 是一次真实的网络请求，还要排队等待平台访问频率限制；
@@ -100,6 +100,11 @@ func (l *listener) isStopped() bool {
 	}
 }
 
+// IsClosed 供事件处理器判断事件是否来自已经关闭的 listener 实例。
+func (l *listener) IsClosed() bool {
+	return l.isStopped()
+}
+
 func (l *listener) Close() {
 	l.close(false)
 }
@@ -116,7 +121,7 @@ func (l *listener) close(syncEvent bool) {
 	}
 	l.runCancel() // 先取消等待并标记停止，禁止并发请求结果继续发布事件
 	close(l.stop)
-	event := events.NewEvent(ListenStop, l.Live)
+	event := events.NewEventWithSource(ListenStop, l.Live, l)
 	if syncEvent {
 		l.ed.DispatchEventSync(event)
 	} else {
@@ -244,7 +249,7 @@ func (l *listener) processInfo(info *live.Info) {
 		logInfo = "Room name was changed"
 	}
 	if isStatusChanged {
-		l.ed.DispatchEvent(events.NewEvent(evtTyp, l.Live))
+		l.ed.DispatchEvent(events.NewEventWithSource(evtTyp, l.Live, l))
 		applog.GetLogger().WithFields(fields).Info(logInfo)
 	}
 }

--- a/src/listeners/listener.go
+++ b/src/listeners/listener.go
@@ -104,8 +104,8 @@ func (l *listener) Close() {
 	l.close(false)
 }
 
-// CloseSync 同步完成 ListenStop 的所有处理器，仅用于初始化 listener 的交接路径。
-// 普通关闭仍保持异步，避免改变其他调用方的延迟语义。
+// CloseSync 同步完成 ListenStop 的所有处理器，用于调用方必须等待下游状态清理
+// 完成后才能继续的 listener 交接路径。
 func (l *listener) CloseSync() {
 	l.close(true)
 }

--- a/src/listeners/listener_test.go
+++ b/src/listeners/listener_test.go
@@ -53,7 +53,7 @@ func TestRefresh(t *testing.T) {
 	live.EXPECT().GetInfo().Return(&livepkg.Info{Status: true}, nil)
 	live.EXPECT().SetLastStartTime(gomock.Any())
 	live.EXPECT().GetPlatformCNName().Return("platform").AnyTimes()
-	ed.EXPECT().DispatchEvent(events.NewEvent(LiveStart, live))
+	ed.EXPECT().DispatchEvent(events.NewEventWithSource(LiveStart, live, l))
 	l.refresh()
 	assert.True(t, l.status.roomStatus)
 
@@ -68,14 +68,14 @@ func TestRefresh(t *testing.T) {
 	live.EXPECT().GetInfo().Return(&livepkg.Info{Status: true, RoomName: "b"}, nil)
 	live.EXPECT().GetRawUrl().Return("").AnyTimes()                 // 添加对GetRawUrl方法的期望调用
 	live.EXPECT().GetPlatformCNName().Return("platform").AnyTimes() // 添加对GetPlatformCNName方法的期望调用
-	ed.EXPECT().DispatchEvent(events.NewEvent(RoomNameChanged, live))
+	ed.EXPECT().DispatchEvent(events.NewEventWithSource(RoomNameChanged, live, l))
 	l.refresh()
 
 	// true -> false
 	live.EXPECT().GetInfo().Return(&livepkg.Info{Status: false}, nil)
 	live.EXPECT().GetRawUrl().Return("").AnyTimes() // 添加对GetRawUrl方法的期望调用
 	live.EXPECT().GetPlatformCNName().Return("platform").AnyTimes()
-	ed.EXPECT().DispatchEvent(events.NewEvent(LiveEnd, live))
+	ed.EXPECT().DispatchEvent(events.NewEventWithSource(LiveEnd, live, l))
 	l.refresh()
 	assert.False(t, l.status.roomStatus)
 }
@@ -145,7 +145,7 @@ func TestClosedListenerDoesNotPublishInfo(t *testing.T) {
 	live := livemock.NewMockLive(ctrl)
 	l := NewListener(ctx, live).(*listener)
 	atomic.StoreUint32(&l.state, running)
-	ed.EXPECT().DispatchEvent(events.NewEvent(ListenStop, live))
+	ed.EXPECT().DispatchEvent(events.NewEventWithSource(ListenStop, live, l))
 	l.Close()
 
 	// 模拟网络请求在 listener 关闭后才返回开播信息；不得再发布 LiveStart。
@@ -162,7 +162,7 @@ func TestListenerCloseSyncWaitsForStopHandlers(t *testing.T) {
 	live := livemock.NewMockLive(ctrl)
 	l := NewListener(ctx, live).(*listener)
 	atomic.StoreUint32(&l.state, running)
-	ed.EXPECT().DispatchEventSync(events.NewEvent(ListenStop, live))
+	ed.EXPECT().DispatchEventSync(events.NewEventWithSource(ListenStop, live, l))
 
 	l.CloseSync()
 	assert.True(t, l.isStopped())

--- a/src/listeners/manager.go
+++ b/src/listeners/manager.go
@@ -17,7 +17,8 @@ var newListener = NewListener
 
 func NewManager(ctx context.Context) Manager {
 	lm := &manager{
-		savers: make(map[types.LiveID]Listener),
+		savers:  make(map[types.LiveID]Listener),
+		closing: make(map[types.LiveID]chan struct{}),
 	}
 	instance.GetInstance(ctx).ListenerManager = lm
 	return lm
@@ -32,8 +33,9 @@ type Manager interface {
 }
 
 type manager struct {
-	lock   sync.RWMutex
-	savers map[types.LiveID]Listener
+	lock    sync.RWMutex
+	savers  map[types.LiveID]Listener
+	closing map[types.LiveID]chan struct{}
 }
 
 func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
@@ -103,29 +105,54 @@ func (m *manager) Close(ctx context.Context) {
 }
 
 func (m *manager) AddListener(ctx context.Context, live live.Live) error {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if _, ok := m.savers[live.GetLiveId()]; ok {
-		return ErrListenerExist
+	liveID := live.GetLiveId()
+	for {
+		m.lock.Lock()
+		if done, ok := m.closing[liveID]; ok {
+			m.lock.Unlock()
+			select {
+			case <-done:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		if _, ok := m.savers[liveID]; ok {
+			m.lock.Unlock()
+			return ErrListenerExist
+		}
+		listener := newListener(ctx, live)
+		m.savers[liveID] = listener
+		err := listener.Start()
+		m.lock.Unlock()
+		return err
 	}
-	listener := newListener(ctx, live)
-	m.savers[live.GetLiveId()] = listener
-	return listener.Start()
 }
 
 func (m *manager) RemoveListener(ctx context.Context, liveId types.LiveID) error {
 	m.lock.Lock()
-	defer m.lock.Unlock()
 	listener, ok := m.savers[liveId]
 	if !ok {
+		m.lock.Unlock()
 		return ErrListenerNotExist
 	}
-	// 在持有 manager 锁期间同步清理旧 listener 的录制器。这样紧随其后的
-	// AddListener 必须等 ListenStop 处理完成后才能发布新的 LiveStart，避免
-	// 旧停止事件误删刚创建的录制器。
-	listener.CloseSync()
+	if m.closing == nil {
+		m.closing = make(map[types.LiveID]chan struct{})
+	}
+	done := make(chan struct{})
+	m.closing[liveId] = done
 	delete(m.savers, liveId)
+	m.lock.Unlock()
+
+	// 同步清理在全局锁外执行，避免阻塞其他房间，也允许事件处理器回调 manager。
+	// 同一房间的 AddListener 会等待 done，再发布新的 LiveStart。
+	defer func() {
+		m.lock.Lock()
+		delete(m.closing, liveId)
+		close(done)
+		m.lock.Unlock()
+	}()
+	listener.CloseSync()
 	return nil
 }
 

--- a/src/listeners/manager.go
+++ b/src/listeners/manager.go
@@ -121,7 +121,10 @@ func (m *manager) RemoveListener(ctx context.Context, liveId types.LiveID) error
 	if !ok {
 		return ErrListenerNotExist
 	}
-	listener.Close()
+	// 在持有 manager 锁期间同步清理旧 listener 的录制器。这样紧随其后的
+	// AddListener 必须等 ListenStop 处理完成后才能发布新的 LiveStart，避免
+	// 旧停止事件误删刚创建的录制器。
+	listener.CloseSync()
 	delete(m.savers, liveId)
 	return nil
 }

--- a/src/listeners/manager.go
+++ b/src/listeners/manager.go
@@ -105,9 +105,16 @@ func (m *manager) Close(ctx context.Context) {
 }
 
 func (m *manager) AddListener(ctx context.Context, live live.Live) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	liveID := live.GetLiveId()
 	for {
 		m.lock.Lock()
+		if err := ctx.Err(); err != nil {
+			m.lock.Unlock()
+			return err
+		}
 		if done, ok := m.closing[liveID]; ok {
 			m.lock.Unlock()
 			select {

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -3,6 +3,7 @@ package listeners
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,17 @@ import (
 )
 
 const concurrentOperationTimeout = time.Second
+
+type doneObservedContext struct {
+	context.Context
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
 
 func TestManagerAddAndRemoveListener(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -46,6 +58,23 @@ func TestManagerAddAndRemoveListener(t *testing.T) {
 	_, err = m.GetListener(context.Background(), "test")
 	assert.Equal(t, ErrListenerNotExist, err)
 	assert.False(t, m.HasListener(context.Background(), "test"))
+}
+
+func TestManagerAddListenerRejectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	m := &manager{savers: make(map[types.LiveID]Listener)}
+	liveMock := livemock.NewMockLive(gomock.NewController(t))
+	backup := newListener
+	newListener = func(context.Context, live.Live) Listener {
+		t.Fatal("context 已取消时不应创建 listener")
+		return nil
+	}
+	defer func() { newListener = backup }()
+
+	assert.ErrorIs(t, m.AddListener(ctx, liveMock), context.Canceled)
+	assert.Empty(t, m.savers)
 }
 
 func TestManagerAddListenerWaitsForSameLiveIDClosing(t *testing.T) {
@@ -81,10 +110,16 @@ func TestManagerAddListenerWaitsForSameLiveIDClosing(t *testing.T) {
 	}()
 	<-closeStarted
 
-	canceledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-	assert.ErrorIs(t, m.AddListener(canceledCtx, liveMock), context.Canceled)
+	baseCtx, cancel := context.WithCancel(context.Background())
+	waitCtx := &doneObservedContext{Context: baseCtx, observed: make(chan struct{})}
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- m.AddListener(waitCtx, liveMock)
+	}()
+	<-waitCtx.observed
 	assert.Zero(t, newListenerCalls, "旧 listener 关闭完成前不应创建新 listener")
+	cancel()
+	assert.ErrorIs(t, <-addDone, context.Canceled)
 
 	close(releaseClose)
 	assert.NoError(t, <-removeDone)

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
@@ -26,7 +27,7 @@ func TestManagerAddAndRemoveListener(t *testing.T) {
 	newListener = func(ctx context.Context, live live.Live) Listener {
 		ln := NewMockListener(ctrl)
 		ln.EXPECT().Start().Return(nil)
-		ln.EXPECT().Close()
+		ln.EXPECT().CloseSync()
 		return ln
 	}
 	defer func() { newListener = backup }()
@@ -43,6 +44,63 @@ func TestManagerAddAndRemoveListener(t *testing.T) {
 	_, err = m.GetListener(context.Background(), "test")
 	assert.Equal(t, ErrListenerNotExist, err)
 	assert.False(t, m.HasListener(context.Background(), "test"))
+}
+
+func TestManagerRemoveListenerWaitsBeforeReAdd(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	closeStarted := make(chan struct{})
+	releaseClose := make(chan struct{})
+	oldListener := NewMockListener(ctrl)
+	oldListener.EXPECT().CloseSync().Do(func() {
+		close(closeStarted)
+		<-releaseClose
+	})
+
+	startCalled := make(chan struct{})
+	newListenerMock := NewMockListener(ctrl)
+	newListenerMock.EXPECT().Start().DoAndReturn(func() error {
+		close(startCalled)
+		return nil
+	})
+
+	liveMock := livemock.NewMockLive(ctrl)
+	liveMock.EXPECT().GetLiveId().Return(types.LiveID("test")).Times(2)
+
+	m := &manager{savers: map[types.LiveID]Listener{"test": oldListener}}
+	backup := newListener
+	newListener = func(context.Context, live.Live) Listener { return newListenerMock }
+	defer func() { newListener = backup }()
+
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- m.RemoveListener(context.Background(), "test")
+	}()
+	<-closeStarted
+
+	addStarted := make(chan struct{})
+	addDone := make(chan error, 1)
+	go func() {
+		close(addStarted)
+		addDone <- m.AddListener(context.Background(), liveMock)
+	}()
+	<-addStarted
+
+	select {
+	case <-startCalled:
+		t.Error("new listener started before old ListenStop handlers completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseClose)
+	assert.NoError(t, <-removeDone)
+	assert.NoError(t, <-addDone)
+	select {
+	case <-startCalled:
+	case <-time.After(time.Second):
+		t.Error("new listener did not start after old ListenStop handlers completed")
+	}
 }
 
 func TestManagerStartAndClose(t *testing.T) {

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/bililive-go/bililive-go/src/types"
 )
 
+const concurrentOperationTimeout = time.Second
+
 func TestManagerAddAndRemoveListener(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -32,7 +34,7 @@ func TestManagerAddAndRemoveListener(t *testing.T) {
 	}
 	defer func() { newListener = backup }()
 	l := livemock.NewMockLive(ctrl)
-	l.EXPECT().GetLiveId().Return(types.LiveID("test")).Times(3)
+	l.EXPECT().GetLiveId().Return(types.LiveID("test")).Times(2)
 	assert.NoError(t, m.AddListener(context.Background(), l))
 	assert.Equal(t, ErrListenerExist, m.AddListener(context.Background(), l))
 	ln, err := m.GetListener(context.Background(), "test")
@@ -46,7 +48,7 @@ func TestManagerAddAndRemoveListener(t *testing.T) {
 	assert.False(t, m.HasListener(context.Background(), "test"))
 }
 
-func TestManagerRemoveListenerWaitsBeforeReAdd(t *testing.T) {
+func TestManagerAddListenerWaitsForSameLiveIDClosing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -58,19 +60,19 @@ func TestManagerRemoveListenerWaitsBeforeReAdd(t *testing.T) {
 		<-releaseClose
 	})
 
-	startCalled := make(chan struct{})
 	newListenerMock := NewMockListener(ctrl)
-	newListenerMock.EXPECT().Start().DoAndReturn(func() error {
-		close(startCalled)
-		return nil
-	})
+	newListenerMock.EXPECT().Start().Return(nil)
 
 	liveMock := livemock.NewMockLive(ctrl)
 	liveMock.EXPECT().GetLiveId().Return(types.LiveID("test")).Times(2)
 
 	m := &manager{savers: map[types.LiveID]Listener{"test": oldListener}}
 	backup := newListener
-	newListener = func(context.Context, live.Live) Listener { return newListenerMock }
+	newListenerCalls := 0
+	newListener = func(context.Context, live.Live) Listener {
+		newListenerCalls++
+		return newListenerMock
+	}
 	defer func() { newListener = backup }()
 
 	removeDone := make(chan error, 1)
@@ -79,27 +81,63 @@ func TestManagerRemoveListenerWaitsBeforeReAdd(t *testing.T) {
 	}()
 	<-closeStarted
 
-	addStarted := make(chan struct{})
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.ErrorIs(t, m.AddListener(canceledCtx, liveMock), context.Canceled)
+	assert.Zero(t, newListenerCalls, "旧 listener 关闭完成前不应创建新 listener")
+
+	close(releaseClose)
+	assert.NoError(t, <-removeDone)
+	assert.NoError(t, m.AddListener(context.Background(), liveMock))
+	assert.Equal(t, 1, newListenerCalls)
+}
+
+func TestManagerRemoveListenerDoesNotBlockOtherLiveID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	closeStarted := make(chan struct{})
+	releaseClose := make(chan struct{})
+	oldListener := NewMockListener(ctrl)
+	oldListener.EXPECT().CloseSync().Do(func() {
+		close(closeStarted)
+		<-releaseClose
+	})
+
+	otherListener := NewMockListener(ctrl)
+	otherListener.EXPECT().Start().Return(nil)
+	otherLive := livemock.NewMockLive(ctrl)
+	otherLive.EXPECT().GetLiveId().Return(types.LiveID("other"))
+
+	m := &manager{savers: map[types.LiveID]Listener{"test": oldListener}}
+	backup := newListener
+	newListener = func(context.Context, live.Live) Listener { return otherListener }
+	defer func() { newListener = backup }()
+
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- m.RemoveListener(context.Background(), "test")
+	}()
+	<-closeStarted
+
 	addDone := make(chan error, 1)
 	go func() {
-		close(addStarted)
-		addDone <- m.AddListener(context.Background(), liveMock)
+		addDone <- m.AddListener(context.Background(), otherLive)
 	}()
-	<-addStarted
 
+	addCompleted := false
 	select {
-	case <-startCalled:
-		t.Error("new listener started before old ListenStop handlers completed")
-	case <-time.After(50 * time.Millisecond):
+	case err := <-addDone:
+		addCompleted = true
+		assert.NoError(t, err)
+	case <-time.After(concurrentOperationTimeout):
+		t.Error("关闭一个房间时阻塞了其他房间的 AddListener")
 	}
 
 	close(releaseClose)
 	assert.NoError(t, <-removeDone)
-	assert.NoError(t, <-addDone)
-	select {
-	case <-startCalled:
-	case <-time.After(time.Second):
-		t.Error("new listener did not start after old ListenStop handlers completed")
+	if !addCompleted {
+		assert.NoError(t, <-addDone)
 	}
 }
 

--- a/src/livestate/events.go
+++ b/src/livestate/events.go
@@ -1,20 +1,75 @@
 package livestate
 
 import (
+	"context"
+
 	"github.com/bililive-go/bililive-go/src/listeners"
 	"github.com/bililive-go/bililive-go/src/live"
 	"github.com/bililive-go/bililive-go/src/pkg/events"
 	"github.com/bililive-go/bililive-go/src/recorders"
+	"github.com/bililive-go/bililive-go/src/types"
 	"github.com/bluele/gcache"
 	"github.com/sirupsen/logrus"
 )
 
+type listenerSourceLookup interface {
+	GetListener(ctx context.Context, liveID types.LiveID) (listeners.Listener, error)
+}
+
+type recorderSourceLookup interface {
+	GetRecorder(ctx context.Context, liveID types.LiveID) (recorders.Recorder, error)
+}
+
+// liveEndSourceReplaced 判断 LiveEnd 是否来自已被同类新实例替换的来源。
+//
+// 不能只检查来源是否已关闭：listener 在关闭前确认并派发的 LiveEnd 可能晚于
+// CloseSync 执行，此时只要尚未出现替代实例，该事件仍应结束当前直播会话。
+// recorder 也可能在 recorder manager 处理同一个 LiveEnd 时先被关闭，因此需要
+// 比较当前实例身份，而不是把“已关闭”等同于“已失效”。
+func liveEndSourceReplaced(
+	ctx context.Context,
+	event *events.Event,
+	liveID types.LiveID,
+	listenerManager listenerSourceLookup,
+	recorderManager recorderSourceLookup,
+) bool {
+	if event == nil || event.Source == nil {
+		return false
+	}
+	switch source := event.Source.(type) {
+	case listeners.Listener:
+		if listenerManager == nil {
+			return false
+		}
+		current, err := listenerManager.GetListener(ctx, liveID)
+		return err == nil && current != source
+	case recorders.Recorder:
+		if recorderManager == nil {
+			return false
+		}
+		current, err := recorderManager.GetRecorder(ctx, liveID)
+		return err == nil && current != source
+	default:
+		return false
+	}
+}
+
 // RegisterEventListeners 注册事件监听器，用于在直播状态变化时更新数据库
 // 参数：
+//   - ctx: 应用级 context
 //   - ed: 事件分发器
 //   - manager: LiveStateManager 实例
 //   - cache: 缓存实例，用于获取直播间信息
-func RegisterEventListeners(ed events.Dispatcher, manager *Manager, cache gcache.Cache) {
+//   - listenerManager: listener 当前实例查询器
+//   - recorderManager: recorder 当前实例查询器
+func RegisterEventListeners(
+	ctx context.Context,
+	ed events.Dispatcher,
+	manager *Manager,
+	cache gcache.Cache,
+	listenerManager listeners.Manager,
+	recorderManager recorders.Manager,
+) {
 	if manager == nil {
 		logrus.Debug("LiveStateManager 未初始化，跳过事件监听器注册")
 		return
@@ -52,16 +107,16 @@ func RegisterEventListeners(ed events.Dispatcher, manager *Manager, cache gcache
 
 	// 监听直播结束事件
 	ed.AddEventListener(listeners.LiveEnd, events.NewEventListener(func(event *events.Event) {
-		if events.SourceClosed(event) {
-			return
-		}
 		l, ok := event.Object.(live.Live)
 		if !ok {
 			return
 		}
 
-		liveID := string(l.GetLiveId())
-		manager.OnLiveEnd(liveID)
+		liveID := l.GetLiveId()
+		if liveEndSourceReplaced(ctx, event, liveID, listenerManager, recorderManager) {
+			return
+		}
+		manager.OnLiveEnd(string(liveID))
 	}))
 
 	// 监听录制开始事件

--- a/src/livestate/events.go
+++ b/src/livestate/events.go
@@ -22,6 +22,9 @@ func RegisterEventListeners(ed events.Dispatcher, manager *Manager, cache gcache
 
 	// 监听直播开始事件
 	ed.AddEventListener(listeners.LiveStart, events.NewEventListener(func(event *events.Event) {
+		if events.SourceClosed(event) {
+			return
+		}
 		l, ok := event.Object.(live.Live)
 		if !ok {
 			return
@@ -49,6 +52,9 @@ func RegisterEventListeners(ed events.Dispatcher, manager *Manager, cache gcache
 
 	// 监听直播结束事件
 	ed.AddEventListener(listeners.LiveEnd, events.NewEventListener(func(event *events.Event) {
+		if events.SourceClosed(event) {
+			return
+		}
 		l, ok := event.Object.(live.Live)
 		if !ok {
 			return

--- a/src/livestate/events_test.go
+++ b/src/livestate/events_test.go
@@ -1,0 +1,119 @@
+package livestate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bililive-go/bililive-go/src/instance"
+	"github.com/bililive-go/bililive-go/src/listeners"
+	"github.com/bililive-go/bililive-go/src/live"
+	"github.com/bililive-go/bililive-go/src/pkg/events"
+	"github.com/bililive-go/bililive-go/src/recorders"
+	"github.com/bililive-go/bililive-go/src/types"
+)
+
+type liveEndListenerSource struct {
+	closed bool
+}
+
+func (*liveEndListenerSource) Start() error {
+	return nil
+}
+
+func (*liveEndListenerSource) StartWithInfo(*live.Info) error {
+	return nil
+}
+
+func (s *liveEndListenerSource) Close() {
+	s.closed = true
+}
+
+func (s *liveEndListenerSource) CloseSync() {
+	s.closed = true
+}
+
+func (s *liveEndListenerSource) IsClosed() bool {
+	return s.closed
+}
+
+type listenerSourceLookupStub struct {
+	current listeners.Listener
+	err     error
+}
+
+func (s listenerSourceLookupStub) GetListener(context.Context, types.LiveID) (listeners.Listener, error) {
+	return s.current, s.err
+}
+
+type recorderSourceLookupStub struct {
+	current recorders.Recorder
+	err     error
+}
+
+func (s recorderSourceLookupStub) GetRecorder(context.Context, types.LiveID) (recorders.Recorder, error) {
+	return s.current, s.err
+}
+
+func TestLiveEndSourceReplacedForListener(t *testing.T) {
+	ctx := context.Background()
+	oldListener := &liveEndListenerSource{closed: true}
+	newListener := &liveEndListenerSource{}
+	event := events.NewEventWithSource(listeners.LiveEnd, nil, oldListener)
+
+	assert.False(t, liveEndSourceReplaced(
+		ctx,
+		event,
+		"test",
+		listenerSourceLookupStub{err: listeners.ErrListenerNotExist},
+		nil,
+	), "关闭前已派发的 LiveEnd 在没有替代 listener 时仍应保留")
+	assert.False(t, liveEndSourceReplaced(
+		ctx,
+		event,
+		"test",
+		listenerSourceLookupStub{current: oldListener},
+		nil,
+	))
+	assert.True(t, liveEndSourceReplaced(
+		ctx,
+		event,
+		"test",
+		listenerSourceLookupStub{current: newListener},
+		nil,
+	), "旧 listener 的 LiveEnd 不应结束新 listener 对应的直播会话")
+}
+
+func TestLiveEndSourceReplacedForRecorder(t *testing.T) {
+	inst := &instance.Instance{}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	inst.EventDispatcher = events.NewDispatcher(ctx)
+	oldRecorder, err := recorders.NewRecorder(ctx, nil)
+	assert.NoError(t, err)
+	newRecorder, err := recorders.NewRecorder(ctx, nil)
+	assert.NoError(t, err)
+	event := events.NewEventWithSource(listeners.LiveEnd, nil, oldRecorder)
+
+	assert.False(t, liveEndSourceReplaced(
+		ctx,
+		event,
+		"test",
+		nil,
+		recorderSourceLookupStub{err: recorders.ErrRecorderNotExist},
+	), "没有替代 recorder 时应保留当前实例派发的 LiveEnd")
+	assert.False(t, liveEndSourceReplaced(
+		ctx,
+		event,
+		"test",
+		nil,
+		recorderSourceLookupStub{current: oldRecorder},
+	))
+	assert.True(t, liveEndSourceReplaced(
+		ctx,
+		event,
+		"test",
+		nil,
+		recorderSourceLookupStub{current: newRecorder},
+	), "旧 recorder 的 LiveEnd 不应结束新 recorder 对应的直播会话")
+}

--- a/src/pkg/events/dispatcher_test.go
+++ b/src/pkg/events/dispatcher_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type closeableEventSource struct {
+	closed bool
+}
+
+func (s *closeableEventSource) IsClosed() bool {
+	return s.closed
+}
+
+func TestSourceClosed(t *testing.T) {
+	assert.False(t, SourceClosed(nil))
+	assert.False(t, SourceClosed(NewEvent("test", nil)))
+	assert.False(t, SourceClosed(NewEventWithSource("test", nil, &closeableEventSource{})))
+	assert.True(t, SourceClosed(NewEventWithSource("test", nil, &closeableEventSource{closed: true})))
+}
+
 func TestAddAndRemoveEventListener(t *testing.T) {
 	d := NewDispatcher(context.Background()).(*dispatcher)
 	l := NewEventListener(func(event *Event) {})

--- a/src/pkg/events/event.go
+++ b/src/pkg/events/event.go
@@ -19,6 +19,16 @@ func NewEventWithSource(eventType EventType, object, source any) *Event {
 	return &Event{Type: eventType, Object: object, Source: source}
 }
 
+// SourceClosed 用于判断事件是否来自已经关闭的发布实例。
+// 事件处理器可用它过滤关闭后才执行的异步事件，避免旧实例影响新实例的状态。
+func SourceClosed(event *Event) bool {
+	if event == nil {
+		return false
+	}
+	source, ok := event.Source.(interface{ IsClosed() bool })
+	return ok && source.IsClosed()
+}
+
 type EventListener struct {
 	Handler EventHandler
 }

--- a/src/pkg/events/event.go
+++ b/src/pkg/events/event.go
@@ -7,10 +7,16 @@ type EventHandler func(event *Event)
 type Event struct {
 	Type   EventType
 	Object any
+	// Source 标识事件的发布实例，供处理器拒绝已失效实例的迟到事件。
+	Source any
 }
 
 func NewEvent(eventType EventType, object any) *Event {
-	return &Event{eventType, object}
+	return &Event{Type: eventType, Object: object}
+}
+
+func NewEventWithSource(eventType EventType, object, source any) *Event {
+	return &Event{Type: eventType, Object: object, Source: source}
 }
 
 type EventListener struct {

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -52,6 +52,7 @@ func SetBroadcastDanmakuFunc(fn BroadcastDanmakuFunc) {
 func NewManager(ctx context.Context) Manager {
 	rm := &manager{
 		savers:       make(map[types.LiveID]Recorder),
+		closing:      make(map[types.LiveID]chan struct{}),
 		statusStopCh: make(chan struct{}),
 	}
 	instance.GetInstance(ctx).RecorderManager = rm
@@ -83,6 +84,7 @@ var (
 type manager struct {
 	lock         sync.RWMutex
 	savers       map[types.LiveID]Recorder
+	closing      map[types.LiveID]chan struct{}
 	statusTicker *time.Ticker
 	statusStopCh chan struct{}
 	statusWg     sync.WaitGroup // 用于等待广播 goroutine 退出
@@ -93,6 +95,24 @@ type manager struct {
 	// 会误判为"无活跃录制"导致优雅更新被提前触发。
 	// 通过 restartingCount 将收尾中的旧 recorder 也计入活跃数量。
 	restartingCount atomic.Int32
+}
+
+type recorderRemovalOptions struct {
+	event               *events.Event
+	allowClosedListener bool
+	waitForClosing      bool
+}
+
+type listenerEventSource interface {
+	IsClosed() bool
+}
+
+func eventFromClosedListener(event *events.Event) bool {
+	if event == nil {
+		return false
+	}
+	source, ok := event.Source.(listenerEventSource)
+	return ok && source.IsClosed()
 }
 
 func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
@@ -107,13 +127,16 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 			}
 		}
 
-		if err := m.AddRecorder(ctx, live); err != nil {
+		if err := m.addRecorder(ctx, live, event); err != nil {
 			live.GetLogger().Errorf("failed to add recorder, err: %v", err)
 		}
 	}))
 
 	ed.AddEventListener(listeners.RoomNameChanged, events.NewEventListener(func(event *events.Event) {
 		live := event.Object.(live.Live)
+		if eventFromClosedListener(event) {
+			return
+		}
 		if !m.HasRecorder(ctx, live.GetLiveId()) {
 			return
 		}
@@ -122,17 +145,23 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 		}
 	}))
 
-	removeEvtListener := events.NewEventListener(func(event *events.Event) {
+	ed.AddEventListener(listeners.LiveEnd, events.NewEventListener(func(event *events.Event) {
 		live := event.Object.(live.Live)
-		if !m.HasRecorder(ctx, live.GetLiveId()) {
-			return
-		}
-		if err := m.RemoveRecorder(ctx, live.GetLiveId()); err != nil {
+		if err := m.removeRecorder(ctx, live.GetLiveId(), recorderRemovalOptions{event: event}); err != nil {
 			live.GetLogger().Errorf("failed to remove recorder, err: %v", err)
 		}
-	})
-	ed.AddEventListener(listeners.LiveEnd, removeEvtListener)
-	ed.AddEventListener(listeners.ListenStop, removeEvtListener)
+	}))
+
+	ed.AddEventListener(listeners.ListenStop, events.NewEventListener(func(event *events.Event) {
+		live := event.Object.(live.Live)
+		if err := m.removeRecorder(ctx, live.GetLiveId(), recorderRemovalOptions{
+			event:               event,
+			allowClosedListener: true,
+			waitForClosing:      true,
+		}); err != nil {
+			live.GetLogger().Errorf("failed to remove recorder, err: %v", err)
+		}
+	}))
 }
 
 func (m *manager) Start(ctx context.Context) error {
@@ -170,9 +199,37 @@ func (m *manager) Close(ctx context.Context) {
 }
 
 func (m *manager) AddRecorder(ctx context.Context, live live.Live) error {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.addRecorderLocked(ctx, live)
+	return m.addRecorder(ctx, live, nil)
+}
+
+func (m *manager) addRecorder(ctx context.Context, live live.Live, event *events.Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	liveID := live.GetLiveId()
+	for {
+		m.lock.Lock()
+		if err := ctx.Err(); err != nil {
+			m.lock.Unlock()
+			return err
+		}
+		if eventFromClosedListener(event) {
+			m.lock.Unlock()
+			return nil
+		}
+		if done, ok := m.closing[liveID]; ok {
+			m.lock.Unlock()
+			select {
+			case <-done:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		err := m.addRecorderLocked(ctx, live)
+		m.lock.Unlock()
+		return err
+	}
 }
 
 // addRecorderLocked 是 AddRecorder 的内部实现，调用者必须已持有 m.lock
@@ -278,19 +335,65 @@ func (m *manager) RestartRecorder(ctx context.Context, live live.Live) error {
 }
 
 func (m *manager) RemoveRecorder(ctx context.Context, liveId types.LiveID) error {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.removeRecorderLocked(ctx, liveId)
+	return m.removeRecorder(ctx, liveId, recorderRemovalOptions{})
 }
 
-// removeRecorderLocked 是 RemoveRecorder 的内部实现，调用者必须已持有 m.lock
-func (m *manager) removeRecorderLocked(ctx context.Context, liveId types.LiveID) error {
-	recorder, ok := m.savers[liveId]
-	if !ok {
+func (m *manager) removeRecorder(ctx context.Context, liveId types.LiveID, opts recorderRemovalOptions) error {
+	m.lock.Lock()
+	if !opts.allowClosedListener && eventFromClosedListener(opts.event) {
+		m.lock.Unlock()
+		return nil
+	}
+	if done, ok := m.closing[liveId]; ok {
+		m.lock.Unlock()
+		if opts.waitForClosing {
+			select {
+			case <-done:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		if opts.event != nil {
+			return nil
+		}
 		return ErrRecorderNotExist
 	}
-	recorder.Close()
+
+	recorder, ok := m.savers[liveId]
+	if !ok {
+		m.lock.Unlock()
+		if opts.event != nil {
+			return nil
+		}
+		return ErrRecorderNotExist
+	}
+	if opts.event != nil {
+		if source, ok := opts.event.Source.(Recorder); ok && source != recorder {
+			m.lock.Unlock()
+			return nil
+		}
+	}
+	if m.closing == nil {
+		m.closing = make(map[types.LiveID]chan struct{})
+	}
+	done := make(chan struct{})
+	m.closing[liveId] = done
 	delete(m.savers, liveId)
+	m.lock.Unlock()
+
+	var finishOnce sync.Once
+	finishClosing := func() {
+		finishOnce.Do(func() {
+			m.lock.Lock()
+			delete(m.closing, liveId)
+			close(done)
+			m.lock.Unlock()
+		})
+	}
+	defer finishClosing()
+	recorder.CloseAndWait()
+	finishClosing()
 
 	// 录制结束后，检查是否有等待中的优雅更新
 	if onRecordingEndFunc != nil {
@@ -382,9 +485,9 @@ func (m *manager) GetRecorderStatus(ctx context.Context, liveId types.LiveID) (m
 }
 
 // GetActiveRecordingsCount 获取当前活跃的录制数量
-// 包含 map 中的录制器和正在执行 CloseForRestart 收尾的旧录制器
+// 包含 map 中的录制器、正在关闭的录制器和执行 CloseForRestart 收尾的旧录制器
 func (m *manager) GetActiveRecordingsCount() int {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	return len(m.savers) + int(m.restartingCount.Load())
+	return len(m.savers) + len(m.closing) + int(m.restartingCount.Load())
 }

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -197,7 +197,18 @@ func (m *manager) Close(ctx context.Context) {
 }
 
 func (m *manager) AddRecorder(ctx context.Context, live live.Live) error {
-	return m.addRecorder(ctx, live, nil)
+	// 直接录制（包括 NotifyOnly 房间）仍可能存在 listener。记录当前 listener
+	// 后，房间改名事件可以重启该 recorder，同时旧 listener 的迟到事件仍会
+	// 被 restartRecorder 的来源身份校验拒绝。
+	var event *events.Event
+	if inst := instance.GetInstance(ctx); inst != nil && inst.ListenerManager != nil {
+		if listenerManager, ok := inst.ListenerManager.(listeners.Manager); ok {
+			if source, err := listenerManager.GetListener(ctx, live.GetLiveId()); err == nil {
+				event = events.NewEventWithSource(listeners.LiveStart, live, source)
+			}
+		}
+	}
+	return m.addRecorder(ctx, live, event)
 }
 
 func (m *manager) addRecorder(ctx context.Context, live live.Live, event *events.Event) error {

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -53,6 +53,7 @@ func NewManager(ctx context.Context) Manager {
 	rm := &manager{
 		savers:       make(map[types.LiveID]Recorder),
 		closing:      make(map[types.LiveID]chan struct{}),
+		sources:      make(map[types.LiveID]any),
 		statusStopCh: make(chan struct{}),
 	}
 	instance.GetInstance(ctx).RecorderManager = rm
@@ -82,9 +83,14 @@ var (
 )
 
 type manager struct {
-	lock         sync.RWMutex
-	savers       map[types.LiveID]Recorder
-	closing      map[types.LiveID]chan struct{}
+	lock    sync.RWMutex
+	savers  map[types.LiveID]Recorder
+	closing map[types.LiveID]chan struct{}
+	// sources 记录创建各录制器的 listener 实例，用于拒绝旧 listener 的迟到事件。
+	sources map[types.LiveID]any
+	// waitingAdds 记录正在等待关闭屏障的重新添加操作。
+	// 与 closing 一起计入活跃录制数，避免优雅更新在交接间隙被触发。
+	waitingAdds  int
 	statusTicker *time.Ticker
 	statusStopCh chan struct{}
 	statusWg     sync.WaitGroup // 用于等待广播 goroutine 退出
@@ -103,16 +109,8 @@ type recorderRemovalOptions struct {
 	waitForClosing      bool
 }
 
-type listenerEventSource interface {
-	IsClosed() bool
-}
-
 func eventFromClosedListener(event *events.Event) bool {
-	if event == nil {
-		return false
-	}
-	source, ok := event.Source.(listenerEventSource)
-	return ok && source.IsClosed()
+	return events.SourceClosed(event)
 }
 
 func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
@@ -140,7 +138,7 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 		if !m.HasRecorder(ctx, live.GetLiveId()) {
 			return
 		}
-		if err := m.RestartRecorder(ctx, live); err != nil {
+		if err := m.restartRecorder(ctx, live, event.Source); err != nil {
 			live.GetLogger().Errorf("failed to cronRestart recorder, err: %v", err)
 		}
 	}))
@@ -207,8 +205,16 @@ func (m *manager) addRecorder(ctx context.Context, live live.Live, event *events
 		return err
 	}
 	liveID := live.GetLiveId()
+	var source any
+	if event != nil {
+		source = event.Source
+	}
+	waitingForClosing := false
 	for {
 		m.lock.Lock()
+		if waitingForClosing {
+			m.waitingAdds--
+		}
 		if err := ctx.Err(); err != nil {
 			m.lock.Unlock()
 			return err
@@ -218,22 +224,27 @@ func (m *manager) addRecorder(ctx context.Context, live live.Live, event *events
 			return nil
 		}
 		if done, ok := m.closing[liveID]; ok {
+			m.waitingAdds++
+			waitingForClosing = true
 			m.lock.Unlock()
 			select {
 			case <-done:
 				continue
 			case <-ctx.Done():
+				m.lock.Lock()
+				m.waitingAdds--
+				m.lock.Unlock()
 				return ctx.Err()
 			}
 		}
-		err := m.addRecorderLocked(ctx, live)
+		err := m.addRecorderLocked(ctx, live, source)
 		m.lock.Unlock()
 		return err
 	}
 }
 
 // addRecorderLocked 是 AddRecorder 的内部实现，调用者必须已持有 m.lock
-func (m *manager) addRecorderLocked(ctx context.Context, live live.Live) error {
+func (m *manager) addRecorderLocked(ctx context.Context, live live.Live, source any) error {
 	if _, ok := m.savers[live.GetLiveId()]; ok {
 		return ErrRecorderExist
 	}
@@ -242,6 +253,10 @@ func (m *manager) addRecorderLocked(ctx context.Context, live live.Live) error {
 		return err
 	}
 	m.savers[live.GetLiveId()] = recorder
+	if m.sources == nil {
+		m.sources = make(map[types.LiveID]any)
+	}
+	m.sources[live.GetLiveId()] = source
 
 	cfg := configs.GetCurrentConfig()
 	if cfg != nil {
@@ -254,6 +269,7 @@ func (m *manager) addRecorderLocked(ctx context.Context, live live.Live) error {
 		// 使用异步 Close 避免在持锁时执行耗时操作（如等待 ffmpeg 进程退出），
 		// 防止长时间阻塞其他 manager 操作
 		delete(m.savers, live.GetLiveId())
+		delete(m.sources, live.GetLiveId())
 		bilisentry.Go(recorder.Close)
 		return err
 	}
@@ -281,6 +297,12 @@ func (m *manager) cronRestart(ctx context.Context, live live.Live) {
 }
 
 func (m *manager) RestartRecorder(ctx context.Context, live live.Live) error {
+	return m.restartRecorder(ctx, live, nil)
+}
+
+// restartRecorder 在锁内重验触发事件的 listener 身份，防止旧 listener
+// 已通过关闭检查、但在新实例建立后才继续执行的迟到事件重启新 recorder。
+func (m *manager) restartRecorder(ctx context.Context, live live.Live, expectedSource any) error {
 	// 1. 在锁内完成 map 操作：取出旧 recorder，创建并放入新 recorder
 	// 这样外部观察者（如 LiveEnd 事件处理器）始终能看到录制器存在，不会出现中间状态
 	m.lock.Lock()
@@ -289,11 +311,18 @@ func (m *manager) RestartRecorder(ctx context.Context, live live.Live) error {
 		m.lock.Unlock()
 		return ErrRecorderNotExist
 	}
+	if expectedSource != nil && m.sources[live.GetLiveId()] != expectedSource {
+		m.lock.Unlock()
+		return nil
+	}
+	oldSource := m.sources[live.GetLiveId()]
 	// 从 map 中移除旧 recorder 并立即添加新 recorder，保持锁贯穿整个替换操作
 	delete(m.savers, live.GetLiveId())
-	if err := m.addRecorderLocked(ctx, live); err != nil {
+	delete(m.sources, live.GetLiveId())
+	if err := m.addRecorderLocked(ctx, live, oldSource); err != nil {
 		// 添加新 recorder 失败，恢复旧 recorder 避免僵尸状态
 		m.savers[live.GetLiveId()] = oldRecorder
+		m.sources[live.GetLiveId()] = oldSource
 		m.lock.Unlock()
 		return err
 	}
@@ -380,6 +409,7 @@ func (m *manager) removeRecorder(ctx context.Context, liveId types.LiveID, opts 
 	done := make(chan struct{})
 	m.closing[liveId] = done
 	delete(m.savers, liveId)
+	delete(m.sources, liveId)
 	m.lock.Unlock()
 
 	var finishOnce sync.Once
@@ -485,9 +515,10 @@ func (m *manager) GetRecorderStatus(ctx context.Context, liveId types.LiveID) (m
 }
 
 // GetActiveRecordingsCount 获取当前活跃的录制数量
-// 包含 map 中的录制器、正在关闭的录制器和执行 CloseForRestart 收尾的旧录制器
+// 包含 map 中的录制器、正在关闭的录制器、等待关闭屏障的重新添加操作，
+// 以及执行 CloseForRestart 收尾的旧录制器。
 func (m *manager) GetActiveRecordingsCount() int {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	return len(m.savers) + len(m.closing) + int(m.restartingCount.Load())
+	return len(m.savers) + len(m.closing) + m.waitingAdds + int(m.restartingCount.Load())
 }

--- a/src/recorders/manager_test.go
+++ b/src/recorders/manager_test.go
@@ -145,6 +145,7 @@ func TestManagerRecorderClosingBlocksReAddAndListenStop(t *testing.T) {
 	}()
 	<-waitCtx.observed
 	assert.Zero(t, newRecorderCalls, "旧 recorder 完全退出前不应创建新 recorder")
+	assert.Equal(t, 2, m.GetActiveRecordingsCount(), "关闭屏障和等待重建的 recorder 都应阻止优雅更新")
 	cancel()
 	assert.ErrorIs(t, <-addDone, context.Canceled)
 
@@ -166,6 +167,31 @@ func TestManagerRecorderClosingBlocksReAddAndListenStop(t *testing.T) {
 	assert.NoError(t, <-stopDone)
 	assert.NoError(t, m.AddRecorder(context.Background(), liveMock))
 	assert.Equal(t, 1, newRecorderCalls)
+}
+
+func TestManagerRejectsLateRoomNameChangedFromOldListener(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	liveMock := livemock.NewMockLive(ctrl)
+	liveMock.EXPECT().GetLiveId().Return(types.LiveID("test")).AnyTimes()
+	oldListener := &testListenerEventSource{}
+	newListener := &testListenerEventSource{}
+	currentRecorder := NewMockRecorder(ctrl)
+	m := &manager{
+		savers:  map[types.LiveID]Recorder{"test": currentRecorder},
+		sources: map[types.LiveID]any{"test": newListener},
+	}
+
+	backup := newRecorder
+	newRecorder = func(context.Context, live.Live) (Recorder, error) {
+		t.Fatal("旧 listener 的迟到事件不应重启新 recorder")
+		return nil, nil
+	}
+	defer func() { newRecorder = backup }()
+
+	assert.NoError(t, m.restartRecorder(context.Background(), liveMock, oldListener))
+	assert.Same(t, currentRecorder, m.savers[types.LiveID("test")])
 }
 
 func closedSourceForTest() *testListenerEventSource {

--- a/src/recorders/manager_test.go
+++ b/src/recorders/manager_test.go
@@ -22,8 +22,53 @@ type testListenerEventSource struct {
 	closed bool
 }
 
+func (s *testListenerEventSource) Start() error {
+	return nil
+}
+
+func (s *testListenerEventSource) StartWithInfo(*live.Info) error {
+	return nil
+}
+
+func (s *testListenerEventSource) Close() {
+	s.closed = true
+}
+
+func (s *testListenerEventSource) CloseSync() {
+	s.closed = true
+}
+
 func (s *testListenerEventSource) IsClosed() bool {
 	return s.closed
+}
+
+type testCurrentListenerManager struct {
+	listener listeners.Listener
+}
+
+func (m *testCurrentListenerManager) Start(context.Context) error {
+	return nil
+}
+
+func (m *testCurrentListenerManager) Close(context.Context) {}
+
+func (m *testCurrentListenerManager) AddListener(context.Context, live.Live) error {
+	return nil
+}
+
+func (m *testCurrentListenerManager) RemoveListener(context.Context, types.LiveID) error {
+	return nil
+}
+
+func (m *testCurrentListenerManager) GetListener(context.Context, types.LiveID) (listeners.Listener, error) {
+	if m.listener == nil {
+		return nil, listeners.ErrListenerNotExist
+	}
+	return m.listener, nil
+}
+
+func (m *testCurrentListenerManager) HasListener(context.Context, types.LiveID) bool {
+	return m.listener != nil
 }
 
 type recorderDoneObservedContext struct {
@@ -192,6 +237,48 @@ func TestManagerRejectsLateRoomNameChangedFromOldListener(t *testing.T) {
 
 	assert.NoError(t, m.restartRecorder(context.Background(), liveMock, oldListener))
 	assert.Same(t, currentRecorder, m.savers[types.LiveID("test")])
+}
+
+func TestManagerDirectRecorderUsesCurrentListenerSource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	configs.SetCurrentConfig(new(configs.Config))
+	listenerSource := &testListenerEventSource{}
+	inst := &instance.Instance{
+		ListenerManager: &testCurrentListenerManager{listener: listenerSource},
+	}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	m := NewManager(ctx).(*manager)
+
+	liveMock := livemock.NewMockLive(ctrl)
+	liveMock.EXPECT().GetLiveId().Return(types.LiveID("test")).AnyTimes()
+	liveMock.EXPECT().GetLogger().Return(livelogger.New(0, nil)).AnyTimes()
+
+	oldRecorder := NewMockRecorder(ctrl)
+	oldRecorder.EXPECT().Start(ctx).Return(nil)
+	oldRecorder.EXPECT().CloseForRestart().Return(nil)
+	newRecorderMock := NewMockRecorder(ctrl)
+	newRecorderMock.EXPECT().Start(ctx).Return(nil)
+
+	backup := newRecorder
+	callCount := 0
+	newRecorder = func(context.Context, live.Live) (Recorder, error) {
+		callCount++
+		if callCount == 1 {
+			return oldRecorder, nil
+		}
+		return newRecorderMock, nil
+	}
+	defer func() { newRecorder = backup }()
+
+	assert.NoError(t, m.AddRecorder(ctx, liveMock))
+	assert.Same(t, listenerSource, m.sources[types.LiveID("test")])
+
+	// 当前 listener 的改名事件必须能够通过来源校验并重启直接录制器。
+	assert.NoError(t, m.restartRecorder(ctx, liveMock, listenerSource))
+	assert.Same(t, newRecorderMock, m.savers[types.LiveID("test")])
+	assert.Same(t, listenerSource, m.sources[types.LiveID("test")])
 }
 
 func closedSourceForTest() *testListenerEventSource {

--- a/src/recorders/manager_test.go
+++ b/src/recorders/manager_test.go
@@ -10,11 +10,32 @@ import (
 
 	"github.com/bililive-go/bililive-go/src/configs"
 	"github.com/bililive-go/bililive-go/src/instance"
+	"github.com/bililive-go/bililive-go/src/listeners"
 	"github.com/bililive-go/bililive-go/src/live"
 	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	"github.com/bililive-go/bililive-go/src/pkg/events"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 	"github.com/bililive-go/bililive-go/src/types"
 )
+
+type testListenerEventSource struct {
+	closed bool
+}
+
+func (s *testListenerEventSource) IsClosed() bool {
+	return s.closed
+}
+
+type recorderDoneObservedContext struct {
+	context.Context
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (c *recorderDoneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
 
 func TestManagerAddAndRemoveRecorder(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -33,8 +54,8 @@ func TestManagerAddAndRemoveRecorder(t *testing.T) {
 			// 第一个 recorder 会被 RestartRecorder 调用 CloseForRestart
 			r.EXPECT().CloseForRestart().Return(nil)
 		} else {
-			// 第二个 recorder 会被 RemoveRecorder 调用 Close
-			r.EXPECT().Close()
+			// 第二个 recorder 会被 RemoveRecorder 调用 CloseAndWait
+			r.EXPECT().CloseAndWait()
 		}
 		return r, nil
 	}
@@ -54,6 +75,101 @@ func TestManagerAddAndRemoveRecorder(t *testing.T) {
 	_, err = m.GetRecorder(context.Background(), "test")
 	assert.Equal(t, ErrRecorderNotExist, err)
 	assert.False(t, m.HasRecorder(context.Background(), "test"))
+}
+
+func TestManagerIgnoresStaleRecorderEvents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	liveMock := livemock.NewMockLive(ctrl)
+	liveMock.EXPECT().GetLiveId().Return(types.LiveID("test")).AnyTimes()
+
+	m := &manager{savers: make(map[types.LiveID]Recorder)}
+	backup := newRecorder
+	newRecorder = func(context.Context, live.Live) (Recorder, error) {
+		t.Fatal("关闭后的 listener 不应创建 recorder")
+		return nil, nil
+	}
+	defer func() { newRecorder = backup }()
+
+	closedSource := &testListenerEventSource{closed: true}
+	staleLiveStart := events.NewEventWithSource(listeners.LiveStart, liveMock, closedSource)
+	assert.NoError(t, m.addRecorder(context.Background(), liveMock, staleLiveStart))
+	assert.Empty(t, m.savers)
+
+	oldRecorder := NewMockRecorder(ctrl)
+	currentRecorder := NewMockRecorder(ctrl)
+	m.savers["test"] = currentRecorder
+	staleLiveEnd := events.NewEventWithSource(listeners.LiveEnd, liveMock, oldRecorder)
+	assert.NoError(t, m.removeRecorder(context.Background(), "test", recorderRemovalOptions{event: staleLiveEnd}))
+	assert.Same(t, currentRecorder, m.savers[types.LiveID("test")])
+}
+
+func TestManagerRecorderClosingBlocksReAddAndListenStop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	closeStarted := make(chan struct{})
+	releaseClose := make(chan struct{})
+	oldRecorder := NewMockRecorder(ctrl)
+	oldRecorder.EXPECT().CloseAndWait().Do(func() {
+		close(closeStarted)
+		<-releaseClose
+	})
+
+	newRecorderMock := NewMockRecorder(ctrl)
+	newRecorderMock.EXPECT().Start(gomock.Any()).Return(nil)
+	liveMock := livemock.NewMockLive(ctrl)
+	liveMock.EXPECT().GetLiveId().Return(types.LiveID("test")).AnyTimes()
+
+	m := &manager{savers: map[types.LiveID]Recorder{"test": oldRecorder}}
+	backup := newRecorder
+	newRecorderCalls := 0
+	newRecorder = func(context.Context, live.Live) (Recorder, error) {
+		newRecorderCalls++
+		return newRecorderMock, nil
+	}
+	defer func() { newRecorder = backup }()
+
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- m.RemoveRecorder(context.Background(), "test")
+	}()
+	<-closeStarted
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	waitCtx := &recorderDoneObservedContext{Context: baseCtx, observed: make(chan struct{})}
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- m.AddRecorder(waitCtx, liveMock)
+	}()
+	<-waitCtx.observed
+	assert.Zero(t, newRecorderCalls, "旧 recorder 完全退出前不应创建新 recorder")
+	cancel()
+	assert.ErrorIs(t, <-addDone, context.Canceled)
+
+	stopBaseCtx, stopCancel := context.WithCancel(context.Background())
+	defer stopCancel()
+	stopCtx := &recorderDoneObservedContext{Context: stopBaseCtx, observed: make(chan struct{})}
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- m.removeRecorder(stopCtx, "test", recorderRemovalOptions{
+			event:               events.NewEventWithSource(listeners.ListenStop, liveMock, closedSourceForTest()),
+			allowClosedListener: true,
+			waitForClosing:      true,
+		})
+	}()
+	<-stopCtx.observed
+
+	close(releaseClose)
+	assert.NoError(t, <-removeDone)
+	assert.NoError(t, <-stopDone)
+	assert.NoError(t, m.AddRecorder(context.Background(), liveMock))
+	assert.Equal(t, 1, newRecorderCalls)
+}
+
+func closedSourceForTest() *testListenerEventSource {
+	return &testListenerEventSource{closed: true}
 }
 
 // TestRestartRecorderRaceWithLiveEnd 验证 RestartRecorder 和 LiveEnd（RemoveRecorder）
@@ -89,6 +205,7 @@ func TestRestartRecorderRaceWithLiveEnd(t *testing.T) {
 		r := NewMockRecorder(ctrl)
 		r.EXPECT().Start(gomock.Any()).Return(nil).AnyTimes()
 		r.EXPECT().Close().AnyTimes()
+		r.EXPECT().CloseAndWait().AnyTimes()
 		r.EXPECT().CloseForRestart().Return(nil).AnyTimes()
 
 		if restartPhase {

--- a/src/recorders/mock_test.go
+++ b/src/recorders/mock_test.go
@@ -56,6 +56,18 @@ func (mr *MockRecorderMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRecorder)(nil).Close))
 }
 
+// CloseAndWait mocks base method.
+func (m *MockRecorder) CloseAndWait() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CloseAndWait")
+}
+
+// CloseAndWait indicates an expected call of CloseAndWait.
+func (mr *MockRecorderMockRecorder) CloseAndWait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAndWait", reflect.TypeOf((*MockRecorder)(nil).CloseAndWait))
+}
+
 // CloseForRestart mocks base method.
 func (m *MockRecorder) CloseForRestart() []notify.RecordingFileDetail {
 	m.ctrl.T.Helper()

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -581,7 +581,9 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		r.getLogger().WithError(err).Error("failed to init parse")
 		return
 	}
-	r.setAndCloseParser(p)
+	if !r.setAndCloseParser(p) {
+		return
+	}
 	r.startTime = time.Now()
 
 	// 弹幕录制（支持哔哩哔哩、抖音、斗鱼平台）
@@ -1054,15 +1056,25 @@ func (r *recorder) getParser() parser.Parser {
 	return r.parser
 }
 
-func (r *recorder) setAndCloseParser(p parser.Parser) {
+// setAndCloseParser 安装新的 parser；若录制器已关闭则立即停止它并返回 false。
+// 这避免 Close 与 tryRecord 并发时，Close 先观察到 parser 为 nil，随后 tryRecord
+// 又安装无法被停止的新 parser。
+func (r *recorder) setAndCloseParser(p parser.Parser) bool {
 	r.parserLock.Lock()
 	defer r.parserLock.Unlock()
+	if atomic.LoadUint32(&r.state) == stopped {
+		if err := p.Stop(); err != nil {
+			r.getLogger().WithError(err).Warn("failed to end recorder")
+		}
+		return false
+	}
 	if r.parser != nil {
 		if err := r.parser.Stop(); err != nil {
 			r.getLogger().WithError(err).Warn("failed to end recorder")
 		}
 	}
 	r.parser = p
+	return true
 }
 
 func (r *recorder) Start(ctx context.Context) error {

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -227,6 +227,8 @@ type Recorder interface {
 	StartTime() time.Time
 	GetStatus() (map[string]interface{}, error)
 	Close()
+	// CloseAndWait 关闭 recorder，并等待 run 与全部文件后处理完成。
+	CloseAndWait()
 	// GetParserPID 获取当前 parser 进程的 PID
 	// 如果 parser 未启动或不支持 PID 获取，返回 0
 	GetParserPID() int
@@ -848,7 +850,7 @@ func (r *recorder) stopRetryForExplicitOffline(err error) bool {
 		return false
 	}
 	r.getLogger().WithError(err).Info("stream source explicitly reported offline, dispatching LiveEnd")
-	r.ed.DispatchEvent(events.NewEvent(listeners.LiveEnd, r.Live))
+	r.ed.DispatchEvent(events.NewEventWithSource(listeners.LiveEnd, r.Live, r))
 	return true
 }
 
@@ -1114,12 +1116,16 @@ func (r *recorder) Close() {
 	r.ed.DispatchEvent(events.NewEvent(RecorderStop, r.Live))
 }
 
+func (r *recorder) CloseAndWait() {
+	r.Close()
+	<-r.done
+}
+
 func (r *recorder) CloseForRestart() []notify.RecordingFileDetail {
 	r.recordedFilesMu.Lock()
 	r.suppressSummary = true
 	r.recordedFilesMu.Unlock()
-	r.Close()
-	<-r.done // 等待 run() 完全退出，确保最后一个文件已累积
+	r.CloseAndWait()
 	r.recordedFilesMu.Lock()
 	defer r.recordedFilesMu.Unlock()
 	r.getLogger().Infof("分段重启：携带 %d 个累积文件传递给新 recorder", len(r.recordedFiles))

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/bluele/gcache"
@@ -13,8 +14,42 @@ import (
 	"github.com/bililive-go/bililive-go/src/configs"
 	"github.com/bililive-go/bililive-go/src/live"
 	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	"github.com/bililive-go/bililive-go/src/pkg/events"
+	evtmock "github.com/bililive-go/bililive-go/src/pkg/events/mock"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 )
+
+func TestRecorderCloseAndWaitWaitsForRunExit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	liveMock := livemock.NewMockLive(ctrl)
+	ed := evtmock.NewMockDispatcher(ctrl)
+	liveMock.EXPECT().GetLogger().Return(livelogger.New(0, nil))
+	ed.EXPECT().DispatchEvent(events.NewEvent(RecorderStop, liveMock))
+
+	r := &recorder{
+		Live:       liveMock,
+		ed:         ed,
+		state:      running,
+		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
+		parserLock: new(sync.RWMutex),
+	}
+	closeReturned := make(chan struct{})
+	go func() {
+		r.CloseAndWait()
+		close(closeReturned)
+	}()
+
+	<-r.stop
+	select {
+	case <-closeReturned:
+		t.Fatal("run 退出前 CloseAndWait 不应返回")
+	default:
+	}
+
+	close(r.done)
+	<-closeReturned
+}
 
 func TestTryRecordStopsWithoutPanicWhenFilenameRenderFails(t *testing.T) {
 	previousConfig := configs.GetCurrentConfig()

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bluele/gcache"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
 
 	"github.com/bililive-go/bililive-go/src/configs"
@@ -49,6 +50,28 @@ func TestRecorderCloseAndWaitWaitsForRunExit(t *testing.T) {
 
 	close(r.done)
 	<-closeReturned
+}
+
+type parserInstalledAfterClose struct {
+	stopped bool
+}
+
+func (p *parserInstalledAfterClose) ParseLiveStream(context.Context, *live.StreamUrlInfo, live.Live, string) error {
+	return nil
+}
+
+func (p *parserInstalledAfterClose) Stop() error {
+	p.stopped = true
+	return nil
+}
+
+func TestRecorderRejectsParserInstalledAfterClose(t *testing.T) {
+	r := &recorder{state: stopped, parserLock: new(sync.RWMutex)}
+	p := &parserInstalledAfterClose{}
+
+	assert.False(t, r.setAndCloseParser(p))
+	assert.True(t, p.stopped, "关闭后的新 parser 应立即停止")
+	assert.Nil(t, r.getParser())
 }
 
 func TestTryRecordStopsWithoutPanicWhenFilenameRenderFails(t *testing.T) {


### PR DESCRIPTION
## 改动

- 手动移除 listener 时同步完成 `ListenStop` 处理，但不在清理期间持有 listener manager 全局锁。
- listener manager 使用按 `liveId` 的 closing 屏障，保证同一房间重新添加前旧 listener 已完成停止交接，同时不阻塞其他房间。
- listener 和 recorder 发出的状态事件携带来源实例；recorder manager 会拒绝已关闭 listener 或已被替换 recorder 的迟到事件。
- recorder manager 使用按 `liveId` 的 closing 屏障，并通过 `CloseAndWait` 等待旧 recorder 的 `run`、解析器退出和文件后处理全部完成后才允许重新创建。
- `AddListener` 在创建和登记 listener 前检查调用方 context，避免已取消请求留下无法运行的 listener。
- 增加并发回归测试，覆盖同房间交接、其他房间不受阻塞、迟到事件过滤、recorder 完整退出屏障和 context 取消。
- 更新 `AGENTS.md`：遇到具有公共价值的领域知识时，将去除本地和隐私信息后的总结写入对应 `.agent/skills/*/SKILL.md`。
- 调整 `.gitignore`，放行 `.agent/skills/` 及全部后代，并同步 Copilot、Gemini CLI、Antigravity 的下游指令文件。

## 根因

此前手动停止监控使用异步 `ListenStop`。快速重新监控时存在三层竞态：

1. 新 `LiveStart` 与旧 `ListenStop` 的处理顺序不确定，旧停止事件可能删除新 recorder。
2. 旧 listener 已派发但尚未执行的 `LiveStart` / `LiveEnd` 可能在交接屏障解除后迟到。
3. recorder 的 `Close` 只发出停止信号，不等待 FFmpeg、`run` 和文件后处理真正退出，新旧实例可能并发操作相同输出路径。

本修改通过 listener 与 recorder 两级、按 `liveId` 隔离的 closing 屏障完成确定性交接，并使用事件来源实例校验拒绝迟到事件。

此外，`.agent/*` 原本只放行 `.agent/rules/`，导致文档提到的 `.agent/skills/` 无法被 Git 跟踪；通用 `build/` 规则还会单独忽略 build skill。本 PR 明确放行整个 skills 子树。

## 影响

手动停止监控请求会等待旧 recorder 完整退出和后处理完成后返回；同一房间的重新监听/录制请求会等待该交接，其他房间的增删监听和录制不受影响。后台普通 listener 关闭仍保持异步语义。

后续 AI 仅在遇到真实、可复用的项目知识时创建或更新对应 skill，并须剔除本机路径、账号、密钥、内网地址、个人配置和用户数据等内容。

## 验证

- `make dev`
- `make build-web dev`
- `make lint`（0 issues）
- `make test`
- 相关 listeners/recorders 并发回归测试连续运行 20 次
- `make sync-agents`
- `git diff --check`
- 验证四个 `.agent/skills/*/SKILL.md` 目标路径均不再被 Git 忽略