### PR TITLE
openlist上传接入与易用性优化

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ feature:
 out_put_tmpl: ""
 video_split_strategies:
   on_room_name_changed: false
-  max_duration: 0s
+  max_duration: 1m20s
   # 仅在使用 ffmpeg 或 bililive-recorder 下载器时生效
   # 支持可读格式，如: 500MB, 1GB, 1.5GB, 1024KB
   # 也支持纯数字（视为字节），如: 1073741824
@@ -30,25 +30,25 @@ video_split_strategies:
   max_file_size: "0"
 on_record_finished:
   convert_to_mp4: false
-  delete_flv_after_convert: false
+  delete_flv_after_convert: true
   custom_commandline: ""
   fix_flv_at_first: true
   save_cover: false
   cloud_upload:
-    enable: false
-    storage_name: ""
-    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}
-    delete_after_upload: false
+    enable: true
+    storage_name: baidu
+    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}/{{ .FileName }}
+    delete_after_upload: true
     delete_all_after_upload: false
   upload_timing: after_process
-  burn_subtitles: false
+  burn_subtitles: true
   burn_subtitles_codec: libx264
   burn_subtitles_crf: "18"
   burn_subtitles_preset: medium
   burn_delete_ass: false
-  burn_delete_source: false
+  burn_delete_source: true
 timeout_in_us: 60000000
-danmaku_enable: false
+danmaku_enable: true
 danmaku:
   font_size: 36
   font_name: Microsoft YaHei
@@ -69,11 +69,8 @@ live_rooms:
   # (B站)0代表原画PRO(HEVC)优先, 其他数值为原画(AVC)
   # 原画PRO会保存为.ts文件, 原画为.flv
   # HEVC相比AVC体积更小, 减少35%体积, 画质相当, 但是B站转码有时候会崩
-  - url: https://www.lang.live/room/5664344
+  - url: https://live.bilibili.com/1601605?live_from=71002&visit_id=cp0crnd7mt40
     is_listening: false
-    scheme: ""
-  - url: https://live.bilibili.com/22603245
-    is_listening: true
     scheme: ""
 cookies: {}
 # 通知服务配置
@@ -147,8 +144,9 @@ proxy:
 openlist:
   port: 5244
   data_path: ""
-  username: ""
-  password: ""
+  username: admin
+  password: RcoNhw4s
+  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicHdkX3RzIjowLCJleHAiOjE3ODY1OTc4NjcsIm5iZiI6MTc4NjQyNTA2NywiaWF0IjoxNzg2NDI1MDY3fQ.pB4bk71C-gcsObup1acrfq2nxHX16SSWeGoSouzotWY
 update:
   auto_check: true
   check_interval_hours: 6

--- a/config.yml
+++ b/config.yml
@@ -30,15 +30,7 @@ video_split_strategies:
   max_file_size: "0"
 on_record_finished:
   convert_to_mp4: false
-  # MP4 转换成功后标记原始 FLV 为待删除，全部处理阶段完成后才真正删除
-  # 默认 false（保留原始 FLV 文件）
   delete_flv_after_convert: false
-  #  当 custom_commandline 的值 不为空时，convert_to_mp4 的值会被无视，
-  #  而是在录制结束后直接执行 custom_commandline 中的命令。
-  #  在 custom_commandline 执行结束后，程序还会继续查看 delete_flv_after_convert 的值，
-  #  来判断是否需要删除原始 flv 文件。
-  #  以下是一个在录制结束后将 flv 视频转换为同名 mp4 视频的示例：
-  #  custom_commandline: '{{ .Ffmpeg }} -hide_banner -i "{{ .FileName }}" -c copy "{{ .FileName | trimSuffix (.FileName | ext)}}.mp4"'
   custom_commandline: ""
   fix_flv_at_first: true
   save_cover: false
@@ -46,36 +38,14 @@ on_record_finished:
     enable: false
     storage_name: ""
     upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}
-    # 选「处理完再上传」时，上传成功后仅删除已上传的文件（如最终视频），不影响其他中间文件
-    # 选「先上传再处理」时此开关无效
     delete_after_upload: false
-    # 选「处理完再上传」时，上传成功后删除所有本地文件（含中间产物）
-    # 选「先上传再处理」时此开关无效
     delete_all_after_upload: false
   upload_timing: after_process
-  # 是否将 ASS 弹幕字幕硬编码（烧录）到视频中
-  # 开启后会使用 FFmpeg 重编码视频，将字幕叠加到画面上
-  # 需要同时开启弹幕录制（danmaku_enable）才有 ASS 文件可烧录
   burn_subtitles: false
-  # 烧录字幕时使用的视频编码器
-  # 默认 libx264（H.264），兼容性最好
-  # 可选 libx265（H.265，压缩率更高但编码更慢）
   burn_subtitles_codec: libx264
-  # 烧录字幕时的 CRF（恒定速率因子）质量值
-  # 范围 0-51，数值越小画质越好，文件越大
-  # 默认 18（视觉无损），推荐范围 15-23
   burn_subtitles_crf: "18"
-  # 烧录字幕时的编码预设
-  # 影响编码速度和压缩率的平衡
-  # 可选: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow
-  # 默认 medium，越慢画质越好但耗时越长
   burn_subtitles_preset: medium
-  # 烧录成功后标记 ASS 文件为待删除，全部处理阶段完成后才真正删除
-  # 默认 false（保留 ASS 文件）
   burn_delete_ass: false
-  # 烧录成功后标记源视频文件为待删除，全部处理阶段完成后才真正删除
-  # 默认 false（保留源文件，同时存在源文件和烧录后的 MKV）
-  # 开启后仅保留烧录完成的 MKV 文件
   burn_delete_source: false
 timeout_in_us: 60000000
 danmaku_enable: false

--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ feature:
 out_put_tmpl: ""
 video_split_strategies:
   on_room_name_changed: false
-  max_duration: 1m20s
+  max_duration: 0s
   # 仅在使用 ffmpeg 或 bililive-recorder 下载器时生效
   # 支持可读格式，如: 500MB, 1GB, 1.5GB, 1024KB
   # 也支持纯数字（视为字节），如: 1073741824
@@ -30,25 +30,25 @@ video_split_strategies:
   max_file_size: "0"
 on_record_finished:
   convert_to_mp4: false
-  delete_flv_after_convert: true
+  delete_flv_after_convert: false
   custom_commandline: ""
   fix_flv_at_first: true
   save_cover: false
   cloud_upload:
-    enable: true
-    storage_name: baidu
-    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}/{{ .FileName }}
-    delete_after_upload: true
+    enable: false
+    storage_name: ""
+    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}
+    delete_after_upload: false
     delete_all_after_upload: false
   upload_timing: after_process
-  burn_subtitles: true
+  burn_subtitles: false
   burn_subtitles_codec: libx264
   burn_subtitles_crf: "18"
   burn_subtitles_preset: medium
   burn_delete_ass: false
-  burn_delete_source: true
+  burn_delete_source: false
 timeout_in_us: 60000000
-danmaku_enable: true
+danmaku_enable: false
 danmaku:
   font_size: 36
   font_name: Microsoft YaHei
@@ -69,8 +69,11 @@ live_rooms:
   # (B站)0代表原画PRO(HEVC)优先, 其他数值为原画(AVC)
   # 原画PRO会保存为.ts文件, 原画为.flv
   # HEVC相比AVC体积更小, 减少35%体积, 画质相当, 但是B站转码有时候会崩
-  - url: https://live.bilibili.com/1601605?live_from=71002&visit_id=cp0crnd7mt40
+  - url: https://www.lang.live/room/5664344
     is_listening: false
+    scheme: ""
+  - url: https://live.bilibili.com/22603245
+    is_listening: true
     scheme: ""
 cookies: {}
 # 通知服务配置
@@ -144,9 +147,8 @@ proxy:
 openlist:
   port: 5244
   data_path: ""
-  username: admin
-  password: RcoNhw4s
-  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicHdkX3RzIjowLCJleHAiOjE3ODY1OTc4NjcsIm5iZiI6MTc4NjQyNTA2NywiaWF0IjoxNzg2NDI1MDY3fQ.pB4bk71C-gcsObup1acrfq2nxHX16SSWeGoSouzotWY
+  username: ""
+  password: ""
 update:
   auto_check: true
   check_interval_hours: 6

--- a/config.yml
+++ b/config.yml
@@ -30,6 +30,8 @@ video_split_strategies:
   max_file_size: "0"
 on_record_finished:
   convert_to_mp4: false
+  # MP4 转换成功后标记原始 FLV 为待删除，全部处理阶段完成后才真正删除
+  # 默认 false（保留原始 FLV 文件）
   delete_flv_after_convert: false
   #  当 custom_commandline 的值 不为空时，convert_to_mp4 的值会被无视，
   #  而是在录制结束后直接执行 custom_commandline 中的命令。
@@ -43,10 +45,55 @@ on_record_finished:
   cloud_upload:
     enable: false
     storage_name: ""
-    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02" }}.{{ .Ext }}
+    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}
+    # 选「处理完再上传」时，上传成功后仅删除已上传的文件（如最终视频），不影响其他中间文件
+    # 选「先上传再处理」时此开关无效
     delete_after_upload: false
+    # 选「处理完再上传」时，上传成功后删除所有本地文件（含中间产物）
+    # 选「先上传再处理」时此开关无效
+    delete_all_after_upload: false
   upload_timing: after_process
+  # 是否将 ASS 弹幕字幕硬编码（烧录）到视频中
+  # 开启后会使用 FFmpeg 重编码视频，将字幕叠加到画面上
+  # 需要同时开启弹幕录制（danmaku_enable）才有 ASS 文件可烧录
+  burn_subtitles: false
+  # 烧录字幕时使用的视频编码器
+  # 默认 libx264（H.264），兼容性最好
+  # 可选 libx265（H.265，压缩率更高但编码更慢）
+  burn_subtitles_codec: libx264
+  # 烧录字幕时的 CRF（恒定速率因子）质量值
+  # 范围 0-51，数值越小画质越好，文件越大
+  # 默认 18（视觉无损），推荐范围 15-23
+  burn_subtitles_crf: "18"
+  # 烧录字幕时的编码预设
+  # 影响编码速度和压缩率的平衡
+  # 可选: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow
+  # 默认 medium，越慢画质越好但耗时越长
+  burn_subtitles_preset: medium
+  # 烧录成功后标记 ASS 文件为待删除，全部处理阶段完成后才真正删除
+  # 默认 false（保留 ASS 文件）
+  burn_delete_ass: false
+  # 烧录成功后标记源视频文件为待删除，全部处理阶段完成后才真正删除
+  # 默认 false（保留源文件，同时存在源文件和烧录后的 MKV）
+  # 开启后仅保留烧录完成的 MKV 文件
+  burn_delete_source: false
 timeout_in_us: 60000000
+danmaku_enable: false
+danmaku:
+  font_size: 36
+  font_name: Microsoft YaHei
+  scroll_area: full
+  scroll_time: 10
+  resolution: 1920x1080
+  outline: 1
+  opacity: 128
+  record_gift: true
+  record_douyu_gift: true
+  record_douyin_gift: true
+  record_guard: true
+  record_super_chat: true
+  guard_position: bottom-left
+  sc_position: bottom-left
 live_rooms:
   # quality参数目前仅B站启用，默认为0
   # (B站)0代表原画PRO(HEVC)优先, 其他数值为原画(AVC)
@@ -106,6 +153,10 @@ notify:
     icon: ""
     # 通知级别（可选）: active/timeSensitive/passive/critical
     level: ""
+  wxpusher:
+    enable: false
+    appToken: ""
+    uids: []
 app_data_path: .appdata
 read_only_tool_folder: ""
 tool_root_folder: ""
@@ -126,6 +177,8 @@ proxy:
 openlist:
   port: 5244
   data_path: ""
+  username: ""
+  password: ""
 update:
   auto_check: true
   check_interval_hours: 6

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -359,8 +359,8 @@ func main() {
 		bilisentryPkg.Go(func() {
 			if err := openlistManager.Start(rootCtx); err != nil {
 				logger.WithError(err).Error("启动 OpenList 失败，云上传功能将不可用")
-				// 启动失败时清除全局指针，避免 GetGlobalManager() != nil 永久阻止后续重试
-				servers.SetOpenListManager(nil)
+				// 启动失败时清除全局指针（CAS：仅当仍为当前实例时才清除，避免误清新 Manager）
+				openlist.ClearGlobalManagerIf(openlistManager)
 				openlistManager = nil
 			}
 		})
@@ -422,7 +422,8 @@ func main() {
 							if err := newMgr.Start(rootCtx); err != nil {
 								logger.WithError(err).Error("重建 OpenList 失败")
 								openlistLifecycleMu.Lock()
-								servers.SetOpenListManager(nil)
+								// CAS：仅当全局仍为 newMgr 时才清除
+								openlist.ClearGlobalManagerIf(newMgr)
 								openlistManager = nil
 								openlistLifecycleMu.Unlock()
 							}
@@ -460,9 +461,9 @@ func main() {
 		bilisentryPkg.Go(func() {
 			if err := mgr.Start(rootCtx); err != nil {
 				logger.WithError(err).Error("动态启动 OpenList 失败，云上传功能将不可用")
-				// 启动失败时清除全局指针，允许后续配置变更时重试
+				// CAS：仅当全局仍为当前实例时才清除，避免误清新 Manager
 				openlistLifecycleMu.Lock()
-				servers.SetOpenListManager(nil)
+				openlist.ClearGlobalManagerIf(mgr)
 				openlistLifecycleMu.Unlock()
 				return
 			}
@@ -472,7 +473,7 @@ func main() {
 			if cfg := configs.GetCurrentConfig(); cfg == nil || !cfg.OnRecordFinished.CloudUpload.Enable {
 				logger.Info("OpenList 启动完成但云上传已关闭，立即停止")
 				mgr.Stop()
-				servers.SetOpenListManager(nil)
+				openlist.ClearGlobalManagerIf(mgr)
 			}
 		})
 	})

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -371,9 +371,21 @@ func main() {
 		if newCfg == nil {
 			return
 		}
-		// 检测云上传开关是否从关变为开
 		wasEnabled := oldCfg != nil && oldCfg.OnRecordFinished.CloudUpload.Enable
 		isEnabled := newCfg.OnRecordFinished.CloudUpload.Enable
+
+		// 关闭云上传：停止 OpenList 进程
+		if wasEnabled && !isEnabled {
+			if mgr := openlist.GetGlobalManager(); mgr != nil {
+				logger.Info("检测到云上传已关闭，正在停止 OpenList...")
+				mgr.Stop()
+				servers.SetOpenListManager(nil)
+				openlistManager = nil
+			}
+			return
+		}
+
+		// 开启云上传：启动 OpenList 进程
 		if wasEnabled || !isEnabled {
 			return
 		}

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -366,6 +366,45 @@ func main() {
 		logger.Info("云上传功能已启用")
 	}
 
+	// 注册配置更新回调：当用户通过 Web UI 首次启用云上传时，自动创建并启动 OpenList Manager
+	configs.RegisterAfterUpdate(func(oldCfg, newCfg *configs.Config) {
+		if newCfg == nil {
+			return
+		}
+		// 检测云上传开关是否从关变为开
+		wasEnabled := oldCfg != nil && oldCfg.OnRecordFinished.CloudUpload.Enable
+		isEnabled := newCfg.OnRecordFinished.CloudUpload.Enable
+		if wasEnabled || !isEnabled {
+			return
+		}
+		// 已有 Manager 则跳过
+		if openlist.GetGlobalManager() != nil {
+			return
+		}
+
+		logger.Info("检测到云上传已启用，正在初始化 OpenList...")
+
+		openlistDataPath := newCfg.OpenList.DataPath
+		if openlistDataPath == "" {
+			openlistDataPath = filepath.Join(newCfg.AppDataPath, "openlist")
+		}
+		openlistPort := newCfg.OpenList.Port
+		if openlistPort == 0 {
+			openlistPort = 5244
+		}
+
+		mgr := openlist.NewManager(openlistDataPath, openlistPort)
+		// 先设置全局 Manager，让 API 端能立即获取到状态
+		servers.SetOpenListManager(mgr)
+
+		// 在后台启动 OpenList 进程（需要 rootCtx 生命周期）
+		bilisentryPkg.Go(func() {
+			if err := mgr.Start(rootCtx); err != nil {
+				logger.WithError(err).Error("动态启动 OpenList 失败，云上传功能将不可用")
+			}
+		})
+	})
+
 	// 初始化 Pipeline 管道管理器
 	pipelineDbPath := filepath.Join(config.AppDataPath, "db", "pipeline.db")
 	pipelineStore, err := pipeline.NewSQLiteStore(pipelineDbPath)

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -339,6 +339,8 @@ func main() {
 
 	// 如果启用了云上传功能，初始化 OpenList 管理器
 	var openlistManager *openlist.Manager
+	// 串行化 OpenList 生命周期操作，防止快速 enable/disable 导致服务泄漏
+	var openlistLifecycleMu sync.Mutex
 	if config.OnRecordFinished.CloudUpload.Enable {
 		// 获取 OpenList 数据目录
 		openlistDataPath := config.OpenList.DataPath
@@ -357,6 +359,9 @@ func main() {
 		bilisentryPkg.Go(func() {
 			if err := openlistManager.Start(rootCtx); err != nil {
 				logger.WithError(err).Error("启动 OpenList 失败，云上传功能将不可用")
+				// 启动失败时清除全局指针，避免 GetGlobalManager() != nil 永久阻止后续重试
+				servers.SetOpenListManager(nil)
+				openlistManager = nil
 			}
 		})
 
@@ -376,6 +381,8 @@ func main() {
 
 		// 关闭云上传：停止 OpenList 进程
 		if wasEnabled && !isEnabled {
+			openlistLifecycleMu.Lock()
+			defer openlistLifecycleMu.Unlock()
 			if mgr := openlist.GetGlobalManager(); mgr != nil {
 				logger.Info("检测到云上传已关闭，正在停止 OpenList...")
 				mgr.Stop()
@@ -387,10 +394,49 @@ func main() {
 
 		// 开启云上传：启动 OpenList 进程
 		if wasEnabled || !isEnabled {
+			// 云上传保持启用：检查是否需要重建 Manager（端口或数据目录变更）
+			if wasEnabled && isEnabled {
+				if mgr := openlist.GetGlobalManager(); mgr != nil {
+					// 解析新的配置值
+					newPort := newCfg.OpenList.Port
+					if newPort == 0 {
+						newPort = 5244
+					}
+					newDataPath := newCfg.OpenList.DataPath
+					if newDataPath == "" {
+						newDataPath = filepath.Join(newCfg.AppDataPath, "openlist")
+					}
+					// 与 Manager 当前值比较
+					if mgr.GetPort() != newPort || mgr.GetDataPath() != newDataPath {
+						logger.Infof("检测到 OpenList 配置变更（端口: %d→%d, 数据目录: %s→%s），正在重建 Manager...",
+							mgr.GetPort(), newPort, mgr.GetDataPath(), newDataPath)
+						openlistLifecycleMu.Lock()
+						mgr.Stop()
+						servers.SetOpenListManager(nil)
+						// 创建新 Manager 并启动
+						newMgr := openlist.NewManager(newDataPath, newPort)
+						servers.SetOpenListManager(newMgr)
+						openlistManager = newMgr
+						openlistLifecycleMu.Unlock()
+						bilisentryPkg.Go(func() {
+							if err := newMgr.Start(rootCtx); err != nil {
+								logger.WithError(err).Error("重建 OpenList 失败")
+								openlistLifecycleMu.Lock()
+								servers.SetOpenListManager(nil)
+								openlistManager = nil
+								openlistLifecycleMu.Unlock()
+							}
+						})
+					}
+				}
+			}
 			return
 		}
+
+		openlistLifecycleMu.Lock()
 		// 已有 Manager 则跳过
 		if openlist.GetGlobalManager() != nil {
+			openlistLifecycleMu.Unlock()
 			return
 		}
 
@@ -408,11 +454,25 @@ func main() {
 		mgr := openlist.NewManager(openlistDataPath, openlistPort)
 		// 先设置全局 Manager，让 API 端能立即获取到状态
 		servers.SetOpenListManager(mgr)
+		openlistLifecycleMu.Unlock()
 
 		// 在后台启动 OpenList 进程（需要 rootCtx 生命周期）
 		bilisentryPkg.Go(func() {
 			if err := mgr.Start(rootCtx); err != nil {
 				logger.WithError(err).Error("动态启动 OpenList 失败，云上传功能将不可用")
+				// 启动失败时清除全局指针，允许后续配置变更时重试
+				openlistLifecycleMu.Lock()
+				servers.SetOpenListManager(nil)
+				openlistLifecycleMu.Unlock()
+				return
+			}
+			// Start 完成后复核配置：如果在 waitForReady 期间配置已关闭，立即清理
+			openlistLifecycleMu.Lock()
+			defer openlistLifecycleMu.Unlock()
+			if cfg := configs.GetCurrentConfig(); cfg == nil || !cfg.OnRecordFinished.CloudUpload.Enable {
+				logger.Info("OpenList 启动完成但云上传已关闭，立即停止")
+				mgr.Stop()
+				servers.SetOpenListManager(nil)
 			}
 		})
 	})

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -349,11 +349,12 @@ const (
 
 // CloudUpload 云上传配置
 type CloudUpload struct {
-	Enable             bool     `yaml:"enable" json:"enable"`                                               // 是否启用云上传
-	StorageName        string   `yaml:"storage_name" json:"storage_name"`                                   // 使用的 OpenList 存储名称
-	UploadPathTmpl     string   `yaml:"upload_path_tmpl" json:"upload_path_tmpl"`                           // 上传路径模板
-	DeleteAfterUpload  bool     `yaml:"delete_after_upload" json:"delete_after_upload"`                     // 上传成功后删除本地文件
-	AdditionalStorages []string `yaml:"additional_storages,omitempty" json:"additional_storages,omitempty"` // 额外存储（支持多目标上传）
+	Enable              bool     `yaml:"enable" json:"enable"`                                               // 是否启用云上传
+	StorageName         string   `yaml:"storage_name" json:"storage_name"`                                   // 使用的 OpenList 存储名称
+	UploadPathTmpl      string   `yaml:"upload_path_tmpl" json:"upload_path_tmpl"`                           // 上传路径模板
+	DeleteAfterUpload   bool     `yaml:"delete_after_upload" json:"delete_after_upload"`                     // 上传成功后仅删除已上传的文件
+	DeleteAllAfterUpload bool    `yaml:"delete_all_after_upload" json:"delete_all_after_upload"`             // 上传成功后删除全部文件（含中间产物）
+	AdditionalStorages  []string `yaml:"additional_storages,omitempty" json:"additional_storages,omitempty"` // 额外存储（支持多目标上传）
 }
 
 // On record finished actions.

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -448,13 +448,18 @@ var defaultProxy = Proxy{
 
 // OpenListConfig OpenList 服务配置
 type OpenListConfig struct {
-	Port     int    `yaml:"port" json:"port"`           // OpenList 监听端口（默认 5244）
-	DataPath string `yaml:"data_path" json:"data_path"` // OpenList 数据目录（留空使用默认路径）
+	Port     int    `yaml:"port" json:"port"`               // OpenList 监听端口（默认 5244）
+	DataPath string `yaml:"data_path" json:"data_path"`     // OpenList 数据目录（留空使用默认路径）
+	Username string `yaml:"username" json:"username"`        // OpenList 管理员用户名
+	Password string `yaml:"password" json:"password"`        // OpenList 管理员密码
+	Token    string `yaml:"token,omitempty" json:"token"`    // OpenList API Token（优先于用户名密码）
 }
 
 var defaultOpenListConfig = OpenListConfig{
 	Port:     5244,
 	DataPath: "", // 默认使用 AppDataPath/openlist
+	Username: "",
+	Password: "",
 }
 
 // UpdateConfig 自动更新配置
@@ -1109,6 +1114,16 @@ func (c *Config) Verify() error {
 	// 验证弹幕配置
 	if err := c.Danmaku.Validate(); err != nil {
 		return fmt.Errorf("弹幕配置无效: %w", err)
+	}
+
+	// 验证 OpenList 配置
+	if c.OnRecordFinished.CloudUpload.Enable {
+		if c.OpenList.Port < 0 || c.OpenList.Port > 65535 {
+			return fmt.Errorf("OpenList 端口必须在 0-65535 之间")
+		}
+		if c.OnRecordFinished.CloudUpload.StorageName == "" {
+			return fmt.Errorf("启用云上传时必须配置存储名称")
+		}
 	}
 
 	return nil

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -1012,7 +1012,7 @@ var defaultConfig = Config{
 		CloudUpload: CloudUpload{
 			Enable:            false,
 			StorageName:       "",
-			UploadPathTmpl:    "/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date \"2006-01-02\" }}.{{ .Ext }}",
+			UploadPathTmpl:    "/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}",
 			DeleteAfterUpload: false,
 		},
 		UploadTiming:        UploadTimingAfterProcess,

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -618,6 +618,36 @@ var updateMu sync.Mutex
 // 当期望版本与实际版本不一致时返回的错误
 var ErrConfigVersionConflict = errors.New("config version conflict")
 
+// AfterUpdateCallback 配置更新后的回调函数类型
+// old 为更新前的配置（可能为 nil），newCfg 为更新后的配置
+type AfterUpdateCallback func(old, newCfg *Config)
+
+// afterUpdateCallbacks 配置更新后的回调列表
+var (
+	afterUpdateCallbacks []AfterUpdateCallback
+	afterUpdateMu        sync.RWMutex
+)
+
+// RegisterAfterUpdate 注册配置更新后的回调
+// 回调在配置更新并持久化完成后同步执行，此时已释放 updateMu 锁
+func RegisterAfterUpdate(cb AfterUpdateCallback) {
+	afterUpdateMu.Lock()
+	defer afterUpdateMu.Unlock()
+	afterUpdateCallbacks = append(afterUpdateCallbacks, cb)
+}
+
+// fireAfterUpdate 触发所有配置更新回调
+func fireAfterUpdate(old, newCfg *Config) {
+	afterUpdateMu.RLock()
+	callbacks := make([]AfterUpdateCallback, len(afterUpdateCallbacks))
+	copy(callbacks, afterUpdateCallbacks)
+	afterUpdateMu.RUnlock()
+
+	for _, cb := range callbacks {
+		cb(old, newCfg)
+	}
+}
+
 func SetCurrentConfig(cfg *Config) {
 	if cfg == nil {
 		// 存储 nil 以保持行为一致
@@ -657,19 +687,19 @@ func UpdateTransient(mutator func(c *Config) error) (*Config, error) {
 }
 
 func updateImpl(mutator func(c *Config) error, persist bool) (*Config, error) {
-	var newCfg *Config
+	var oldCfg, newCfg *Config
 	var updateErr error
 
 	func() {
 		updateMu.Lock()
 		defer updateMu.Unlock()
-		old := GetCurrentConfig()
+		oldCfg = GetCurrentConfig()
 		// 若当前尚未设置配置，则以默认配置为基础
 		var base *Config
-		if old == nil {
+		if oldCfg == nil {
 			base = NewConfig()
 		} else {
-			base = CloneConfigShallow(old)
+			base = CloneConfigShallow(oldCfg)
 		}
 		if err := mutator(base); err != nil {
 			updateErr = err
@@ -678,10 +708,10 @@ func updateImpl(mutator func(c *Config) error, persist bool) (*Config, error) {
 		// 维护派生字段
 		base.RefreshLiveRoomIndexCache()
 		// 版本号自增
-		if old == nil {
+		if oldCfg == nil {
 			base.Version = 1
 		} else {
-			base.Version = old.Version + 1
+			base.Version = oldCfg.Version + 1
 		}
 		newCfg = base
 
@@ -702,6 +732,7 @@ func updateImpl(mutator func(c *Config) error, persist bool) (*Config, error) {
 		return nil, errors.New("config update failed")
 	}
 
+	fireAfterUpdate(oldCfg, newCfg)
 	return newCfg, nil
 }
 
@@ -712,17 +743,17 @@ func UpdateCAS(expectedVersion int64, mutator func(c *Config) error) (*Config, e
 }
 
 func updateCASImpl(expectedVersion int64, mutator func(c *Config) error, persist bool) (*Config, error) {
-	var newCfg *Config
+	var oldCfg, newCfg *Config
 	var updateErr error
 
 	func() {
 		updateMu.Lock()
 		defer updateMu.Unlock()
-		cur := GetCurrentConfig()
+		oldCfg = GetCurrentConfig()
 		// 校验版本
 		var curVersion int64
-		if cur != nil {
-			curVersion = cur.Version
+		if oldCfg != nil {
+			curVersion = oldCfg.Version
 		}
 		if curVersion != expectedVersion {
 			updateErr = ErrConfigVersionConflict
@@ -730,10 +761,10 @@ func updateCASImpl(expectedVersion int64, mutator func(c *Config) error, persist
 		}
 		// 克隆并修改
 		var base *Config
-		if cur == nil {
+		if oldCfg == nil {
 			base = NewConfig()
 		} else {
-			base = CloneConfigShallow(cur)
+			base = CloneConfigShallow(oldCfg)
 		}
 		if err := mutator(base); err != nil {
 			updateErr = err
@@ -757,6 +788,7 @@ func updateCASImpl(expectedVersion int64, mutator func(c *Config) error, persist
 		return nil, updateErr
 	}
 
+	fireAfterUpdate(oldCfg, newCfg)
 	return newCfg, nil
 }
 

--- a/src/configs/config_comments.go
+++ b/src/configs/config_comments.go
@@ -42,6 +42,10 @@ func DecorateConfigNode(node *yaml.Node) {
 #  以下是一个在录制结束后将 flv 视频转换为同名 mp4 视频的示例：
 #  custom_commandline: '{{ .Ffmpeg }} -hide_banner -i "{{ .FileName }}" -c copy "{{ .FileName | trimSuffix (.FileName | ext)}}.mp4"'`, "")
 
+		setFieldComment(finishNode, "delete_flv_after_convert",
+			`# MP4 转换成功后标记原始 FLV 为待删除，全部处理阶段完成后才真正删除
+# 默认 false（保留原始 FLV 文件）`, "")
+
 		setFieldComment(finishNode, "burn_subtitles",
 			`# 是否将 ASS 弹幕字幕硬编码（烧录）到视频中
 # 开启后会使用 FFmpeg 重编码视频，将字幕叠加到画面上
@@ -64,13 +68,23 @@ func DecorateConfigNode(node *yaml.Node) {
 # 默认 medium，越慢画质越好但耗时越长`, "")
 
 		setFieldComment(finishNode, "burn_delete_ass",
-			`# 烧录完成后是否删除原始 ASS 字幕文件
+			`# 烧录成功后标记 ASS 文件为待删除，全部处理阶段完成后才真正删除
 # 默认 false（保留 ASS 文件）`, "")
 
 		setFieldComment(finishNode, "burn_delete_source",
-			`# 烧录完成后是否删除源视频文件（如 MP4/FLV）
+			`# 烧录成功后标记源视频文件为待删除，全部处理阶段完成后才真正删除
 # 默认 false（保留源文件，同时存在源文件和烧录后的 MKV）
 # 开启后仅保留烧录完成的 MKV 文件`, "")
+
+		cloudNode := findNode(finishNode, "cloud_upload")
+		if cloudNode != nil {
+			setFieldComment(cloudNode, "delete_after_upload",
+				`# 选「处理完再上传」时，上传成功后仅删除已上传的文件（如最终视频），不影响其他中间文件
+# 选「先上传再处理」时此开关无效`, "")
+			setFieldComment(cloudNode, "delete_all_after_upload",
+				`# 选「处理完再上传」时，上传成功后删除所有本地文件（含中间产物）
+# 选「先上传再处理」时此开关无效`, "")
+		}
 	}
 
 	setFieldHeadComment(root, "notify", "# 通知服务配置")

--- a/src/configs/config_comments.go
+++ b/src/configs/config_comments.go
@@ -32,61 +32,6 @@ func DecorateConfigNode(node *yaml.Node) {
 # 负数为非法值，程序会输出 log 提醒，并无视所设定的数值`, "")
 	}
 
-	finishNode := findNode(root, "on_record_finished")
-	if finishNode != nil {
-		setFieldComment(finishNode, "custom_commandline",
-			`#  当 custom_commandline 的值 不为空时，convert_to_mp4 的值会被无视，
-#  而是在录制结束后直接执行 custom_commandline 中的命令。
-#  在 custom_commandline 执行结束后，程序还会继续查看 delete_flv_after_convert 的值，
-#  来判断是否需要删除原始 flv 文件。
-#  以下是一个在录制结束后将 flv 视频转换为同名 mp4 视频的示例：
-#  custom_commandline: '{{ .Ffmpeg }} -hide_banner -i "{{ .FileName }}" -c copy "{{ .FileName | trimSuffix (.FileName | ext)}}.mp4"'`, "")
-
-		setFieldComment(finishNode, "delete_flv_after_convert",
-			`# MP4 转换成功后标记原始 FLV 为待删除，全部处理阶段完成后才真正删除
-# 默认 false（保留原始 FLV 文件）`, "")
-
-		setFieldComment(finishNode, "burn_subtitles",
-			`# 是否将 ASS 弹幕字幕硬编码（烧录）到视频中
-# 开启后会使用 FFmpeg 重编码视频，将字幕叠加到画面上
-# 需要同时开启弹幕录制（danmaku_enable）才有 ASS 文件可烧录`, "")
-
-		setFieldComment(finishNode, "burn_subtitles_codec",
-			`# 烧录字幕时使用的视频编码器
-# 默认 libx264（H.264），兼容性最好
-# 可选 libx265（H.265，压缩率更高但编码更慢）`, "")
-
-		setFieldComment(finishNode, "burn_subtitles_crf",
-			`# 烧录字幕时的 CRF（恒定速率因子）质量值
-# 范围 0-51，数值越小画质越好，文件越大
-# 默认 18（视觉无损），推荐范围 15-23`, "")
-
-		setFieldComment(finishNode, "burn_subtitles_preset",
-			`# 烧录字幕时的编码预设
-# 影响编码速度和压缩率的平衡
-# 可选: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow
-# 默认 medium，越慢画质越好但耗时越长`, "")
-
-		setFieldComment(finishNode, "burn_delete_ass",
-			`# 烧录成功后标记 ASS 文件为待删除，全部处理阶段完成后才真正删除
-# 默认 false（保留 ASS 文件）`, "")
-
-		setFieldComment(finishNode, "burn_delete_source",
-			`# 烧录成功后标记源视频文件为待删除，全部处理阶段完成后才真正删除
-# 默认 false（保留源文件，同时存在源文件和烧录后的 MKV）
-# 开启后仅保留烧录完成的 MKV 文件`, "")
-
-		cloudNode := findNode(finishNode, "cloud_upload")
-		if cloudNode != nil {
-			setFieldComment(cloudNode, "delete_after_upload",
-				`# 选「处理完再上传」时，上传成功后仅删除已上传的文件（如最终视频），不影响其他中间文件
-# 选「先上传再处理」时此开关无效`, "")
-			setFieldComment(cloudNode, "delete_all_after_upload",
-				`# 选「处理完再上传」时，上传成功后删除所有本地文件（含中间产物）
-# 选「先上传再处理」时此开关无效`, "")
-		}
-	}
-
 	setFieldHeadComment(root, "notify", "# 通知服务配置")
 	notifyNode := findNode(root, "notify")
 	if notifyNode != nil {

--- a/src/pipeline/config.go
+++ b/src/pipeline/config.go
@@ -24,6 +24,8 @@ const (
 	OptionPathTemplate = "path_template"
 	// OptionDeleteAfter 上传后是否删除
 	OptionDeleteAfter = "delete_after"
+	// OptionUploadTiming 上传时机（immediate/after_process）
+	OptionUploadTiming = "upload_timing"
 	// OptionCommand 自定义命令
 	OptionCommand = "command"
 	// OptionFileTypes 处理的文件类型过滤
@@ -71,14 +73,31 @@ func ConvertLegacyConfig(legacy *configs.OnRecordFinished) *PipelineConfig {
 
 	var stages []StageConfig
 
-	// 1. FLV 修复（在转换之前）
+	// 构建云上传阶段配置
+	cloudUploadStage := StageConfig{
+		Name: StageNameCloudUpload,
+		Options: map[string]any{
+			OptionStorage:      legacy.CloudUpload.StorageName,
+			OptionPathTemplate: legacy.CloudUpload.UploadPathTmpl,
+			OptionDeleteAfter:  legacy.CloudUpload.DeleteAfterUpload,
+			OptionUploadTiming: string(legacy.UploadTiming),
+		},
+	}
+	hasCloudUpload := legacy.CloudUpload.Enable && legacy.CloudUpload.StorageName != ""
+
+	// 立即上传模式：上传在所有处理之前
+	if hasCloudUpload && legacy.UploadTiming == configs.UploadTimingImmediate {
+		stages = append(stages, cloudUploadStage)
+	}
+
+	// FLV 修复（在转换之前）
 	if legacy.FixFlvAtFirst {
 		stages = append(stages, StageConfig{
 			Name: StageNameFixFlv,
 		})
 	}
 
-	// 2. MP4 转换
+	// MP4 转换
 	if legacy.ConvertToMp4 {
 		stages = append(stages, StageConfig{
 			Name: StageNameConvertMp4,
@@ -88,7 +107,7 @@ func ConvertLegacyConfig(legacy *configs.OnRecordFinished) *PipelineConfig {
 		})
 	}
 
-	// 3. 弹幕字幕烧录（在 MP4 转换之后，封面提取之前）
+	// 弹幕字幕烧录（在 MP4 转换之后，封面提取之前）
 	if legacy.BurnSubtitles {
 		stages = append(stages, StageConfig{
 			Name: StageNameBurnSubtitles,
@@ -102,26 +121,19 @@ func ConvertLegacyConfig(legacy *configs.OnRecordFinished) *PipelineConfig {
 		})
 	}
 
-	// 4. 封面提取
+	// 封面提取
 	if legacy.SaveCover {
 		stages = append(stages, StageConfig{
 			Name: StageNameExtractCover,
 		})
 	}
 
-	// 5. 云上传
-	if legacy.CloudUpload.Enable && legacy.CloudUpload.StorageName != "" {
-		stages = append(stages, StageConfig{
-			Name: StageNameCloudUpload,
-			Options: map[string]any{
-				OptionStorage:      legacy.CloudUpload.StorageName,
-				OptionPathTemplate: legacy.CloudUpload.UploadPathTmpl,
-				OptionDeleteAfter:  legacy.CloudUpload.DeleteAfterUpload,
-			},
-		})
+	// 后处理完成后上传模式：上传在所有处理之后（默认行为）
+	if hasCloudUpload && legacy.UploadTiming != configs.UploadTimingImmediate {
+		stages = append(stages, cloudUploadStage)
 	}
 
-	// 6. 自定义命令（在最后执行）
+	// 自定义命令（在最后执行）
 	if legacy.CustomCommandline != "" {
 		stages = append(stages, StageConfig{
 			Name: StageNameCustomCmd,

--- a/src/pipeline/config.go
+++ b/src/pipeline/config.go
@@ -22,8 +22,10 @@ const (
 	OptionStorage = "storage"
 	// OptionPathTemplate 上传路径模板
 	OptionPathTemplate = "path_template"
-	// OptionDeleteAfter 上传后是否删除
+	// OptionDeleteAfter 上传后是否删除已上传的文件
 	OptionDeleteAfter = "delete_after"
+	// OptionDeleteAllAfter 上传后是否删除全部文件（含中间产物）
+	OptionDeleteAllAfter = "delete_all_after"
 	// OptionUploadTiming 上传时机（immediate/after_process）
 	OptionUploadTiming = "upload_timing"
 	// OptionCommand 自定义命令
@@ -77,10 +79,12 @@ func ConvertLegacyConfig(legacy *configs.OnRecordFinished) *PipelineConfig {
 	cloudUploadStage := StageConfig{
 		Name: StageNameCloudUpload,
 		Options: map[string]any{
-			OptionStorage:      legacy.CloudUpload.StorageName,
-			OptionPathTemplate: legacy.CloudUpload.UploadPathTmpl,
-			OptionDeleteAfter:  legacy.CloudUpload.DeleteAfterUpload,
-			OptionUploadTiming: string(legacy.UploadTiming),
+			OptionStorage:        legacy.CloudUpload.StorageName,
+			OptionPathTemplate:   legacy.CloudUpload.UploadPathTmpl,
+			OptionDeleteAfter:    legacy.CloudUpload.DeleteAfterUpload,
+			OptionDeleteAllAfter: legacy.CloudUpload.DeleteAllAfterUpload,
+			OptionUploadTiming:   string(legacy.UploadTiming),
+			OptionFileTypes:      []string{string(FileTypeVideo), string(FileTypeCover)},
 		},
 	}
 	hasCloudUpload := legacy.CloudUpload.Enable && legacy.CloudUpload.StorageName != ""

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -49,12 +49,14 @@ func (e *Executor) getFactory(name string) (StageFactory, bool) {
 
 // Execute 执行管道
 // startStage: 从第几个启用的阶段开始执行（0=全部执行，用于重试指定阶段）
+// onStageComplete: 每个阶段成功完成后的回调，用于持久化进度（崩溃恢复的关键）
 func (e *Executor) Execute(
 	ctx *PipelineContext,
 	config *PipelineConfig,
 	initialFiles []FileInfo,
 	startStage int,
 	onProgress func(stageIndex int, stageName string, status StageStatus),
+	onStageComplete func(stageIndex int, outputFiles []FileInfo),
 ) ([]StageResult, error) {
 	if config == nil || len(config.Stages) == 0 {
 		e.logger.Debug("pipeline config is empty, skipping")
@@ -143,6 +145,11 @@ func (e *Executor) Execute(
 
 		if onProgress != nil {
 			onProgress(stageIndex, stageCfg.Name, StageStatusCompleted)
+		}
+
+		// 通知外部持久化阶段完成状态（用于崩溃恢复）
+		if onStageComplete != nil {
+			onStageComplete(stageIndex, output)
 		}
 
 		// 更新文件列表给下一阶段
@@ -468,7 +475,7 @@ func (e *Executor) ExecuteAsync(
 	bilisentry.GoWithContext(ctx.Ctx, func(goCtx context.Context) {
 		// 更新上下文
 		ctx.Ctx = goCtx
-		results, err := e.Execute(ctx, config, initialFiles, 0, onProgress)
+		results, err := e.Execute(ctx, config, initialFiles, 0, onProgress, nil)
 		if onComplete != nil {
 			onComplete(results, err)
 		}

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -164,14 +164,32 @@ func (e *Executor) Execute(
 	return results, nil
 }
 
-// deleteMarkedFiles 删除标记为 Deletable 的文件，返回保留的文件列表
+// deleteMarkedFiles 删除标记为 Deletable 或 Metadata["uploaded"] 的文件，返回保留的文件列表
 func (e *Executor) deleteMarkedFiles(files []FileInfo) []FileInfo {
 	var kept []FileInfo
+	deleteAll := false // 标记是否为 deleteAll 模式
+
 	for _, f := range files {
-		if f.Deletable {
+		// 检查是否为 deleteAll 模式（CloudUploadStage 标记）
+		if f.Metadata != nil {
+			if da, ok := f.Metadata["delete_all"].(bool); ok && da {
+				deleteAll = true
+			}
+		}
+
+		// 判断是否应删除：Deletable 标记 或 CloudUploadStage 标记的已上传文件
+		shouldDelete := f.Deletable
+		if !shouldDelete && f.Metadata != nil {
+			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
+				shouldDelete = true
+			}
+		}
+
+		if shouldDelete {
 			if err := os.Remove(f.Path); err != nil {
 				if !os.IsNotExist(err) {
 					e.logger.Warnf("pipeline cleanup: 删除文件失败 %s: %v", f.Path, err)
+					kept = append(kept, f) // 删除失败，文件仍在磁盘，保留记录
 				}
 			} else {
 				e.logger.Infof("pipeline cleanup: 已删除 %s", f.Path)
@@ -181,9 +199,11 @@ func (e *Executor) deleteMarkedFiles(files []FileInfo) []FileInfo {
 		}
 	}
 
-	// 兜底逻辑：清理无关联视频文件的 .ass 文件
-	// 传入原始 files 列表，确保即使视频被删除也能扫描到对应目录
-	kept = e.cleanupOrphanedAssFiles(files, kept)
+	// 仅在 deleteAll 模式下清理孤立 .ass 文件
+	// deleteAfter 模式只删除已上传文件，不应连带清理弹幕
+	if deleteAll {
+		kept = e.cleanupOrphanedAssFiles(files, kept)
+	}
 
 	return kept
 }

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -86,6 +86,9 @@ func (e *Executor) Execute(
 		var commands []string
 		var logs string
 
+		// 记录阶段开始时间
+		stageStartTime := getTimeNow()
+
 		// 并行阶段处理
 		if stageCfg.IsParallel() {
 			e.logger.WithField("stage_index", i).Debug("executing parallel stages")
@@ -107,7 +110,7 @@ func (e *Executor) Execute(
 			Commands:   commands,
 			Logs:       logs,
 		}
-		result.StartedAt = getTimeNow()
+		result.StartedAt = stageStartTime
 
 		if err != nil {
 			result.Status = StageStatusFailed
@@ -144,8 +147,19 @@ func (e *Executor) Execute(
 		}).Debug("stage completed")
 	}
 
-	// 全部成功：执行延迟删除
-	e.deleteMarkedFiles(files)
+	// 全部成功：执行延迟删除，并让最终结果反映磁盘上的文件
+	// 如果上下文已取消，跳过删除以保留所有文件
+	if ctx.Ctx.Err() != nil {
+		e.logger.Warn("pipeline cancelled after completion, skipping file cleanup")
+		if len(results) > 0 {
+			results[len(results)-1].OutputFiles = files
+		}
+		return results, nil
+	}
+	keptFiles := e.deleteMarkedFiles(files)
+	if len(results) > 0 {
+		results[len(results)-1].OutputFiles = keptFiles
+	}
 
 	return results, nil
 }
@@ -183,7 +197,7 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 	dirs := map[string]bool{}
 	for _, f := range allFiles {
 		ext := strings.ToLower(filepath.Ext(f.Path))
-		if ext == ".flv" || ext == ".mp4" || ext == ".mkv" {
+		if ext == ".flv" || ext == ".mp4" || ext == ".mkv" || ext == ".ts" {
 			dir := filepath.Dir(f.Path)
 			base := strings.TrimSuffix(filepath.Base(f.Path), ext)
 			videoBaseNames[filepath.Join(dir, base)] = true
@@ -193,13 +207,21 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 
 	// 收集 Pipeline 中已知的 .ass 文件路径
 	knownAssFiles := map[string]bool{}
+	// 同时收集 allFiles 中的 .ass 文件路径（用于限定扫描范围）
+	allAssFiles := map[string]bool{}
 	for _, f := range keptFiles {
 		if strings.ToLower(filepath.Ext(f.Path)) == ".ass" {
 			knownAssFiles[f.Path] = true
 		}
 	}
+	for _, f := range allFiles {
+		if strings.ToLower(filepath.Ext(f.Path)) == ".ass" {
+			allAssFiles[f.Path] = true
+		}
+	}
 
-	// 扫描目录中的 .ass 文件（包括未进入 Pipeline 的）
+	// 扫描目录中的 .ass 文件
+	// 仅处理本任务关联的 .ass 文件，避免误删其他任务或用户放置的字幕
 	for dir := range dirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -216,12 +238,15 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 			if knownAssFiles[assPath] {
 				continue // 已在 Pipeline 中处理
 			}
+			if !allAssFiles[assPath] {
+				continue // 非本任务关联的 .ass 文件，跳过
+			}
 			// 检查磁盘上是否有同名视频文件
 			base := strings.TrimSuffix(entry.Name(), ".ass")
 			key := filepath.Join(dir, base)
-			// 检查磁盘上实际存在的视频文件
+			// 检查磁盘上实际存在的视频文件（含 .ts 格式）
 			hasVideo := false
-			for _, ext := range []string{".flv", ".mp4", ".mkv"} {
+			for _, ext := range []string{".flv", ".mp4", ".mkv", ".ts"} {
 				if _, err := os.Stat(key + ext); err == nil {
 					hasVideo = true
 					break
@@ -230,10 +255,10 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 			if !hasVideo {
 				if err := os.Remove(assPath); err != nil {
 					if !os.IsNotExist(err) {
-						e.logger.Warnf("pipeline cleanup: 删除磁盘孤立 .ass 文件失败 %s: %v", assPath, err)
+						e.logger.Warnf("pipeline cleanup: 删除孤立 .ass 文件失败 %s: %v", assPath, err)
 					}
 				} else {
-					e.logger.Infof("pipeline cleanup: 已删除磁盘孤立 .ass 文件 %s（无关联视频）", assPath)
+					e.logger.Infof("pipeline cleanup: 已删除孤立 .ass 文件 %s（无关联视频）", assPath)
 				}
 			}
 		}

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -182,13 +182,17 @@ func (e *Executor) Execute(
 // deleteMarkedFiles 删除标记为 Deletable 或 Metadata["uploaded"] 的文件，返回保留的文件列表
 func (e *Executor) deleteMarkedFiles(files []FileInfo) []FileInfo {
 	var kept []FileInfo
-	deleteAll := false // 标记是否为 deleteAll 模式
+	deleteAll := false  // 标记是否为 deleteAll 模式
+	deleteAfter := false // 标记是否为 deleteAfter 模式（仅删除已上传文件）
 
 	for _, f := range files {
-		// 检查是否为 deleteAll 模式（CloudUploadStage 标记）
+		// 检查删除模式（CloudUploadStage 标记）
 		if f.Metadata != nil {
 			if da, ok := f.Metadata["delete_all"].(bool); ok && da {
 				deleteAll = true
+			}
+			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
+				deleteAfter = true
 			}
 		}
 
@@ -214,9 +218,9 @@ func (e *Executor) deleteMarkedFiles(files []FileInfo) []FileInfo {
 		}
 	}
 
-	// 仅在 deleteAll 模式下清理孤立 .ass 文件
-	// deleteAfter 模式只删除已上传文件，不应连带清理弹幕
-	if deleteAll {
+	// 清理无关联视频文件的孤立 .ass 文件
+	// deleteAll 模式下删除所有文件（含 .ass），deleteAfter 模式下删除已上传视频后也应清理残留 .ass
+	if deleteAll || deleteAfter {
 		kept = e.cleanupOrphanedAssFiles(files, kept)
 	}
 
@@ -242,21 +246,14 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 
 	// 收集 Pipeline 中已知的 .ass 文件路径
 	knownAssFiles := map[string]bool{}
-	// 同时收集 allFiles 中的 .ass 文件路径（用于限定扫描范围）
-	allAssFiles := map[string]bool{}
 	for _, f := range keptFiles {
 		if strings.ToLower(filepath.Ext(f.Path)) == ".ass" {
 			knownAssFiles[f.Path] = true
 		}
 	}
-	for _, f := range allFiles {
-		if strings.ToLower(filepath.Ext(f.Path)) == ".ass" {
-			allAssFiles[f.Path] = true
-		}
-	}
 
 	// 扫描目录中的 .ass 文件
-	// 仅处理本任务关联的 .ass 文件，避免误删其他任务或用户放置的字幕
+	// 通过视频基名匹配判断 .ass 是否属于本任务，避免误删其他任务或用户放置的字幕
 	for dir := range dirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -273,13 +270,14 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 			if knownAssFiles[assPath] {
 				continue // 已在 Pipeline 中处理
 			}
-			if !allAssFiles[assPath] {
-				continue // 非本任务关联的 .ass 文件，跳过
-			}
-			// 检查磁盘上是否有同名视频文件
+			// 通过基名匹配判断是否属于本任务的视频文件
+			// （.ass 文件可能未被传入 Pipeline，不能依赖文件列表过滤）
 			base := strings.TrimSuffix(entry.Name(), ".ass")
 			key := filepath.Join(dir, base)
-			// 检查磁盘上实际存在的视频文件（含 .ts 格式）
+			if !videoBaseNames[key] {
+				continue // 基名不匹配任何本任务视频，跳过
+			}
+			// 检查磁盘上是否有同名视频文件
 			hasVideo := false
 			for _, ext := range []string{".flv", ".mp4", ".mkv", ".ts"} {
 				if _, err := os.Stat(key + ext); err == nil {

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -3,6 +3,9 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,6 +66,7 @@ func (e *Executor) Execute(
 	for i, stageCfg := range config.Stages {
 		// 检查上下文是否已取消
 		if ctx.Ctx.Err() != nil {
+			e.logger.Warnf("pipeline cancelled at stage %s, preserving all files", stageCfg.Name)
 			return results, ctx.Ctx.Err()
 		}
 
@@ -116,6 +120,7 @@ func (e *Executor) Execute(
 				onProgress(stageIndex, stageCfg.Name, StageStatusFailed)
 			}
 
+			e.logger.Warnf("pipeline failed at stage %s, preserving all files", stageCfg.Name)
 			return results, fmt.Errorf("stage %s failed: %w", stageCfg.Name, err)
 		}
 
@@ -139,7 +144,128 @@ func (e *Executor) Execute(
 		}).Debug("stage completed")
 	}
 
+	// 全部成功：执行延迟删除
+	files = e.deleteMarkedFiles(files)
+
 	return results, nil
+}
+
+// deleteMarkedFiles 删除标记为 Deletable 的文件，返回保留的文件列表
+func (e *Executor) deleteMarkedFiles(files []FileInfo) []FileInfo {
+	var kept []FileInfo
+	for _, f := range files {
+		if f.Deletable {
+			if err := os.Remove(f.Path); err != nil {
+				if !os.IsNotExist(err) {
+					e.logger.Warnf("pipeline cleanup: 删除文件失败 %s: %v", f.Path, err)
+				}
+			} else {
+				e.logger.Infof("pipeline cleanup: 已删除 %s", f.Path)
+			}
+		} else {
+			kept = append(kept, f)
+		}
+	}
+
+	// 兜底逻辑：清理无关联视频文件的 .ass 文件
+	// 传入原始 files 列表，确保即使视频被删除也能扫描到对应目录
+	kept = e.cleanupOrphanedAssFiles(files, kept)
+
+	return kept
+}
+
+// cleanupOrphanedAssFiles 清理无关联视频文件的 .ass 文件
+// allFiles: 原始文件列表（含已删除的视频），用于确定扫描目录
+// keptFiles: 保留的文件列表，用于检查 Pipeline 内的 .ass 文件
+func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []FileInfo) []FileInfo {
+	// 从原始文件列表收集所有视频文件目录（即使视频已被删除）
+	videoBaseNames := map[string]bool{}
+	dirs := map[string]bool{}
+	for _, f := range allFiles {
+		ext := strings.ToLower(filepath.Ext(f.Path))
+		if ext == ".flv" || ext == ".mp4" || ext == ".mkv" {
+			dir := filepath.Dir(f.Path)
+			base := strings.TrimSuffix(filepath.Base(f.Path), ext)
+			videoBaseNames[filepath.Join(dir, base)] = true
+			dirs[dir] = true
+		}
+	}
+
+	// 收集 Pipeline 中已知的 .ass 文件路径
+	knownAssFiles := map[string]bool{}
+	for _, f := range keptFiles {
+		if strings.ToLower(filepath.Ext(f.Path)) == ".ass" {
+			knownAssFiles[f.Path] = true
+		}
+	}
+
+	// 扫描目录中的 .ass 文件（包括未进入 Pipeline 的）
+	for dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if strings.ToLower(filepath.Ext(entry.Name())) != ".ass" {
+				continue
+			}
+			assPath := filepath.Join(dir, entry.Name())
+			if knownAssFiles[assPath] {
+				continue // 已在 Pipeline 中处理
+			}
+			// 检查磁盘上是否有同名视频文件
+			base := strings.TrimSuffix(entry.Name(), ".ass")
+			key := filepath.Join(dir, base)
+			// 检查磁盘上实际存在的视频文件
+			hasVideo := false
+			for _, ext := range []string{".flv", ".mp4", ".mkv"} {
+				if _, err := os.Stat(key + ext); err == nil {
+					hasVideo = true
+					break
+				}
+			}
+			if !hasVideo {
+				if err := os.Remove(assPath); err != nil {
+					if !os.IsNotExist(err) {
+						e.logger.Warnf("pipeline cleanup: 删除磁盘孤立 .ass 文件失败 %s: %v", assPath, err)
+					}
+				} else {
+					e.logger.Infof("pipeline cleanup: 已删除磁盘孤立 .ass 文件 %s（无关联视频）", assPath)
+				}
+			}
+		}
+	}
+
+	// 处理 Pipeline 中的 .ass 文件
+	var kept []FileInfo
+	for _, f := range keptFiles {
+		ext := strings.ToLower(filepath.Ext(f.Path))
+		if ext == ".ass" {
+			dir := filepath.Dir(f.Path)
+			base := strings.TrimSuffix(filepath.Base(f.Path), ".ass")
+			key := filepath.Join(dir, base)
+			if !videoBaseNames[key] {
+				// 无关联视频文件，删除 .ass
+				if err := os.Remove(f.Path); err != nil {
+					if !os.IsNotExist(err) {
+						e.logger.Warnf("pipeline cleanup: 删除孤立 .ass 文件失败 %s: %v", f.Path, err)
+					}
+					kept = append(kept, f) // 删除失败则保留
+				} else {
+					e.logger.Infof("pipeline cleanup: 已删除孤立 .ass 文件 %s（无关联视频）", f.Path)
+				}
+			} else {
+				kept = append(kept, f)
+			}
+		} else {
+			kept = append(kept, f)
+		}
+	}
+
+	return kept
 }
 
 // executeStage 执行单个阶段

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -145,7 +145,7 @@ func (e *Executor) Execute(
 	}
 
 	// 全部成功：执行延迟删除
-	files = e.deleteMarkedFiles(files)
+	e.deleteMarkedFiles(files)
 
 	return results, nil
 }

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -56,7 +56,7 @@ func (e *Executor) Execute(
 	initialFiles []FileInfo,
 	startStage int,
 	onProgress func(stageIndex int, stageName string, status StageStatus),
-	onStageComplete func(stageIndex int, outputFiles []FileInfo),
+	onStageComplete func(stageIndex int, result StageResult),
 ) ([]StageResult, error) {
 	if config == nil || len(config.Stages) == 0 {
 		e.logger.Debug("pipeline config is empty, skipping")
@@ -149,7 +149,7 @@ func (e *Executor) Execute(
 
 		// 通知外部持久化阶段完成状态（用于崩溃恢复）
 		if onStageComplete != nil {
-			onStageComplete(stageIndex, output)
+			onStageComplete(stageIndex, result)
 		}
 
 		// 更新文件列表给下一阶段
@@ -163,13 +163,13 @@ func (e *Executor) Execute(
 	}
 
 	// 全部成功：执行延迟删除，并让最终结果反映磁盘上的文件
-	// 如果上下文已取消，跳过删除以保留所有文件
+	// 如果上下文已取消，跳过删除以保留所有文件，返回取消错误让任务标记为 Cancelled
 	if ctx.Ctx.Err() != nil {
 		e.logger.Warn("pipeline cancelled after completion, skipping file cleanup")
 		if len(results) > 0 {
 			results[len(results)-1].OutputFiles = files
 		}
-		return results, nil
+		return results, ctx.Ctx.Err()
 	}
 	keptFiles := e.deleteMarkedFiles(files)
 	if len(results) > 0 {

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -48,10 +48,12 @@ func (e *Executor) getFactory(name string) (StageFactory, bool) {
 }
 
 // Execute 执行管道
+// startStage: 从第几个启用的阶段开始执行（0=全部执行，用于重试指定阶段）
 func (e *Executor) Execute(
 	ctx *PipelineContext,
 	config *PipelineConfig,
 	initialFiles []FileInfo,
+	startStage int,
 	onProgress func(stageIndex int, stageName string, status StageStatus),
 ) ([]StageResult, error) {
 	if config == nil || len(config.Stages) == 0 {
@@ -73,6 +75,12 @@ func (e *Executor) Execute(
 		// 检查是否启用
 		if !stageCfg.IsEnabled() {
 			e.logger.WithField("stage", stageCfg.Name).Debug("stage disabled, skipping")
+			continue
+		}
+
+		// 跳过 startStage 之前的阶段（用于从指定阶段重试）
+		if stageIndex < startStage {
+			stageIndex++
 			continue
 		}
 
@@ -460,7 +468,7 @@ func (e *Executor) ExecuteAsync(
 	bilisentry.GoWithContext(ctx.Ctx, func(goCtx context.Context) {
 		// 更新上下文
 		ctx.Ctx = goCtx
-		results, err := e.Execute(ctx, config, initialFiles, onProgress)
+		results, err := e.Execute(ctx, config, initialFiles, 0, onProgress)
 		if onComplete != nil {
 			onComplete(results, err)
 		}

--- a/src/pipeline/executor_test.go
+++ b/src/pipeline/executor_test.go
@@ -86,7 +86,7 @@ func TestExecute_AllStagesSucceed_AllDeletableFilesRemoved(t *testing.T) {
 
 	results, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: originalFile, Type: FileTypeVideo},
-	}, nil)
+	}, 0, nil)
 
 	// 验证：无错误
 	assert.NoError(t, err)
@@ -142,7 +142,7 @@ func TestExecute_StageFailed_AllFilesPreserved(t *testing.T) {
 
 	_, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: originalFile, Type: FileTypeVideo},
-	}, nil)
+	}, 0, nil)
 
 	// 验证：返回错误
 	assert.Error(t, err)
@@ -199,7 +199,7 @@ func TestExecute_Cancelled_AllFilesPreserved(t *testing.T) {
 
 	_, _ = executor.Execute(ctx, config, []FileInfo{
 		{Path: originalFile, Type: FileTypeVideo},
-	}, nil)
+	}, 0, nil)
 
 	// 验证：stage2 返回成功，但下一轮循环检测到 context 已取消
 	// 注意：stage2 本身成功了，所以 deleteMarkedFiles 会被调用
@@ -248,7 +248,7 @@ func TestExecute_PassthroughPreservesDeletable(t *testing.T) {
 	results, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: file1, Type: FileTypeVideo},
 		{Path: file2, Type: FileTypeOther, Deletable: true},
-	}, nil)
+	}, 0, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -304,7 +304,7 @@ func TestExecute_UploadCancelledDuringUpload_FilePreserved(t *testing.T) {
 
 	_, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: localFile, Type: FileTypeVideo},
-	}, nil)
+	}, 0, nil)
 
 	// 验证：返回错误
 	assert.Error(t, err)
@@ -363,7 +363,7 @@ func TestExecute_UploadFailsMiddleOfFileList_NoneDeleted(t *testing.T) {
 		{Path: file1, Type: FileTypeVideo},
 		{Path: file2, Type: FileTypeVideo},
 		{Path: file3, Type: FileTypeVideo},
-	}, nil)
+	}, 0, nil)
 
 	assert.NoError(t, err)
 
@@ -423,7 +423,7 @@ func TestExecute_StaleDeletableFromDB_ClearedOnFailure(t *testing.T) {
 	_, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: file1, Type: FileTypeVideo, Deletable: true}, // 旧标记
 		{Path: file2, Type: FileTypeVideo, Deletable: true}, // 旧标记
-	}, nil)
+	}, 0, nil)
 
 	assert.NoError(t, err)
 

--- a/src/pipeline/executor_test.go
+++ b/src/pipeline/executor_test.go
@@ -1,0 +1,433 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStage 模拟阶段，用于测试
+type mockStage struct {
+	name      string
+	executeFn func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error)
+}
+
+func (s *mockStage) Name() string { return s.name }
+func (s *mockStage) Execute(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+	return s.executeFn(ctx, input)
+}
+
+// 创建临时测试文件
+func createTempFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte("test content"), 0644))
+	return path
+}
+
+// TestExecute_AllStagesSucceed_AllDeletableFilesRemoved 测试全部成功时删除标记文件
+func TestExecute_AllStagesSucceed_AllDeletableFilesRemoved(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// 创建测试文件
+	originalFile := createTempFile(t, tmpDir, "video.flv")
+	intermediateFile := filepath.Join(tmpDir, "video.mp4")
+	finalFile := filepath.Join(tmpDir, "video.mkv")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "stage1"},
+			{Name: "stage2"},
+		},
+	}
+
+	stage1 := &mockStage{
+		name: "stage1",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 模拟转换：产出新文件，标记原始文件为可删除
+			require.NoError(t, os.WriteFile(intermediateFile, []byte("mp4"), 0644))
+			return []FileInfo{
+				{Path: intermediateFile, Type: FileTypeVideo},
+				{Path: input[0].Path, Type: FileTypeVideo, Deletable: true}, // 标记原始文件
+			}, nil
+		},
+	}
+
+	stage2 := &mockStage{
+		name: "stage2",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 模拟烧录：产出新文件，标记中间文件为可删除
+			require.NoError(t, os.WriteFile(finalFile, []byte("mkv"), 0644))
+			var output []FileInfo
+			output = append(output, FileInfo{Path: finalFile, Type: FileTypeVideo})
+			for _, f := range input {
+				if f.Path == intermediateFile {
+					f.Deletable = true
+				}
+				output = append(output, f)
+			}
+			return output, nil
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("stage1", func(config StageConfig) (Stage, error) { return stage1, nil })
+	executor.RegisterStage("stage2", func(config StageConfig) (Stage, error) { return stage2, nil })
+
+	ctx := &PipelineContext{
+		Ctx: context.Background(),
+	}
+
+	results, err := executor.Execute(ctx, config, []FileInfo{
+		{Path: originalFile, Type: FileTypeVideo},
+	}, nil)
+
+	// 验证：无错误
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// 验证：原始文件和中间文件已被删除
+	assert.NoFileExists(t, originalFile, "原始文件应被删除")
+	assert.NoFileExists(t, intermediateFile, "中间文件应被删除")
+
+	// 验证：最终文件保留
+	assert.FileExists(t, finalFile, "最终文件应保留")
+}
+
+// TestExecute_StageFailed_AllFilesPreserved 测试阶段失败时保留所有文件
+func TestExecute_StageFailed_AllFilesPreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalFile := createTempFile(t, tmpDir, "video.flv")
+	intermediateFile := filepath.Join(tmpDir, "video.mp4")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "stage1"},
+			{Name: "stage2"},
+		},
+	}
+
+	stage1 := &mockStage{
+		name: "stage1",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			require.NoError(t, os.WriteFile(intermediateFile, []byte("mp4"), 0644))
+			return []FileInfo{
+				{Path: intermediateFile, Type: FileTypeVideo},
+				{Path: input[0].Path, Type: FileTypeVideo, Deletable: true},
+			}, nil
+		},
+	}
+
+	stage2 := &mockStage{
+		name: "stage2",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			return nil, fmt.Errorf("模拟失败")
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("stage1", func(config StageConfig) (Stage, error) { return stage1, nil })
+	executor.RegisterStage("stage2", func(config StageConfig) (Stage, error) { return stage2, nil })
+
+	ctx := &PipelineContext{
+		Ctx: context.Background(),
+	}
+
+	_, err := executor.Execute(ctx, config, []FileInfo{
+		{Path: originalFile, Type: FileTypeVideo},
+	}, nil)
+
+	// 验证：返回错误
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "模拟失败")
+
+	// 验证：所有文件保留
+	assert.FileExists(t, originalFile, "原始文件应保留")
+	assert.FileExists(t, intermediateFile, "中间文件应保留")
+}
+
+// TestExecute_Cancelled_AllFilesPreserved 测试取消时保留所有文件
+func TestExecute_Cancelled_AllFilesPreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalFile := createTempFile(t, tmpDir, "video.flv")
+	intermediateFile := filepath.Join(tmpDir, "video.mp4")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "stage1"},
+			{Name: "stage2"},
+		},
+	}
+
+	stage1 := &mockStage{
+		name: "stage1",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			require.NoError(t, os.WriteFile(intermediateFile, []byte("mp4"), 0644))
+			return []FileInfo{
+				{Path: intermediateFile, Type: FileTypeVideo},
+				{Path: input[0].Path, Type: FileTypeVideo, Deletable: true},
+			}, nil
+		},
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+
+	stage2 := &mockStage{
+		name: "stage2",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 在 stage2 执行时取消 context
+			cancel()
+			return []FileInfo{input[0]}, nil
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("stage1", func(config StageConfig) (Stage, error) { return stage1, nil })
+	executor.RegisterStage("stage2", func(config StageConfig) (Stage, error) { return stage2, nil })
+
+	ctx := &PipelineContext{
+		Ctx: cancelCtx,
+	}
+
+	_, _ = executor.Execute(ctx, config, []FileInfo{
+		{Path: originalFile, Type: FileTypeVideo},
+	}, nil)
+
+	// 验证：stage2 返回成功，但下一轮循环检测到 context 已取消
+	// 注意：stage2 本身成功了，所以 deleteMarkedFiles 会被调用
+	// 但如果在 stage2 执行后、deleteMarkedFiles 之前 context 被检查，就不会删除
+	// 实际上 executor 在 stage2 成功后直接进入下一轮循环，此时检测到取消
+
+	// 验证：原始文件行为取决于 stage2 是否成功
+	// stage2 成功 → deleteMarkedFiles 被调用 → 原始文件被删除
+	// 但如果 stage2 之后的循环检测到取消 → 不调用 deleteMarkedFiles
+	assert.FileExists(t, intermediateFile, "中间文件应保留")
+}
+
+// TestExecute_PassthroughPreservesDeletable 测试透传文件保留 Deletable 标记
+func TestExecute_PassthroughPreservesDeletable(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	file1 := createTempFile(t, tmpDir, "video.flv")
+	file2 := createTempFile(t, tmpDir, "subtitle.ass")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "stage1"},
+		},
+	}
+
+	stage1 := &mockStage{
+		name: "stage1",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 只处理第一个文件，第二个透传
+			output := []FileInfo{
+				{Path: input[0].Path + ".processed", Type: FileTypeVideo},
+				input[1], // 透传，保留原始 Deletable
+			}
+			return output, nil
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("stage1", func(config StageConfig) (Stage, error) { return stage1, nil })
+
+	ctx := &PipelineContext{
+		Ctx: context.Background(),
+	}
+
+	// 标记 file2 为 Deletable
+	results, err := executor.Execute(ctx, config, []FileInfo{
+		{Path: file1, Type: FileTypeVideo},
+		{Path: file2, Type: FileTypeOther, Deletable: true},
+	}, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	// 验证：file2 已被删除（因为 Deletable=true 且管道成功）
+	assert.NoFileExists(t, file2, "标记为 Deletable 的透传文件应被删除")
+}
+
+// TestDeleteMarkedFiles_FileNotExist 测试文件不存在时静默跳过
+func TestDeleteMarkedFiles_FileNotExist(t *testing.T) {
+	executor := NewExecutor(logrus.StandardLogger())
+
+	files := []FileInfo{
+		{Path: "/nonexistent/file.flv", Type: FileTypeVideo, Deletable: true},
+		{Path: "/nonexistent/file.mp4", Type: FileTypeVideo, Deletable: false},
+	}
+
+	// 不应 panic，不应报错
+	kept := executor.deleteMarkedFiles(files)
+	assert.Len(t, kept, 1)
+	assert.Equal(t, "/nonexistent/file.mp4", kept[0].Path)
+}
+
+// TestExecute_UploadCancelledDuringUpload_FilePreserved
+// 测试：上传阶段被取消（context 取消），上传返回 error，文件应保留且有日志
+func TestExecute_UploadCancelledDuringUpload_FilePreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	localFile := createTempFile(t, tmpDir, "video.mkv")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "upload"},
+		},
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+
+	uploadStage := &mockStage{
+		name: "upload",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 模拟上传过程中被取消
+			cancel()
+			// 上传返回 error（实际中 client.Upload 会因 context 取消而返回 error）
+			return input, fmt.Errorf("upload cancelled: %w", context.Canceled)
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("upload", func(config StageConfig) (Stage, error) { return uploadStage, nil })
+
+	ctx := &PipelineContext{Ctx: cancelCtx}
+
+	_, err := executor.Execute(ctx, config, []FileInfo{
+		{Path: localFile, Type: FileTypeVideo},
+	}, nil)
+
+	// 验证：返回错误
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "upload cancelled")
+
+	// 验证：本地文件保留（上传失败，不应删除）
+	assert.FileExists(t, localFile, "上传被取消，本地文件应保留")
+}
+
+// TestExecute_UploadFailsMiddleOfFileList_NoneDeleted
+// 测试：多个文件上传，中间某个失败，全部文件保留（部分成功也不删除）
+func TestExecute_UploadFailsMiddleOfFileList_NoneDeleted(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	file1 := createTempFile(t, tmpDir, "video1.mkv")
+	file2 := createTempFile(t, tmpDir, "video2.mkv")
+	file3 := createTempFile(t, tmpDir, "video3.mkv")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "upload"},
+		},
+	}
+
+	uploadStage := &mockStage{
+		name: "upload",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 模拟 CloudUploadStage 的"全部成功才标记"逻辑
+			var output []FileInfo
+			var failed bool
+			for i, f := range input {
+				if i == 1 {
+					// 第二个文件上传失败
+					output = append(output, f)
+					failed = true
+				} else {
+					output = append(output, f)
+				}
+			}
+			// 只有全部成功才标记 Deletable
+			if !failed {
+				for i := range output {
+					output[i].Deletable = true
+				}
+			}
+			return output, nil
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("upload", func(config StageConfig) (Stage, error) { return uploadStage, nil })
+
+	ctx := &PipelineContext{Ctx: context.Background()}
+
+	_, err := executor.Execute(ctx, config, []FileInfo{
+		{Path: file1, Type: FileTypeVideo},
+		{Path: file2, Type: FileTypeVideo},
+		{Path: file3, Type: FileTypeVideo},
+	}, nil)
+
+	assert.NoError(t, err)
+
+	// 验证：部分失败，全部文件保留
+	assert.FileExists(t, file1, "部分失败时全部文件应保留")
+	assert.FileExists(t, file2, "部分失败时全部文件应保留")
+	assert.FileExists(t, file3, "部分失败时全部文件应保留")
+}
+
+// TestExecute_StaleDeletableFromDB_ClearedOnFailure
+// 测试：数据库中残留 Deletable=true 标记，本次上传失败后应清除，不删除文件
+func TestExecute_StaleDeletableFromDB_ClearedOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	file1 := createTempFile(t, tmpDir, "video1.mkv")
+	file2 := createTempFile(t, tmpDir, "video2.mkv")
+
+	config := &PipelineConfig{
+		Stages: []StageConfig{
+			{Name: "upload"},
+		},
+	}
+
+	uploadStage := &mockStage{
+		name: "upload",
+		executeFn: func(ctx *PipelineContext, input []FileInfo) ([]FileInfo, error) {
+			// 模拟 CloudUploadStage 的逻辑：先清除 Deletable，再判断上传结果
+			for i := range input {
+				input[i].Deletable = false
+			}
+			var output []FileInfo
+			var failed bool
+			for _, f := range input {
+				if f.Path == file2 {
+					// 第二个文件上传失败
+					output = append(output, f)
+					failed = true
+				} else {
+					output = append(output, f)
+				}
+			}
+			if !failed {
+				for i := range output {
+					output[i].Deletable = true
+				}
+			}
+			return output, nil
+		},
+	}
+
+	executor := NewExecutor(logrus.StandardLogger())
+	executor.RegisterStage("upload", func(config StageConfig) (Stage, error) { return uploadStage, nil })
+
+	ctx := &PipelineContext{Ctx: context.Background()}
+
+	// 模拟数据库中残留 Deletable=true 的文件
+	_, err := executor.Execute(ctx, config, []FileInfo{
+		{Path: file1, Type: FileTypeVideo, Deletable: true}, // 旧标记
+		{Path: file2, Type: FileTypeVideo, Deletable: true}, // 旧标记
+	}, nil)
+
+	assert.NoError(t, err)
+
+	// 验证：上传失败，旧标记被清除，文件保留
+	assert.FileExists(t, file1, "数据库残留标记应被清除，文件保留")
+	assert.FileExists(t, file2, "数据库残留标记应被清除，文件保留")
+}

--- a/src/pipeline/executor_test.go
+++ b/src/pipeline/executor_test.go
@@ -86,7 +86,7 @@ func TestExecute_AllStagesSucceed_AllDeletableFilesRemoved(t *testing.T) {
 
 	results, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: originalFile, Type: FileTypeVideo},
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	// 验证：无错误
 	assert.NoError(t, err)
@@ -142,7 +142,7 @@ func TestExecute_StageFailed_AllFilesPreserved(t *testing.T) {
 
 	_, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: originalFile, Type: FileTypeVideo},
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	// 验证：返回错误
 	assert.Error(t, err)
@@ -199,7 +199,7 @@ func TestExecute_Cancelled_AllFilesPreserved(t *testing.T) {
 
 	_, _ = executor.Execute(ctx, config, []FileInfo{
 		{Path: originalFile, Type: FileTypeVideo},
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	// 验证：stage2 返回成功，但下一轮循环检测到 context 已取消
 	// 注意：stage2 本身成功了，所以 deleteMarkedFiles 会被调用
@@ -248,7 +248,7 @@ func TestExecute_PassthroughPreservesDeletable(t *testing.T) {
 	results, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: file1, Type: FileTypeVideo},
 		{Path: file2, Type: FileTypeOther, Deletable: true},
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -304,7 +304,7 @@ func TestExecute_UploadCancelledDuringUpload_FilePreserved(t *testing.T) {
 
 	_, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: localFile, Type: FileTypeVideo},
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	// 验证：返回错误
 	assert.Error(t, err)
@@ -363,7 +363,7 @@ func TestExecute_UploadFailsMiddleOfFileList_NoneDeleted(t *testing.T) {
 		{Path: file1, Type: FileTypeVideo},
 		{Path: file2, Type: FileTypeVideo},
 		{Path: file3, Type: FileTypeVideo},
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	assert.NoError(t, err)
 
@@ -423,7 +423,7 @@ func TestExecute_StaleDeletableFromDB_ClearedOnFailure(t *testing.T) {
 	_, err := executor.Execute(ctx, config, []FileInfo{
 		{Path: file1, Type: FileTypeVideo, Deletable: true}, // 旧标记
 		{Path: file2, Type: FileTypeVideo, Deletable: true}, // 旧标记
-	}, 0, nil)
+	}, 0, nil, nil)
 
 	assert.NoError(t, err)
 

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -226,6 +226,13 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 			}
 			m.broadcastTaskUpdate(task)
 		},
+		// 阶段完成后持久化 CurrentFiles，确保崩溃恢复时能拿到正确的中间文件
+		func(stageIndex int, outputFiles []FileInfo) {
+			task.CurrentFiles = outputFiles
+			if err := m.store.UpdateTask(ctx, task); err != nil {
+				logrus.WithError(err).Warn("failed to persist stage output files")
+			}
+		},
 	)
 
 	// 合并：保留之前的结果 + 新执行的结果
@@ -347,8 +354,9 @@ func (m *Manager) RetryTask(taskID int64) error {
 		return fmt.Errorf("task cannot be retried")
 	}
 
-	if task.Status != PipelineStatusFailed && task.Status != PipelineStatusCancelled {
-		return fmt.Errorf("only failed or cancelled tasks can be retried")
+	// 允许 Failed/Cancelled/Completed 状态
+	if task.Status != PipelineStatusFailed && task.Status != PipelineStatusCancelled && task.Status != PipelineStatusCompleted {
+		return fmt.Errorf("only failed, cancelled or completed tasks can be retried")
 	}
 
 	// 重置任务状态
@@ -435,6 +443,22 @@ func (m *Manager) RetryTaskFromStage(taskID int64, stageName string) error {
 		// 从头开始，使用初始文件
 		inputFiles = task.InitialFiles
 	}
+
+	// 过滤掉已标记删除/已上传的中间文件（它们在管道完成后已被 deleteMarkedFiles 从磁盘移除）
+	// 只保留目标阶段实际需要的文件，确保后续 os.Stat 校验和重试执行不会引用已删除的路径
+	var activeFiles []FileInfo
+	for _, f := range inputFiles {
+		if f.Deletable {
+			continue
+		}
+		if f.Metadata != nil {
+			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
+				continue
+			}
+		}
+		activeFiles = append(activeFiles, f)
+	}
+	inputFiles = activeFiles
 
 	// 校验输入文件不为空
 	if len(inputFiles) == 0 {

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -226,11 +226,16 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 			}
 			m.broadcastTaskUpdate(task)
 		},
-		// 阶段完成后持久化 CurrentFiles，确保崩溃恢复时能拿到正确的中间文件
-		func(stageIndex int, outputFiles []FileInfo) {
-			task.CurrentFiles = outputFiles
+		// 阶段完成后持久化结果，确保崩溃恢复时阶段记录完整
+		func(stageIndex int, result StageResult) {
+			task.CurrentFiles = result.OutputFiles
+			// 追加/更新 StageResults，让崩溃恢复后 preservedResults 合并条件成立
+			for len(task.StageResults) <= stageIndex {
+				task.StageResults = append(task.StageResults, StageResult{})
+			}
+			task.StageResults[stageIndex] = result
 			if err := m.store.UpdateTask(ctx, task); err != nil {
-				logrus.WithError(err).Warn("failed to persist stage output files")
+				logrus.WithError(err).Warn("failed to persist stage result")
 			}
 		},
 	)
@@ -359,6 +364,13 @@ func (m *Manager) RetryTask(taskID int64) error {
 		return fmt.Errorf("only failed, cancelled or completed tasks can be retried")
 	}
 
+	// 校验初始文件存在（Completed 任务的文件可能已被 deleteMarkedFiles 清理）
+	for _, f := range task.InitialFiles {
+		if _, err := os.Stat(f.Path); os.IsNotExist(err) {
+			return fmt.Errorf("initial file not found, cannot retry (may have been deleted after upload): %s", f.Path)
+		}
+	}
+
 	// 重置任务状态
 	task.Status = PipelineStatusPending
 	task.StartedAt = nil
@@ -444,17 +456,24 @@ func (m *Manager) RetryTaskFromStage(taskID int64, stageName string) error {
 		inputFiles = task.InitialFiles
 	}
 
-	// 过滤掉已标记删除/已上传的中间文件（它们在管道完成后已被 deleteMarkedFiles 从磁盘移除）
-	// 只保留目标阶段实际需要的文件，确保后续 os.Stat 校验和重试执行不会引用已删除的路径
+	// 过滤已清理的中间文件，保留仍在磁盘上的文件
+	// deleteMarkedFiles 仅在管道全部成功后执行，失败/取消时文件仍在磁盘但带有标记
+	// 因此需要结合磁盘实际存在性判断：标记但仍在 → 保留（管道未清理），标记且已删 → 跳过
 	var activeFiles []FileInfo
 	for _, f := range inputFiles {
-		if f.Deletable {
-			continue
-		}
+		isDeletable := f.Deletable
+		isUploaded := false
 		if f.Metadata != nil {
 			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
-				continue
+				isUploaded = true
 			}
+		}
+
+		if _, err := os.Stat(f.Path); os.IsNotExist(err) {
+			if isDeletable || isUploaded {
+				continue // 已被 deleteMarkedFiles 正常清理，跳过
+			}
+			return fmt.Errorf("input file not found, cannot retry: %s", f.Path)
 		}
 		activeFiles = append(activeFiles, f)
 	}
@@ -463,13 +482,6 @@ func (m *Manager) RetryTaskFromStage(taskID int64, stageName string) error {
 	// 校验输入文件不为空
 	if len(inputFiles) == 0 {
 		return fmt.Errorf("no input files available for stage %s, cannot retry", stageName)
-	}
-
-	// 验证文件存在于磁盘
-	for _, f := range inputFiles {
-		if _, err := os.Stat(f.Path); os.IsNotExist(err) {
-			return fmt.Errorf("input file not found, cannot retry: %s", f.Path)
-		}
 	}
 
 	// 重置任务状态
@@ -483,7 +495,7 @@ func (m *Manager) RetryTaskFromStage(taskID int64, stageName string) error {
 	if targetStageIndex < len(task.StageResults) {
 		task.StageResults = task.StageResults[:targetStageIndex]
 	}
-	task.Progress = (targetStageIndex * 100) / task.TotalStages
+	task.UpdateProgress()
 
 	if err := m.store.UpdateTask(m.ctx, task); err != nil {
 		return err

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -201,11 +202,21 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 		WorkDir: "", // 后续可以从配置获取
 	}
 
-	// 执行管道
+	// 执行管道（从 startStage 开始，支持从指定阶段重试）
+	startStage := task.CurrentStage
+
+	// 保留目标阶段之前的结果（用于合并）
+	var preservedResults []StageResult
+	if startStage > 0 && len(task.StageResults) >= startStage {
+		preservedResults = make([]StageResult, startStage)
+		copy(preservedResults, task.StageResults[:startStage])
+	}
+
 	results, err := m.executor.Execute(
 		pipelineCtx,
 		task.PipelineConfig,
 		task.CurrentFiles,
+		startStage,
 		func(stageIndex int, stageName string, status StageStatus) {
 			// 更新任务进度
 			task.CurrentStage = stageIndex
@@ -217,8 +228,12 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 		},
 	)
 
-	// 保存阶段结果
-	task.StageResults = results
+	// 合并：保留之前的结果 + 新执行的结果
+	if preservedResults != nil {
+		task.StageResults = append(preservedResults, results...)
+	} else {
+		task.StageResults = results
+	}
 
 	if err != nil {
 		if ctx.Err() == context.Canceled {
@@ -345,6 +360,106 @@ func (m *Manager) RetryTask(taskID int64) error {
 	task.CurrentFiles = task.InitialFiles // 重置为初始文件，从头开始重试
 	task.StageResults = nil
 	task.Progress = 0
+
+	if err := m.store.UpdateTask(m.ctx, task); err != nil {
+		return err
+	}
+
+	m.broadcastTaskUpdate(task)
+
+	// 立即尝试调度
+	bilisentry.Go(func() { m.scheduleNextTasks() })
+
+	return nil
+}
+
+// RetryTaskFromStage 从指定阶段开始重试任务
+// 允许 Failed/Cancelled/Completed 状态的任务
+// stageName: 要从哪个阶段开始重试（如 "cloud_upload"）
+func (m *Manager) RetryTaskFromStage(taskID int64, stageName string) error {
+	task, err := m.store.GetTask(m.ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	if !task.CanRetry {
+		return fmt.Errorf("task cannot be retried")
+	}
+
+	// 允许 Failed/Cancelled/Completed 状态
+	if task.Status != PipelineStatusFailed &&
+		task.Status != PipelineStatusCancelled &&
+		task.Status != PipelineStatusCompleted {
+		return fmt.Errorf("only failed, cancelled or completed tasks can be retried")
+	}
+
+	// 找到目标阶段在启用阶段中的索引
+	targetStageIndex := -1
+	stageIndex := 0
+	for _, stageCfg := range task.PipelineConfig.Stages {
+		if !stageCfg.IsEnabled() {
+			continue
+		}
+		if stageCfg.Name == stageName {
+			targetStageIndex = stageIndex
+			break
+		}
+		stageIndex++
+	}
+	if targetStageIndex == -1 {
+		return fmt.Errorf("stage %s not found in pipeline", stageName)
+	}
+
+	// 校验：目标阶段之前的所有阶段必须已完成
+	if targetStageIndex > 0 {
+		for i := 0; i < targetStageIndex; i++ {
+			if i >= len(task.StageResults) {
+				return fmt.Errorf("stage %d has not been executed, cannot retry from stage %s", i, stageName)
+			}
+			if task.StageResults[i].Status != StageStatusCompleted {
+				return fmt.Errorf("stage %d (%s) is not completed (status: %s), cannot retry from stage %s",
+					i, task.StageResults[i].StageName, task.StageResults[i].Status, stageName)
+			}
+		}
+	}
+
+	// 获取目标阶段的输入文件
+	var inputFiles []FileInfo
+	if targetStageIndex < len(task.StageResults) {
+		// 从已有的 StageResult 中取输入文件
+		inputFiles = task.StageResults[targetStageIndex].InputFiles
+	} else if targetStageIndex > 0 && targetStageIndex-1 < len(task.StageResults) {
+		// 使用上一阶段的输出文件
+		inputFiles = task.StageResults[targetStageIndex-1].OutputFiles
+	} else if targetStageIndex == 0 {
+		// 从头开始，使用初始文件
+		inputFiles = task.InitialFiles
+	}
+
+	// 校验输入文件不为空
+	if len(inputFiles) == 0 {
+		return fmt.Errorf("no input files available for stage %s, cannot retry", stageName)
+	}
+
+	// 验证文件存在于磁盘
+	for _, f := range inputFiles {
+		if _, err := os.Stat(f.Path); os.IsNotExist(err) {
+			return fmt.Errorf("input file not found, cannot retry: %s", f.Path)
+		}
+	}
+
+	// 重置任务状态
+	task.Status = PipelineStatusPending
+	task.StartedAt = nil
+	task.CompletedAt = nil
+	task.ErrorMessage = ""
+	task.CurrentStage = targetStageIndex
+	task.CurrentFiles = inputFiles
+	// 保留目标阶段之前的结果，清除目标阶段及之后的结果
+	if targetStageIndex < len(task.StageResults) {
+		task.StageResults = task.StageResults[:targetStageIndex]
+	}
+	task.Progress = (targetStageIndex * 100) / task.TotalStages
 
 	if err := m.store.UpdateTask(m.ctx, task); err != nil {
 		return err

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -342,6 +342,7 @@ func (m *Manager) RetryTask(taskID int64) error {
 	task.CompletedAt = nil
 	task.ErrorMessage = ""
 	task.CurrentStage = 0
+	task.CurrentFiles = task.InitialFiles // 重置为初始文件，从头开始重试
 	task.StageResults = nil
 	task.Progress = 0
 

--- a/src/pipeline/stages/burn_subtitles.go
+++ b/src/pipeline/stages/burn_subtitles.go
@@ -83,6 +83,13 @@ func (s *BurnSubtitlesStage) Execute(ctx *pipeline.PipelineContext, input []pipe
 			continue
 		}
 
+		// 跳过已标记待删除的文件（如 ConvertMp4 阶段标记的原始 FLV），
+		// 但仍将其透传到 output，保证 Executor 的延迟删除机制正常工作。
+		if file.Deletable {
+			output = append(output, file)
+			continue
+		}
+
 		// 检查文件是否存在
 		if _, err := os.Stat(file.Path); os.IsNotExist(err) {
 			s.logs += fmt.Sprintf("文件不存在: %s\n", file.Path)

--- a/src/pipeline/stages/burn_subtitles.go
+++ b/src/pipeline/stages/burn_subtitles.go
@@ -16,7 +16,6 @@ import (
 	bilisentry "github.com/bililive-go/bililive-go/src/pkg/sentry"
 	"github.com/bililive-go/bililive-go/src/pkg/utils"
 	"github.com/bililive-go/bililive-go/src/tools"
-	"github.com/sirupsen/logrus"
 )
 
 // BurnSubtitlesStage 弹幕字幕烧录阶段
@@ -197,27 +196,24 @@ func (s *BurnSubtitlesStage) Execute(ctx *pipeline.PipelineContext, input []pipe
 			SourcePath: file.Path,
 		})
 
-		// 可选：删除 ASS 文件
+		// 可选：标记 ASS 文件为可删除（由 Executor 在管道全部成功后统一删除）
 		if s.deleteAss {
-			if err := os.Remove(assPath); err != nil {
-				logrus.WithError(err).WithField("file", assPath).Warn("failed to delete ASS file")
-				s.logs += fmt.Sprintf("删除 ASS 文件失败: %s\n", assPath)
-			} else {
-				s.logs += fmt.Sprintf("已删除 ASS 文件: %s\n", assPath)
-				ctx.Logger.Infof("已删除 ASS 文件: %s", assPath)
-			}
+			output = append(output, pipeline.FileInfo{
+				Path:      assPath,
+				Type:      pipeline.FileTypeOther,
+				Deletable: true,
+			})
+			s.logs += fmt.Sprintf("已标记 ASS 文件待删除: %s\n", assPath)
+			ctx.Logger.Infof("已标记 ASS 文件待删除: %s", assPath)
 		}
 
-		// 可选：删除源视频文件
+		// 可选：标记源视频文件为可删除（由 Executor 在管道全部成功后统一删除）
 		if s.deleteSource && file.Path != outputPath {
-			if err := os.Remove(file.Path); err != nil {
-				logrus.WithError(err).WithField("file", file.Path).Warn("failed to delete source video file")
-				s.logs += fmt.Sprintf("删除源视频文件失败: %s\n", file.Path)
-			} else {
-				s.logs += fmt.Sprintf("已删除源视频文件: %s\n", file.Path)
-				ctx.Logger.Infof("已删除源视频文件: %s", file.Path)
-			}
+			file.Deletable = true
+			s.logs += fmt.Sprintf("已标记源视频文件待删除: %s\n", file.Path)
+			ctx.Logger.Infof("已标记源视频文件待删除: %s", file.Path)
 		}
+		output = append(output, file)
 
 		s.logs += fmt.Sprintf("字幕烧录完成: %s -> %s\n", filepath.Base(file.Path), filepath.Base(outputPath))
 		ctx.Logger.Infof("字幕烧录完成: %s", outputPath)

--- a/src/pipeline/stages/convert_mp4.go
+++ b/src/pipeline/stages/convert_mp4.go
@@ -120,6 +120,12 @@ func (s *ConvertMp4Stage) Execute(ctx *pipeline.PipelineContext, input []pipelin
 			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 		}
 
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			s.logs += fmt.Sprintf("创建错误管道失败: %s\n", err.Error())
+			return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+		}
+
 		if err := cmd.Start(); err != nil {
 			s.logs += fmt.Sprintf("启动 ffmpeg 失败: %s\n", err.Error())
 			return nil, fmt.Errorf("failed to start ffmpeg: %w", err)
@@ -130,10 +136,14 @@ func (s *ConvertMp4Stage) Execute(ctx *pipeline.PipelineContext, input []pipelin
 			s.parseProgress(goCtx, stdout, duration)
 		})
 
+		// 读取 stderr 防止缓冲区满导致 ffmpeg 挂起
+		stderrBytes, _ := io.ReadAll(stderr)
+
 		// 等待命令完成
 		if err := cmd.Wait(); err != nil {
 			os.Remove(tempFile)
 			s.logs += fmt.Sprintf("ffmpeg 转换失败: %s - %s\n", file.Path, err.Error())
+			s.logs += fmt.Sprintf("ffmpeg stderr: %s\n", string(stderrBytes))
 			return nil, fmt.Errorf("ffmpeg conversion failed for %s: %w", file.Path, err)
 		}
 

--- a/src/pipeline/stages/convert_mp4.go
+++ b/src/pipeline/stages/convert_mp4.go
@@ -16,7 +16,6 @@ import (
 	bilisentry "github.com/bililive-go/bililive-go/src/pkg/sentry"
 	"github.com/bililive-go/bililive-go/src/pkg/utils"
 	"github.com/bililive-go/bililive-go/src/tools"
-	"github.com/sirupsen/logrus"
 )
 
 // ConvertMp4Stage MP4 转换阶段
@@ -157,21 +156,13 @@ func (s *ConvertMp4Stage) Execute(ctx *pipeline.PipelineContext, input []pipelin
 			SourcePath: file.Path,
 		})
 
-		// 删除原始文件
+		// 标记原始文件为可删除（由 Executor 在管道全部成功后统一删除）
 		if s.deleteSource && file.Path != outputPath {
-			if err := os.Remove(file.Path); err != nil {
-				logrus.WithError(err).WithField("file", file.Path).Warn("failed to delete original file")
-				s.logs += fmt.Sprintf("删除原始文件失败: %s\n", file.Path)
-			} else {
-				s.logs += fmt.Sprintf("已删除原始文件: %s\n", file.Path)
-				ctx.Logger.Infof("已删除原始文件: %s", file.Path)
-			}
-		} else {
-			// 保留原始文件在输出中
-			if !s.deleteSource {
-				output = append(output, file)
-			}
+			file.Deletable = true
+			s.logs += fmt.Sprintf("已标记原始文件待删除: %s\n", file.Path)
+			ctx.Logger.Infof("已标记原始文件待删除: %s", file.Path)
 		}
+		output = append(output, file)
 
 		s.logs += fmt.Sprintf("转换完成: %s -> %s\n", filepath.Base(file.Path), filepath.Base(outputPath))
 		ctx.Logger.Infof("MP4 转换完成: %s", outputPath)

--- a/src/pipeline/stages/custom_command.go
+++ b/src/pipeline/stages/custom_command.go
@@ -51,9 +51,10 @@ func (s *CustomCommandStage) Execute(ctx *pipeline.PipelineContext, input []pipe
 	var output []pipeline.FileInfo
 
 	for _, file := range input {
-		// 跳过已标记待删除的文件（如 ConvertMp4/BurnSubtitles 阶段标记的中间产物），
-		// 避免对本应删除的文件重复执行命令，但仍将其透传到 output。
-		if file.Deletable {
+		// 跳过中间产物（如 ConvertMp4 标记的原始 FLV），避免重复执行命令。
+		// 但 delete_all_after_upload 模式会将所有文件（含最终成品）标记为 Deletable，
+		// 此类文件仍需执行自定义命令，不能跳过。
+		if file.Deletable && !isDeleteAllMarked(file) {
 			output = append(output, file)
 			continue
 		}
@@ -82,6 +83,16 @@ func (s *CustomCommandStage) Execute(ctx *pipeline.PipelineContext, input []pipe
 	}
 
 	return output, nil
+}
+
+// isDeleteAllMarked 检查文件是否被 delete_all_after_upload 模式标记
+// 此类文件虽为 Deletable，但属于最终成品，仍需执行自定义命令
+func isDeleteAllMarked(file pipeline.FileInfo) bool {
+	if file.Metadata == nil {
+		return false
+	}
+	da, ok := file.Metadata["delete_all"].(bool)
+	return ok && da
 }
 
 // renderCommand 渲染命令模板

--- a/src/pipeline/stages/custom_command.go
+++ b/src/pipeline/stages/custom_command.go
@@ -51,6 +51,13 @@ func (s *CustomCommandStage) Execute(ctx *pipeline.PipelineContext, input []pipe
 	var output []pipeline.FileInfo
 
 	for _, file := range input {
+		// 跳过已标记待删除的文件（如 ConvertMp4/BurnSubtitles 阶段标记的中间产物），
+		// 避免对本应删除的文件重复执行命令，但仍将其透传到 output。
+		if file.Deletable {
+			output = append(output, file)
+			continue
+		}
+
 		// 渲染命令模板
 		cmdStr, err := s.renderCommand(ctx, file)
 		if err != nil {

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -1,12 +1,19 @@
 package stages
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"text/template"
+	"time"
 
+	"github.com/bililive-go/bililive-go/src/configs"
 	"github.com/bililive-go/bililive-go/src/pipeline"
+	"github.com/bililive-go/bililive-go/src/pkg/openlist"
 	"github.com/bililive-go/bililive-go/src/tools"
 )
 
@@ -90,6 +97,7 @@ type CloudUploadStage struct {
 	storageName  string
 	pathTemplate string
 	deleteAfter  bool
+	uploadTiming string // immediate 或 after_process
 	fileTypes    []string // 过滤的文件类型，空表示所有
 	commands     []string
 	logs         string
@@ -102,6 +110,7 @@ func NewCloudUploadStage(config pipeline.StageConfig) (pipeline.Stage, error) {
 		storageName:  config.GetStringOption(pipeline.OptionStorage, ""),
 		pathTemplate: config.GetStringOption(pipeline.OptionPathTemplate, ""),
 		deleteAfter:  config.GetBoolOption(pipeline.OptionDeleteAfter, false),
+		uploadTiming: config.GetStringOption(pipeline.OptionUploadTiming, ""),
 		fileTypes:    config.GetStringSliceOption(pipeline.OptionFileTypes),
 	}, nil
 }
@@ -119,6 +128,34 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 	if s.storageName == "" {
 		s.logs = "未配置存储名称，跳过上传"
 		return input, nil
+	}
+
+	// 获取 OpenList 管理器
+	mgr := openlist.GetGlobalManager()
+	if mgr == nil {
+		s.logs = "OpenList 管理器未初始化，跳过上传\n"
+		return input, nil
+	}
+
+	// 获取配置并创建客户端
+	config := configs.GetCurrentConfig()
+	uploadCtx, cancel := context.WithTimeout(ctx.Ctx, 30*time.Minute)
+	defer cancel()
+
+	client, err := mgr.GetClient(uploadCtx, config.OpenList.Token, config.OpenList.Username, config.OpenList.Password)
+	if err != nil {
+		s.logs += fmt.Sprintf("创建 OpenList 客户端失败: %s\n", err.Error())
+		return input, fmt.Errorf("创建 OpenList 客户端失败: %w", err)
+	}
+
+	// 如果 token 变化了（通过用户名密码登录获取了新 token），自动写回配置
+	if newToken := client.GetCurrentToken(); newToken != "" && newToken != config.OpenList.Token {
+		config.OpenList.Token = newToken
+		if err := config.Marshal(); err != nil {
+			ctx.Logger.Warnf("保存 OpenList token 到配置文件失败: %v", err)
+		} else {
+			ctx.Logger.Info("OpenList token 已自动更新到配置文件")
+		}
 	}
 
 	var output []pipeline.FileInfo
@@ -145,17 +182,64 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 		}
 
 		ctx.Logger.Infof("上传文件: %s -> %s", file.Path, targetPath)
-
-		// TODO: 调用 OpenList API 进行上传
-		// 当前先记录命令，实际上传逻辑需要集成 OpenList
 		s.commands = append(s.commands, fmt.Sprintf("upload %s to %s/%s", file.Path, s.storageName, targetPath))
-		s.logs += fmt.Sprintf("上传任务已创建: %s -> %s/%s\n", filepath.Base(file.Path), s.storageName, targetPath)
 
-		// 如果不删除，保留文件在输出中
-		if !s.deleteAfter {
+		// 构建完整的远程路径（storage + targetPath）
+		// OpenList API 的 File-Path 需要包含存储路径
+		remotePath := targetPath
+		if !strings.HasPrefix(remotePath, "/") {
+			remotePath = "/" + remotePath
+		}
+		// 确保存储名和路径之间没有双斜杠
+		fullRemotePath := "/" + s.storageName + remotePath
+
+		// 确保远程目录存在（递归创建）
+		// 使用 path.Dir 而非 filepath.Dir，因为远程路径始终用正斜杠
+		remoteDir := path.Dir(fullRemotePath)
+		if remoteDir != "" && remoteDir != "." {
+			if err := client.MkdirRecursive(uploadCtx, remoteDir); err != nil {
+				ctx.Logger.Warnf("创建远程目录失败（可能已存在）: %s - %v", remoteDir, err)
+			}
+		}
+
+		// 执行上传（带进度追踪）
+		fileName := filepath.Base(file.Path)
+		var lastPct float64
+		err := client.Upload(uploadCtx, file.Path, fullRemotePath, func(p openlist.UploadProgress) {
+			// 每 10% 报告一次进度
+			if p.Percentage-lastPct >= 10 || p.Percentage >= 100 {
+				lastPct = p.Percentage
+				speedMB := float64(p.SpeedBytesPerSec) / 1024 / 1024
+				ctx.Logger.Infof("上传进度 [%s]: %.1f%% (%.1f MB/s, 剩余 %ds)",
+					fileName, p.Percentage, speedMB, p.EtaSeconds)
+			}
+		})
+
+		if err != nil {
+			s.logs += fmt.Sprintf("上传失败: %s -> %s/%s - %s\n", fileName, s.storageName, targetPath, err.Error())
+			ctx.Logger.Errorf("上传失败: %s - %v", file.Path, err)
+			// 上传失败，保留文件
 			output = append(output, file)
+			continue
+		}
+
+		s.logs += fmt.Sprintf("上传成功: %s -> %s/%s\n", fileName, s.storageName, targetPath)
+		ctx.Logger.Infof("文件上传成功: %s -> %s/%s", fileName, s.storageName, targetPath)
+
+		// 立即上传模式：始终保留文件，后续阶段（修复/转换/烧录）会处理删除
+		// 后处理上传模式：如果配置了删除，则删除文件（此时已是最终文件）
+		if s.deleteAfter && s.uploadTiming != "immediate" {
+			if err := os.Remove(file.Path); err != nil {
+				// 删除失败，保留文件在输出中供后续阶段使用
+				s.logs += fmt.Sprintf("删除本地文件失败: %s - %s\n", fileName, err.Error())
+				ctx.Logger.Warnf("删除本地文件失败: %s - %v", file.Path, err)
+				output = append(output, file)
+			} else {
+				s.logs += fmt.Sprintf("已删除本地文件: %s\n", fileName)
+			}
 		} else {
-			s.logs += fmt.Sprintf("上传后删除: %s\n", filepath.Base(file.Path))
+			// 保留文件在输出中
+			output = append(output, file)
 		}
 	}
 
@@ -183,25 +267,85 @@ func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file 
 		)
 	}
 
-	// 简单的模板替换
-	path := s.pathTemplate
-	path = strings.ReplaceAll(path, "{{ .Platform }}", ctx.RecordInfo.Platform)
-	path = strings.ReplaceAll(path, "{{.Platform}}", ctx.RecordInfo.Platform)
-	path = strings.ReplaceAll(path, "{{ .HostName }}", ctx.RecordInfo.HostName)
-	path = strings.ReplaceAll(path, "{{.HostName}}", ctx.RecordInfo.HostName)
-	path = strings.ReplaceAll(path, "{{ .RoomName }}", ctx.RecordInfo.RoomName)
-	path = strings.ReplaceAll(path, "{{.RoomName}}", ctx.RecordInfo.RoomName)
-	path = strings.ReplaceAll(path, "{{ .FileName }}", filepath.Base(file.Path))
-	path = strings.ReplaceAll(path, "{{.FileName}}", filepath.Base(file.Path))
-
 	// 获取扩展名
 	ext := filepath.Ext(file.Path)
 	if len(ext) > 0 && ext[0] == '.' {
 		ext = ext[1:]
 	}
-	path = strings.ReplaceAll(path, "{{ .Ext }}", ext)
-	path = strings.ReplaceAll(path, "{{.Ext}}", ext)
 
+	// 模板数据
+	data := struct {
+		Platform string
+		HostName string
+		RoomName string
+		FileName string
+		Ext      string
+	}{
+		Platform: ctx.RecordInfo.Platform,
+		HostName: ctx.RecordInfo.HostName,
+		RoomName: ctx.RecordInfo.RoomName,
+		FileName: filepath.Base(file.Path),
+		Ext:      ext,
+	}
+
+	// 使用 Go 模板引擎
+	funcMap := template.FuncMap{
+		"date": func(format string, t time.Time) string {
+			return t.Format(format)
+		},
+		"now": func() time.Time {
+			return time.Now()
+		},
+		"trimSuffix": func(suffix, s string) string {
+			return strings.TrimSuffix(s, suffix)
+		},
+		"ext": func(path string) string {
+			return filepath.Ext(path)
+		},
+		"filenameFilter": func(s string) string {
+			// 过滤文件名中的非法字符
+			replacer := strings.NewReplacer(
+				"/", "_", "\\", "_", ":", "_", "*", "_",
+				"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+			)
+			return replacer.Replace(s)
+		},
+	}
+
+	tmpl, err := template.New("path").Funcs(funcMap).Parse(s.pathTemplate)
+	if err != nil {
+		// 模板解析失败，回退到简单替换
+		return s.fallbackRender(data)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		// 模板执行失败，回退到简单替换
+		return s.fallbackRender(data)
+	}
+
+	return buf.String()
+}
+
+// fallbackRender 简单字符串替换（模板引擎失败时的回退方案）
+func (s *CloudUploadStage) fallbackRender(data struct {
+	Platform string
+	HostName string
+	RoomName string
+	FileName string
+	Ext      string
+}) string {
+	path := s.pathTemplate
+	path = strings.ReplaceAll(path, "{{ .Platform }}", data.Platform)
+	path = strings.ReplaceAll(path, "{{.Platform}}", data.Platform)
+	path = strings.ReplaceAll(path, "{{ .HostName }}", data.HostName)
+	path = strings.ReplaceAll(path, "{{.HostName}}", data.HostName)
+	path = strings.ReplaceAll(path, "{{ .RoomName }}", data.RoomName)
+	path = strings.ReplaceAll(path, "{{.RoomName}}", data.RoomName)
+	path = strings.ReplaceAll(path, "{{ .FileName }}", data.FileName)
+	path = strings.ReplaceAll(path, "{{.FileName}}", data.FileName)
+	path = strings.ReplaceAll(path, "{{ .Ext }}", data.Ext)
+	path = strings.ReplaceAll(path, "{{.Ext}}", data.Ext)
 	return path
 }
 

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -212,10 +212,11 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 		// 检测远程路径冲突（多分段视频或视频+封面使用相同模板时可能产生同路径）
 		// 冲突时自动追加原始文件名以区分
 		if usedPaths[targetPath] {
-			dir := filepath.Dir(targetPath)
+			// 使用 path.* 而非 filepath.*，因为 targetPath 是远程路径，始终用正斜杠
+			dir := path.Dir(targetPath)
 			ext := filepath.Ext(targetPath)
-			base := strings.TrimSuffix(filepath.Base(targetPath), ext)
-			targetPath = filepath.Join(dir, base+"_"+filepath.Base(file.Path))
+			base := strings.TrimSuffix(path.Base(targetPath), ext)
+			targetPath = path.Join(dir, base+"_"+filepath.Base(file.Path))
 			ctx.Logger.Infof("检测到远程路径冲突，自动追加文件名: %s", targetPath)
 		}
 		usedPaths[targetPath] = true

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -304,7 +304,13 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 			}
 
 			// 删除全部文件（含中间产物）：用 Deletable 标记
+			// 跳过已是 Deletable 的中间产物（如 BurnSubtitles 标记的源视频），
+			// 避免 delete_all 标记覆盖其"中间产物"身份，导致 CustomCommandStage 误执行
 			for i := range output {
+				if output[i].Deletable {
+					// 中间产物：保留原始 Deletable 标记，不加 delete_all
+					continue
+				}
 				output[i].Deletable = true
 				if output[i].Metadata == nil {
 					output[i].Metadata = map[string]any{}

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -52,6 +52,12 @@ func (s *ExtractCoverStage) Execute(ctx *pipeline.PipelineContext, input []pipel
 			continue
 		}
 
+		// 跳过已标记待删除的文件（如 ConvertMp4 阶段标记的原始 FLV），
+		// 避免重复提取封面。
+		if file.Deletable {
+			continue
+		}
+
 		// 检查文件是否存在
 		if _, err := os.Stat(file.Path); os.IsNotExist(err) {
 			s.logs += fmt.Sprintf("文件不存在: %s\n", file.Path)
@@ -134,8 +140,8 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 	// 获取 OpenList 管理器
 	mgr := openlist.GetGlobalManager()
 	if mgr == nil {
-		s.logs = "OpenList 管理器未初始化，跳过上传\n"
-		return input, nil
+		s.logs = "OpenList 管理器未初始化\n"
+		return input, fmt.Errorf("OpenList 管理器未初始化")
 	}
 
 	// 获取配置并创建客户端
@@ -149,8 +155,11 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 	// 如果 token 变化了（通过用户名密码登录获取了新 token），自动写回配置
 	if newToken := client.GetCurrentToken(); newToken != "" && newToken != config.OpenList.Token {
-		config.OpenList.Token = newToken
-		if err := config.Marshal(); err != nil {
+		_, err := configs.UpdateWithRetry(func(c *configs.Config) error {
+			c.OpenList.Token = newToken
+			return nil
+		}, 3, 10*time.Millisecond)
+		if err != nil {
 			ctx.Logger.Warnf("保存 OpenList token 到配置文件失败: %v", err)
 		} else {
 			ctx.Logger.Info("OpenList token 已自动更新到配置文件")
@@ -160,15 +169,18 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 	var output []pipeline.FileInfo
 	var uploadFailed bool
 
-	// 清除所有输入文件的 Deletable 标记（防止数据库中残留的旧标记影响本次判断）
-	for i := range input {
-		input[i].Deletable = false
-	}
-
-	// 只上传第一个视频文件和封面文件，跳过中间产物
-	// Pipeline 阶段输出顺序保证：最终视频在最前面，中间文件在后面
-	videoUploaded := false
+	// 上传所有非 Deletable 的视频文件和封面文件
+	// Deletable 检查已能正确区分中间产物（如 ConvertMp4 标记的原始 FLV）
+	// 与最终视频（如录播姬生成的多分段 _PART 文件），无需额外限制
 	uploadedIndices := map[int]bool{} // 记录实际上传的文件在 output 中的索引
+
+	// 统计待上传的视频文件数量，用于判断是否需要在路径中包含文件名以避免冲突
+	nonDeletableVideoCount := 0
+	for _, file := range input {
+		if file.Type == pipeline.FileTypeVideo && !file.Deletable {
+			nonDeletableVideoCount++
+		}
+	}
 
 	for _, file := range input {
 		// 跳过标记为待删除的中间文件（由其他阶段产出，不应上传）
@@ -183,23 +195,17 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 			continue
 		}
 
-		// 视频文件：只上传第一个（最终视频），跳过后续中间视频
-		if file.Type == pipeline.FileTypeVideo {
-			if videoUploaded {
-				output = append(output, file)
-				continue
-			}
-			videoUploaded = true
-		}
-
 		// 检查文件是否存在
 		if _, err := os.Stat(file.Path); os.IsNotExist(err) {
 			s.logs += fmt.Sprintf("文件不存在: %s\n", file.Path)
+			output = append(output, file)
+			uploadFailed = true
 			continue
 		}
 
 		// 渲染目标路径
-		targetPath := s.renderTargetPath(ctx, file)
+		// 多视频场景（如录播姬 _PART 分段）时，若模板不含 .FileName 则自动追加，确保路径唯一
+		targetPath := s.renderTargetPath(ctx, file, nonDeletableVideoCount > 1)
 		if targetPath == "" {
 			s.logs += fmt.Sprintf("无法生成目标路径: %s\n", file.Path)
 			output = append(output, file)
@@ -293,7 +299,8 @@ func (s *CloudUploadStage) matchFileType(fileType pipeline.FileType) bool {
 }
 
 // renderTargetPath 渲染目标路径
-func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file pipeline.FileInfo) string {
+// multiVideo 为 true 时，若模板不含 .FileName 则自动追加，确保多分段文件路径唯一
+func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file pipeline.FileInfo, multiVideo bool) string {
 	if s.pathTemplate == "" {
 		// 默认路径：/录播归档/{平台}/{主播名}/{文件名}
 		return fmt.Sprintf("/录播归档/%s/%s/%s",
@@ -301,6 +308,18 @@ func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file 
 			ctx.RecordInfo.HostName,
 			filepath.Base(file.Path),
 		)
+	}
+
+	// 多视频场景下，若模板不含 .FileName 则自动追加以避免路径冲突
+	templateStr := s.pathTemplate
+	if multiVideo && !strings.Contains(templateStr, ".FileName") {
+		// 在模板末尾（扩展名之前）插入文件名
+		// 例如: /path/房间名-日期.{{ .Ext }} → /path/房间名-日期_{{ .FileName }}.{{ .Ext }}
+		templateStr = strings.TrimSuffix(templateStr, ".{{ .Ext }}") + "_{{ .FileName }}.{{ .Ext }}"
+		if !strings.Contains(templateStr, ".FileName") {
+			// 兜底：直接在末尾追加
+			templateStr = s.pathTemplate + "/{{ .FileName }}"
+		}
 	}
 
 	// 获取扩展名
@@ -330,7 +349,7 @@ func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file 
 			return t.Format(format)
 		},
 		"now": func() time.Time {
-			return time.Now()
+			return ctx.RecordInfo.StartTime
 		},
 		"trimSuffix": func(suffix, s string) string {
 			return strings.TrimSuffix(s, suffix)
@@ -348,41 +367,20 @@ func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file 
 		},
 	}
 
-	tmpl, err := template.New("path").Funcs(funcMap).Parse(s.pathTemplate)
+	tmpl, err := template.New("path").Funcs(funcMap).Parse(templateStr)
 	if err != nil {
-		// 模板解析失败，回退到简单替换
-		return s.fallbackRender(data)
+		// 模板语法错误，返回空让调用方跳过上传，避免上传到错误路径
+		ctx.Logger.Errorf("上传路径模板解析失败: %v", err)
+		return ""
 	}
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		// 模板执行失败，回退到简单替换
-		return s.fallbackRender(data)
+		ctx.Logger.Errorf("上传路径模板执行失败: %v", err)
+		return ""
 	}
 
 	return buf.String()
-}
-
-// fallbackRender 简单字符串替换（模板引擎失败时的回退方案）
-func (s *CloudUploadStage) fallbackRender(data struct {
-	Platform string
-	HostName string
-	RoomName string
-	FileName string
-	Ext      string
-}) string {
-	path := s.pathTemplate
-	path = strings.ReplaceAll(path, "{{ .Platform }}", data.Platform)
-	path = strings.ReplaceAll(path, "{{.Platform}}", data.Platform)
-	path = strings.ReplaceAll(path, "{{ .HostName }}", data.HostName)
-	path = strings.ReplaceAll(path, "{{.HostName}}", data.HostName)
-	path = strings.ReplaceAll(path, "{{ .RoomName }}", data.RoomName)
-	path = strings.ReplaceAll(path, "{{.RoomName}}", data.RoomName)
-	path = strings.ReplaceAll(path, "{{ .FileName }}", data.FileName)
-	path = strings.ReplaceAll(path, "{{.FileName}}", data.FileName)
-	path = strings.ReplaceAll(path, "{{ .Ext }}", data.Ext)
-	path = strings.ReplaceAll(path, "{{.Ext}}", data.Ext)
-	return path
 }
 
 func (s *CloudUploadStage) GetCommands() []string {

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -146,6 +146,10 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 	// 获取配置并创建客户端
 	config := configs.GetCurrentConfig()
+	if config == nil {
+		s.logs = "配置未初始化\n"
+		return input, fmt.Errorf("配置未初始化")
+	}
 
 	client, err := mgr.GetClient(ctx.Ctx, config.OpenList.Token, config.OpenList.Username, config.OpenList.Password)
 	if err != nil {
@@ -168,19 +172,12 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 	var output []pipeline.FileInfo
 	var uploadFailed bool
+	usedPaths := map[string]bool{} // 检测远程路径冲突
 
 	// 上传所有非 Deletable 的视频文件和封面文件
 	// Deletable 检查已能正确区分中间产物（如 ConvertMp4 标记的原始 FLV）
 	// 与最终视频（如录播姬生成的多分段 _PART 文件），无需额外限制
 	uploadedIndices := map[int]bool{} // 记录实际上传的文件在 output 中的索引
-
-	// 统计待上传的视频文件数量，用于判断是否需要在路径中包含文件名以避免冲突
-	nonDeletableVideoCount := 0
-	for _, file := range input {
-		if file.Type == pipeline.FileTypeVideo && !file.Deletable {
-			nonDeletableVideoCount++
-		}
-	}
 
 	for _, file := range input {
 		// 跳过标记为待删除的中间文件（由其他阶段产出，不应上传）
@@ -204,14 +201,24 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 		}
 
 		// 渲染目标路径
-		// 多视频场景（如录播姬 _PART 分段）时，若模板不含 .FileName 则自动追加，确保路径唯一
-		targetPath := s.renderTargetPath(ctx, file, nonDeletableVideoCount > 1)
+		targetPath := s.renderTargetPath(ctx, file)
 		if targetPath == "" {
 			s.logs += fmt.Sprintf("无法生成目标路径: %s\n", file.Path)
 			output = append(output, file)
 			uploadFailed = true
 			continue
 		}
+
+		// 检测远程路径冲突（多分段视频或视频+封面使用相同模板时可能产生同路径）
+		// 冲突时自动追加原始文件名以区分
+		if usedPaths[targetPath] {
+			dir := filepath.Dir(targetPath)
+			ext := filepath.Ext(targetPath)
+			base := strings.TrimSuffix(filepath.Base(targetPath), ext)
+			targetPath = filepath.Join(dir, base+"_"+filepath.Base(file.Path))
+			ctx.Logger.Infof("检测到远程路径冲突，自动追加文件名: %s", targetPath)
+		}
+		usedPaths[targetPath] = true
 
 		ctx.Logger.Infof("上传文件: %s -> %s", file.Path, targetPath)
 		s.commands = append(s.commands, fmt.Sprintf("upload %s to %s/%s", file.Path, s.storageName, targetPath))
@@ -258,20 +265,62 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 	// 全部上传成功后，根据配置标记文件为可删除（由 Executor 在管道全部成功后统一删除）
 	// 任意一个上传失败，则不标记任何文件，确保本地文件全部保留
+	// 注意：不使用 Deletable 标记，避免后续阶段（如 CustomCommand）误跳过最终成品
+	// 改用 Metadata["uploaded"] 标记，由 Executor 在清理时读取
 	if !uploadFailed && s.uploadTiming != "immediate" {
 		if s.deleteAllAfter {
-			// 删除全部文件（含中间产物）
+			// 删除全部模式：查找视频文件关联的 .ass 字幕文件并加入 output
+			// （BurnSubtitlesStage 仅在 burn_delete_ass=true 时才将 .ass 加入 output，
+			//   但 delete_all 意图是删除所有文件，应包含字幕）
+			assAdded := map[string]bool{}
+			for _, f := range output {
+				ext := strings.ToLower(filepath.Ext(f.Path))
+				if ext != ".flv" && ext != ".mp4" && ext != ".mkv" && ext != ".ts" {
+					continue
+				}
+				assPath := strings.TrimSuffix(f.Path, ext) + ".ass"
+				if assAdded[assPath] {
+					continue
+				}
+				if _, err := os.Stat(assPath); err == nil {
+					// 检查 output 中是否已存在
+					alreadyInOutput := false
+					for _, of := range output {
+						if of.Path == assPath {
+							alreadyInOutput = true
+							break
+						}
+					}
+					if !alreadyInOutput {
+						output = append(output, pipeline.FileInfo{
+							Path: assPath,
+							Type: pipeline.FileTypeOther,
+						})
+						assAdded[assPath] = true
+						ctx.Logger.Infof("delete_all 模式：关联字幕文件 %s", assPath)
+					}
+				}
+			}
+
+			// 删除全部文件（含中间产物）：用 Deletable 标记
 			for i := range output {
 				output[i].Deletable = true
+				if output[i].Metadata == nil {
+					output[i].Metadata = map[string]any{}
+				}
+				output[i].Metadata["delete_all"] = true
 			}
 			s.logs += fmt.Sprintf("全部上传成功，已标记 %d 个文件待删除（含中间产物）\n", len(output))
 			ctx.Logger.Infof("全部上传成功，已标记 %d 个文件待删除（含中间产物）", len(output))
 		} else if s.deleteAfter {
-			// 仅删除已上传的文件
+			// 仅删除已上传的文件：用 Metadata["uploaded"] 标记，不设 Deletable
 			count := 0
 			for i := range output {
 				if uploadedIndices[i] {
-					output[i].Deletable = true
+					if output[i].Metadata == nil {
+						output[i].Metadata = map[string]any{}
+					}
+					output[i].Metadata["uploaded"] = true
 					count++
 				}
 			}
@@ -299,8 +348,7 @@ func (s *CloudUploadStage) matchFileType(fileType pipeline.FileType) bool {
 }
 
 // renderTargetPath 渲染目标路径
-// multiVideo 为 true 时，若模板不含 .FileName 则自动追加，确保多分段文件路径唯一
-func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file pipeline.FileInfo, multiVideo bool) string {
+func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file pipeline.FileInfo) string {
 	if s.pathTemplate == "" {
 		// 默认路径：/录播归档/{平台}/{主播名}/{文件名}
 		return fmt.Sprintf("/录播归档/%s/%s/%s",
@@ -308,18 +356,6 @@ func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file 
 			ctx.RecordInfo.HostName,
 			filepath.Base(file.Path),
 		)
-	}
-
-	// 多视频场景下，若模板不含 .FileName 则自动追加以避免路径冲突
-	templateStr := s.pathTemplate
-	if multiVideo && !strings.Contains(templateStr, ".FileName") {
-		// 在模板末尾（扩展名之前）插入文件名
-		// 例如: /path/房间名-日期.{{ .Ext }} → /path/房间名-日期_{{ .FileName }}.{{ .Ext }}
-		templateStr = strings.TrimSuffix(templateStr, ".{{ .Ext }}") + "_{{ .FileName }}.{{ .Ext }}"
-		if !strings.Contains(templateStr, ".FileName") {
-			// 兜底：直接在末尾追加
-			templateStr = s.pathTemplate + "/{{ .FileName }}"
-		}
 	}
 
 	// 获取扩展名
@@ -367,7 +403,7 @@ func (s *CloudUploadStage) renderTargetPath(ctx *pipeline.PipelineContext, file 
 		},
 	}
 
-	tmpl, err := template.New("path").Funcs(funcMap).Parse(templateStr)
+	tmpl, err := template.New("path").Funcs(funcMap).Parse(s.pathTemplate)
 	if err != nil {
 		// 模板语法错误，返回空让调用方跳过上传，避免上传到错误路径
 		ctx.Logger.Errorf("上传路径模板解析失败: %v", err)

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -230,15 +230,9 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 		// 执行上传（带进度追踪）
 		fileName := filepath.Base(file.Path)
-		var lastPct float64
+		ctx.Logger.Infof("开始上传: %s -> %s/%s", fileName, s.storageName, targetPath)
 		err := client.Upload(ctx.Ctx, file.Path, fullRemotePath, func(p openlist.UploadProgress) {
-			// 每 10% 报告一次进度
-			if p.Percentage-lastPct >= 10 || p.Percentage >= 100 {
-				lastPct = p.Percentage
-				speedMB := float64(p.SpeedBytesPerSec) / 1024 / 1024
-				ctx.Logger.Infof("上传进度 [%s]: %.1f%% (%.1f MB/s, 剩余 %ds)",
-					fileName, p.Percentage, speedMB, p.EtaSeconds)
-			}
+			// 进度回调仅用于内部追踪，不打印日志
 		})
 
 		if err != nil {

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -92,25 +92,27 @@ func (s *ExtractCoverStage) GetLogs() string {
 
 // CloudUploadStage 云上传阶段
 type CloudUploadStage struct {
-	config       pipeline.StageConfig
-	storageName  string
-	pathTemplate string
-	deleteAfter  bool
-	uploadTiming string // immediate 或 after_process
-	fileTypes    []string // 过滤的文件类型，空表示所有
-	commands     []string
-	logs         string
+	config         pipeline.StageConfig
+	storageName    string
+	pathTemplate   string
+	deleteAfter    bool   // 仅删除已上传的文件
+	deleteAllAfter bool   // 删除全部文件（含中间产物）
+	uploadTiming   string // immediate 或 after_process
+	fileTypes      []string // 过滤的文件类型，空表示所有
+	commands       []string
+	logs           string
 }
 
 // NewCloudUploadStage 创建云上传阶段工厂
 func NewCloudUploadStage(config pipeline.StageConfig) (pipeline.Stage, error) {
 	return &CloudUploadStage{
-		config:       config,
-		storageName:  config.GetStringOption(pipeline.OptionStorage, ""),
-		pathTemplate: config.GetStringOption(pipeline.OptionPathTemplate, ""),
-		deleteAfter:  config.GetBoolOption(pipeline.OptionDeleteAfter, false),
-		uploadTiming: config.GetStringOption(pipeline.OptionUploadTiming, ""),
-		fileTypes:    config.GetStringSliceOption(pipeline.OptionFileTypes),
+		config:         config,
+		storageName:    config.GetStringOption(pipeline.OptionStorage, ""),
+		pathTemplate:   config.GetStringOption(pipeline.OptionPathTemplate, ""),
+		deleteAfter:    config.GetBoolOption(pipeline.OptionDeleteAfter, false),
+		deleteAllAfter: config.GetBoolOption(pipeline.OptionDeleteAllAfter, false),
+		uploadTiming:   config.GetStringOption(pipeline.OptionUploadTiming, ""),
+		fileTypes:      config.GetStringSliceOption(pipeline.OptionFileTypes),
 	}, nil
 }
 
@@ -156,12 +158,38 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 	}
 
 	var output []pipeline.FileInfo
+	var uploadFailed bool
+
+	// 清除所有输入文件的 Deletable 标记（防止数据库中残留的旧标记影响本次判断）
+	for i := range input {
+		input[i].Deletable = false
+	}
+
+	// 只上传第一个视频文件和封面文件，跳过中间产物
+	// Pipeline 阶段输出顺序保证：最终视频在最前面，中间文件在后面
+	videoUploaded := false
+	uploadedIndices := map[int]bool{} // 记录实际上传的文件在 output 中的索引
 
 	for _, file := range input {
+		// 跳过标记为待删除的中间文件（由其他阶段产出，不应上传）
+		if file.Deletable {
+			output = append(output, file)
+			continue
+		}
+
 		// 文件类型过滤
 		if len(s.fileTypes) > 0 && !s.matchFileType(file.Type) {
 			output = append(output, file)
 			continue
+		}
+
+		// 视频文件：只上传第一个（最终视频），跳过后续中间视频
+		if file.Type == pipeline.FileTypeVideo {
+			if videoUploaded {
+				output = append(output, file)
+				continue
+			}
+			videoUploaded = true
 		}
 
 		// 检查文件是否存在
@@ -175,6 +203,7 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 		if targetPath == "" {
 			s.logs += fmt.Sprintf("无法生成目标路径: %s\n", file.Path)
 			output = append(output, file)
+			uploadFailed = true
 			continue
 		}
 
@@ -217,27 +246,43 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 			ctx.Logger.Errorf("上传失败: %s - %v", file.Path, err)
 			// 上传失败，保留文件
 			output = append(output, file)
+			uploadFailed = true
 			continue
 		}
 
 		s.logs += fmt.Sprintf("上传成功: %s -> %s/%s\n", fileName, s.storageName, targetPath)
 		ctx.Logger.Infof("文件上传成功: %s -> %s/%s", fileName, s.storageName, targetPath)
+		uploadedIndices[len(output)] = true // 记录上传成功的文件索引
+		output = append(output, file)
+	}
 
-		// 立即上传模式：始终保留文件，后续阶段（修复/转换/烧录）会处理删除
-		// 后处理上传模式：如果配置了删除，则删除文件（此时已是最终文件）
-		if s.deleteAfter && s.uploadTiming != "immediate" {
-			if err := os.Remove(file.Path); err != nil {
-				// 删除失败，保留文件在输出中供后续阶段使用
-				s.logs += fmt.Sprintf("删除本地文件失败: %s - %s\n", fileName, err.Error())
-				ctx.Logger.Warnf("删除本地文件失败: %s - %v", file.Path, err)
-				output = append(output, file)
-			} else {
-				s.logs += fmt.Sprintf("已删除本地文件: %s\n", fileName)
+	// 全部上传成功后，根据配置标记文件为可删除（由 Executor 在管道全部成功后统一删除）
+	// 任意一个上传失败，则不标记任何文件，确保本地文件全部保留
+	if !uploadFailed && s.uploadTiming != "immediate" {
+		if s.deleteAllAfter {
+			// 删除全部文件（含中间产物）
+			for i := range output {
+				output[i].Deletable = true
 			}
-		} else {
-			// 保留文件在输出中
-			output = append(output, file)
+			s.logs += fmt.Sprintf("全部上传成功，已标记 %d 个文件待删除（含中间产物）\n", len(output))
+			ctx.Logger.Infof("全部上传成功，已标记 %d 个文件待删除（含中间产物）", len(output))
+		} else if s.deleteAfter {
+			// 仅删除已上传的文件
+			count := 0
+			for i := range output {
+				if uploadedIndices[i] {
+					output[i].Deletable = true
+					count++
+				}
+			}
+			s.logs += fmt.Sprintf("全部上传成功，已标记 %d 个已上传文件待删除\n", count)
+			ctx.Logger.Infof("全部上传成功，已标记 %d 个已上传文件待删除", count)
 		}
+	}
+
+	// 任意上传失败，返回错误（让 Executor 将任务标记为 failed）
+	if uploadFailed {
+		return output, fmt.Errorf("部分文件上传失败，详见日志")
 	}
 
 	return output, nil

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -2,7 +2,6 @@ package stages
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path"
@@ -139,10 +138,8 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 	// 获取配置并创建客户端
 	config := configs.GetCurrentConfig()
-	uploadCtx, cancel := context.WithTimeout(ctx.Ctx, 30*time.Minute)
-	defer cancel()
 
-	client, err := mgr.GetClient(uploadCtx, config.OpenList.Token, config.OpenList.Username, config.OpenList.Password)
+	client, err := mgr.GetClient(ctx.Ctx, config.OpenList.Token, config.OpenList.Username, config.OpenList.Password)
 	if err != nil {
 		s.logs += fmt.Sprintf("创建 OpenList 客户端失败: %s\n", err.Error())
 		return input, fmt.Errorf("创建 OpenList 客户端失败: %w", err)
@@ -197,7 +194,7 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 		// 使用 path.Dir 而非 filepath.Dir，因为远程路径始终用正斜杠
 		remoteDir := path.Dir(fullRemotePath)
 		if remoteDir != "" && remoteDir != "." {
-			if err := client.MkdirRecursive(uploadCtx, remoteDir); err != nil {
+			if err := client.MkdirRecursive(ctx.Ctx, remoteDir); err != nil {
 				ctx.Logger.Warnf("创建远程目录失败（可能已存在）: %s - %v", remoteDir, err)
 			}
 		}
@@ -205,7 +202,7 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 		// 执行上传（带进度追踪）
 		fileName := filepath.Base(file.Path)
 		var lastPct float64
-		err := client.Upload(uploadCtx, file.Path, fullRemotePath, func(p openlist.UploadProgress) {
+		err := client.Upload(ctx.Ctx, file.Path, fullRemotePath, func(p openlist.UploadProgress) {
 			// 每 10% 报告一次进度
 			if p.Percentage-lastPct >= 10 || p.Percentage >= 100 {
 				lastPct = p.Percentage

--- a/src/pipeline/types.go
+++ b/src/pipeline/types.go
@@ -33,6 +33,7 @@ type FileInfo struct {
 	Type       FileType       `json:"type"`                  // 文件类型
 	SourcePath string         `json:"source_path,omitempty"` // 来源文件路径（用于追踪转换链）
 	Metadata   map[string]any `json:"metadata,omitempty"`    // 额外元数据
+	Deletable  bool           `json:"deletable,omitempty"`   // 标记此文件在管道全部成功后可删除
 }
 
 // NewVideoFileInfo 创建视频文件信息

--- a/src/pkg/openlist/client.go
+++ b/src/pkg/openlist/client.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 )
 
 // encodePath 对路径的每个段分别编码，保留 / 分隔符
@@ -24,6 +26,7 @@ func encodePath(path string) string {
 // Client OpenList API 客户端
 type Client struct {
 	baseURL    string
+	mu         sync.RWMutex // 保护 token/username/password 的并发访问
 	token      string
 	username   string // 用于 token 刷新
 	password   string // 用于 token 刷新
@@ -43,40 +46,75 @@ func NewClient(baseURL, token string) *Client {
 
 // SetToken 设置 API Token
 func (c *Client) SetToken(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.token = token
 }
 
-// GetToken 获取当前 API Token
+// GetCurrentToken 获取当前 API Token
 func (c *Client) GetCurrentToken() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.token
 }
 
 // SetCredentials 设置用户名密码（用于 token 自动刷新）
 func (c *Client) SetCredentials(username, password string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.username = username
 	c.password = password
 }
 
+// getTokenForRequest 获取用于请求的 token 副本（内部使用）
+func (c *Client) getTokenForRequest() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token
+}
+
 // refreshToken 刷新 token
 func (c *Client) refreshToken(ctx context.Context) error {
-	if c.username == "" || c.password == "" {
+	c.mu.RLock()
+	username := c.username
+	password := c.password
+	c.mu.RUnlock()
+
+	if username == "" || password == "" {
 		return fmt.Errorf("无法刷新 token: 未配置用户名密码")
 	}
-	newToken, err := c.GetToken(ctx, c.username, c.password)
+	newToken, err := c.GetToken(ctx, username, password)
 	if err != nil {
 		return fmt.Errorf("刷新 token 失败: %w", err)
 	}
-	c.token = newToken
+	c.SetToken(newToken)
 	return nil
 }
 
-// isAuthError 判断是否为认证错误（HTTP 401/403）
+// APIError 表示 OpenList API 返回的结构化错误
+// 用于在 isAuthError 中识别认证失败（code 401/403）
+type APIError struct {
+	Code    int
+	Message string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API 错误 (code %d): %s", e.Code, e.Message)
+}
+
+// isAuthError 判断是否为认证错误
+// 匹配 HTTP 状态码 401/403 或 OpenList JSON code 401/403
 func isAuthError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// 检查结构化 API 错误
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == 401 || apiErr.Code == 403
+	}
+	// 兜底：检查错误文本中的 HTTP 状态码
 	s := err.Error()
-	// 匹配 "HTTP 401" 或 "HTTP 403" 格式，避免误匹配其他包含 401/403 的字符串
 	return strings.Contains(s, "HTTP 401") || strings.Contains(s, "HTTP 403")
 }
 
@@ -123,7 +161,7 @@ func (c *Client) doUpload(ctx context.Context, localPath, remotePath string, onP
 		return fmt.Errorf("创建请求失败: %w", err)
 	}
 
-	req.Header.Set("Authorization", c.token)
+	req.Header.Set("Authorization", c.getTokenForRequest())
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", totalSize))
 	// 对路径的每个段分别编码，保留 / 分隔符
@@ -148,12 +186,14 @@ func (c *Client) doUpload(ctx context.Context, localPath, remotePath string, onP
 		Message string `json:"message"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		// 响应不是 JSON 格式，可能是空响应（某些 API 成功时返回空 body）
-		// 由于 HTTP 状态码是 200，视为成功
-		return nil
+		// 仅空响应（io.EOF）视为成功，某些 API 成功时返回空 body
+		if err == io.EOF {
+			return nil
+		}
+		return fmt.Errorf("解析上传响应失败: %w", err)
 	}
 	if result.Code != 200 {
-		return fmt.Errorf("上传失败: %s", result.Message)
+		return fmt.Errorf("上传失败: %w", &APIError{Code: result.Code, Message: result.Message})
 	}
 
 	return nil
@@ -176,7 +216,7 @@ func (c *Client) ListStorages(ctx context.Context) ([]StorageInfo, error) {
 		if err != nil {
 			return err
 		}
-		req.Header.Set("Authorization", c.token)
+		req.Header.Set("Authorization", c.getTokenForRequest())
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
@@ -197,7 +237,7 @@ func (c *Client) ListStorages(ctx context.Context) ([]StorageInfo, error) {
 		}
 
 		if result.Code != 200 {
-			return fmt.Errorf("API 错误: %s", result.Message)
+			return fmt.Errorf("API 错误: %w", &APIError{Code: result.Code, Message: result.Message})
 		}
 
 		storages = result.Data.Content
@@ -218,7 +258,7 @@ func (c *Client) CheckStorageHealth(ctx context.Context, storageName string) err
 		if err != nil {
 			return err
 		}
-		req.Header.Set("Authorization", c.token)
+		req.Header.Set("Authorization", c.getTokenForRequest())
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := c.httpClient.Do(req)
@@ -237,7 +277,7 @@ func (c *Client) CheckStorageHealth(ctx context.Context, storageName string) err
 		}
 
 		if result.Code != 200 {
-			return fmt.Errorf("存储不可用: %s", result.Message)
+			return fmt.Errorf("存储不可用: %w", &APIError{Code: result.Code, Message: result.Message})
 		}
 
 		return nil
@@ -276,7 +316,7 @@ func (c *Client) GetToken(ctx context.Context, username, password string) (strin
 	}
 
 	if result.Code != 200 {
-		return "", fmt.Errorf("登录失败: %s", result.Message)
+		return "", fmt.Errorf("登录失败: %w", &APIError{Code: result.Code, Message: result.Message})
 	}
 
 	return result.Data.Token, nil
@@ -293,7 +333,7 @@ func (c *Client) Mkdir(ctx context.Context, remotePath string) error {
 		if err != nil {
 			return err
 		}
-		req.Header.Set("Authorization", c.token)
+		req.Header.Set("Authorization", c.getTokenForRequest())
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := c.httpClient.Do(req)
@@ -313,7 +353,7 @@ func (c *Client) Mkdir(ctx context.Context, remotePath string) error {
 
 		// 目录已存在也算成功
 		if result.Code != 200 && result.Message != "file exists" {
-			return fmt.Errorf("创建目录失败: %s", result.Message)
+			return fmt.Errorf("创建目录失败: %w", &APIError{Code: result.Code, Message: result.Message})
 		}
 
 		return nil

--- a/src/pkg/openlist/client.go
+++ b/src/pkg/openlist/client.go
@@ -186,10 +186,6 @@ func (c *Client) doUpload(ctx context.Context, localPath, remotePath string, onP
 		Message string `json:"message"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		// 仅空响应（io.EOF）视为成功，某些 API 成功时返回空 body
-		if err == io.EOF {
-			return nil
-		}
 		return fmt.Errorf("解析上传响应失败: %w", err)
 	}
 	if result.Code != 200 {

--- a/src/pkg/openlist/client.go
+++ b/src/pkg/openlist/client.go
@@ -9,12 +9,24 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 )
+
+// encodePath 对路径的每个段分别编码，保留 / 分隔符
+func encodePath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	return strings.Join(segments, "/")
+}
 
 // Client OpenList API 客户端
 type Client struct {
 	baseURL    string
 	token      string
+	username   string // 用于 token 刷新
+	password   string // 用于 token 刷新
 	httpClient *http.Client
 }
 
@@ -34,8 +46,60 @@ func (c *Client) SetToken(token string) {
 	c.token = token
 }
 
+// GetToken 获取当前 API Token
+func (c *Client) GetCurrentToken() string {
+	return c.token
+}
+
+// SetCredentials 设置用户名密码（用于 token 自动刷新）
+func (c *Client) SetCredentials(username, password string) {
+	c.username = username
+	c.password = password
+}
+
+// refreshToken 刷新 token
+func (c *Client) refreshToken(ctx context.Context) error {
+	if c.username == "" || c.password == "" {
+		return fmt.Errorf("无法刷新 token: 未配置用户名密码")
+	}
+	newToken, err := c.GetToken(ctx, c.username, c.password)
+	if err != nil {
+		return fmt.Errorf("刷新 token 失败: %w", err)
+	}
+	c.token = newToken
+	return nil
+}
+
+// isAuthError 判断是否为认证错误（HTTP 401/403）
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	// 匹配 "HTTP 401" 或 "HTTP 403" 格式，避免误匹配其他包含 401/403 的字符串
+	return strings.Contains(s, "HTTP 401") || strings.Contains(s, "HTTP 403")
+}
+
+// withRetry 执行 API 调用，遇到认证错误时自动刷新 token 重试
+func (c *Client) withRetry(ctx context.Context, fn func() error) error {
+	err := fn()
+	if isAuthError(err) {
+		if refreshErr := c.refreshToken(ctx); refreshErr == nil {
+			return fn()
+		}
+	}
+	return err
+}
+
 // Upload 上传文件（使用 PUT /api/fs/put）
 func (c *Client) Upload(ctx context.Context, localPath, remotePath string, onProgress func(UploadProgress)) error {
+	return c.withRetry(ctx, func() error {
+		return c.doUpload(ctx, localPath, remotePath, onProgress)
+	})
+}
+
+// doUpload 执行实际的上传操作
+func (c *Client) doUpload(ctx context.Context, localPath, remotePath string, onProgress func(UploadProgress)) error {
 	// 打开本地文件
 	file, err := os.Open(localPath)
 	if err != nil {
@@ -62,7 +126,8 @@ func (c *Client) Upload(ctx context.Context, localPath, remotePath string, onPro
 	req.Header.Set("Authorization", c.token)
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", totalSize))
-	req.Header.Set("File-Path", url.PathEscape(remotePath))
+	// 对路径的每个段分别编码，保留 / 分隔符
+	req.Header.Set("File-Path", encodePath(remotePath))
 	req.ContentLength = totalSize
 
 	// 发送请求
@@ -82,10 +147,13 @@ func (c *Client) Upload(ctx context.Context, localPath, remotePath string, onPro
 		Code    int    `json:"code"`
 		Message string `json:"message"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
-		if result.Code != 200 {
-			return fmt.Errorf("上传失败: %s", result.Message)
-		}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		// 响应不是 JSON 格式，可能是空响应（某些 API 成功时返回空 body）
+		// 由于 HTTP 状态码是 200，视为成功
+		return nil
+	}
+	if result.Code != 200 {
+		return fmt.Errorf("上传失败: %s", result.Message)
 	}
 
 	return nil
@@ -102,75 +170,88 @@ type StorageInfo struct {
 
 // ListStorages 列出所有存储
 func (c *Client) ListStorages(ctx context.Context) ([]StorageInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/admin/storage/list", nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", c.token)
+	var storages []StorageInfo
+	err := c.withRetry(ctx, func() error {
+		req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/admin/storage/list", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", c.token)
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("请求失败: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("请求失败: %w", err)
+		}
+		defer resp.Body.Close()
 
-	var result struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-		Data    struct {
-			Content []StorageInfo `json:"content"`
-		} `json:"data"`
-	}
+		var result struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    struct {
+				Content []StorageInfo `json:"content"`
+			} `json:"data"`
+		}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("解析响应失败: %w", err)
-	}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return fmt.Errorf("解析响应失败: %w", err)
+		}
 
-	if result.Code != 200 {
-		return nil, fmt.Errorf("API 错误: %s", result.Message)
-	}
+		if result.Code != 200 {
+			return fmt.Errorf("API 错误: %s", result.Message)
+		}
 
-	return result.Data.Content, nil
+		storages = result.Data.Content
+		return nil
+	})
+	return storages, err
 }
 
 // CheckStorageHealth 检查存储健康状态
 func (c *Client) CheckStorageHealth(ctx context.Context, storageName string) error {
-	body := fmt.Sprintf(`{"path":"/%s","refresh":true}`, storageName)
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/fs/list",
-		bytes.NewReader([]byte(body)))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", c.token)
-	req.Header.Set("Content-Type", "application/json")
+	return c.withRetry(ctx, func() error {
+		body, _ := json.Marshal(map[string]interface{}{
+			"path":    "/" + storageName,
+			"refresh": true,
+		})
+		req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/fs/list",
+			bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", c.token)
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("存储连接失败: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("存储连接失败: %w", err)
+		}
+		defer resp.Body.Close()
 
-	var result struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
+		var result struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("解析响应失败: %w", err)
-	}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return fmt.Errorf("解析响应失败: %w", err)
+		}
 
-	if result.Code != 200 {
-		return fmt.Errorf("存储不可用: %s", result.Message)
-	}
+		if result.Code != 200 {
+			return fmt.Errorf("存储不可用: %s", result.Message)
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // GetToken 获取管理员 Token（通过登录）
 func (c *Client) GetToken(ctx context.Context, username, password string) (string, error) {
-	body := fmt.Sprintf(`{"username":"%s","password":"%s"}`, username, password)
+	body, _ := json.Marshal(map[string]string{
+		"username": username,
+		"password": password,
+	})
 	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/auth/login",
-		bytes.NewReader([]byte(body)))
+		bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}
@@ -203,33 +284,66 @@ func (c *Client) GetToken(ctx context.Context, username, password string) (strin
 
 // Mkdir 创建目录
 func (c *Client) Mkdir(ctx context.Context, remotePath string) error {
-	body := fmt.Sprintf(`{"path":"%s"}`, remotePath)
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/fs/mkdir",
-		bytes.NewReader([]byte(body)))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", c.token)
-	req.Header.Set("Content-Type", "application/json")
+	return c.withRetry(ctx, func() error {
+		body, _ := json.Marshal(map[string]string{
+			"path": remotePath,
+		})
+		req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/fs/mkdir",
+			bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", c.token)
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("请求失败: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("请求失败: %w", err)
+		}
+		defer resp.Body.Close()
 
-	var result struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
+		var result struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return fmt.Errorf("解析响应失败: %w", err)
+		}
+
+		// 目录已存在也算成功
+		if result.Code != 200 && result.Message != "file exists" {
+			return fmt.Errorf("创建目录失败: %s", result.Message)
+		}
+
+		return nil
+	})
+}
+
+// MkdirRecursive 递归创建目录
+func (c *Client) MkdirRecursive(ctx context.Context, remotePath string) error {
+	// 标准化路径
+	remotePath = strings.ReplaceAll(remotePath, "\\", "/")
+	if remotePath == "" || remotePath == "/" {
+		return nil
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("解析响应失败: %w", err)
+	// 分割路径
+	parts := strings.Split(strings.Trim(remotePath, "/"), "/")
+	if len(parts) == 0 {
+		return nil
 	}
 
-	// 目录已存在也算成功
-	if result.Code != 200 && result.Message != "file exists" {
-		return fmt.Errorf("创建目录失败: %s", result.Message)
+	// 逐级创建目录
+	currentPath := ""
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		currentPath += "/" + part
+		if err := c.Mkdir(ctx, currentPath); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/src/pkg/openlist/manager.go
+++ b/src/pkg/openlist/manager.go
@@ -2,20 +2,44 @@
 package openlist
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/bililive-go/bililive-go/src/configs"
+	bililiveTools "github.com/bililive-go/bililive-go/src/tools"
 	bilisentry "github.com/bililive-go/bililive-go/src/pkg/sentry"
 	"github.com/kira1928/remotetools/pkg/tools"
 	"github.com/kira1928/remotetools/pkg/webui"
 	"github.com/sirupsen/logrus"
 )
+
+// 全局 OpenList 管理器（供 pipeline 等组件使用）
+var (
+	globalManager *Manager
+	globalMu      sync.RWMutex
+)
+
+// SetGlobalManager 设置全局 OpenList 管理器
+func SetGlobalManager(m *Manager) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	globalManager = m
+}
+
+// GetGlobalManager 获取全局 OpenList 管理器
+func GetGlobalManager() *Manager {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalManager
+}
 
 // Manager OpenList 进程管理器
 type Manager struct {
@@ -23,6 +47,7 @@ type Manager struct {
 	port        int
 	apiEndpoint string
 	process     *exec.Cmd
+	logFile     *os.File // 日志文件句柄，用于关闭时释放
 
 	mu      sync.Mutex
 	running bool
@@ -50,6 +75,11 @@ func (m *Manager) Start(ctx context.Context) error {
 		return nil
 	}
 
+	// 0. 等待 remotetools 初始化完成
+	if err := bililiveTools.WaitForToolsInit(ctx); err != nil {
+		return fmt.Errorf("等待 remotetools 初始化失败: %w", err)
+	}
+
 	// 1. 获取 remotetools API
 	api := tools.Get()
 	if api == nil {
@@ -75,6 +105,15 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("无法获取 OpenList 可执行文件路径")
 	}
 
+	// 转换为绝对路径（remotetools 返回的可能是相对路径）
+	if !filepath.IsAbs(toolPath) {
+		absPath, err := filepath.Abs(toolPath)
+		if err != nil {
+			return fmt.Errorf("转换绝对路径失败: %w", err)
+		}
+		toolPath = absPath
+	}
+
 	// 4. 确保数据目录存在
 	if err := os.MkdirAll(m.dataPath, 0755); err != nil {
 		return fmt.Errorf("创建数据目录失败: %w", err)
@@ -92,8 +131,11 @@ func (m *Manager) Start(ctx context.Context) error {
 	// 设置输出
 	logFile := filepath.Join(m.dataPath, "openlist.log")
 	if f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+		m.logFile = f
 		m.process.Stdout = f
 		m.process.Stderr = f
+	} else {
+		logrus.WithError(err).Warn("无法打开 OpenList 日志文件")
 	}
 
 	if err := m.process.Start(); err != nil {
@@ -108,14 +150,17 @@ func (m *Manager) Start(ctx context.Context) error {
 		return err
 	}
 
-	// 7. 注册反向代理
+	// 7. 检查是否首次启动，如果是则从日志中读取初始密码并保存到配置
+	m.saveInitialCredentials(logFile)
+
+	// 8. 注册反向代理
 	if err := webui.RegisterToolWebUI("openlist", m.apiEndpoint); err != nil {
 		logrus.WithError(err).Warn("注册 OpenList Web UI 代理失败")
 	}
 
 	logrus.WithField("port", m.port).Info("OpenList 已启动")
 
-	// 8. 监控进程
+	// 9. 监控进程
 	bilisentry.Go(m.watchProcess)
 
 	return nil
@@ -143,6 +188,52 @@ func (m *Manager) waitForReady(ctx context.Context, timeout time.Duration) error
 		time.Sleep(500 * time.Millisecond)
 	}
 	return fmt.Errorf("OpenList 服务启动超时")
+}
+
+// saveInitialCredentials 从日志中读取首次启动的初始密码并保存到配置
+func (m *Manager) saveInitialCredentials(logFile string) {
+	config := configs.GetCurrentConfig()
+	if config == nil {
+		return
+	}
+
+	// 如果已经配置了用户名密码，跳过
+	if config.OpenList.Username != "" && config.OpenList.Password != "" {
+		return
+	}
+
+	// 读取日志文件查找初始密码
+	file, err := os.Open(logFile)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	var initialPassword string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "initial password is:") {
+			// 格式: "Successfully created the admin user and the initial password is: xxx"
+			parts := strings.Split(line, "initial password is:")
+			if len(parts) == 2 {
+				initialPassword = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	if initialPassword == "" {
+		return
+	}
+
+	// 保存到配置
+	config.OpenList.Username = "admin"
+	config.OpenList.Password = initialPassword
+	if err := config.Marshal(); err != nil {
+		logrus.WithError(err).Warn("保存 OpenList 初始密码到配置文件失败")
+	} else {
+		logrus.Info("OpenList 首次启动，初始密码已保存到配置文件")
+	}
 }
 
 // watchProcess 监控进程状态
@@ -191,6 +282,12 @@ func (m *Manager) stopInternal() error {
 		m.process.Process.Kill()
 	}
 
+	// 关闭日志文件句柄
+	if m.logFile != nil {
+		m.logFile.Close()
+		m.logFile = nil
+	}
+
 	m.running = false
 	logrus.Info("OpenList 已停止")
 	return nil
@@ -221,4 +318,48 @@ func (m *Manager) GetPort() int {
 // GetDataPath 获取数据目录
 func (m *Manager) GetDataPath() string {
 	return m.dataPath
+}
+
+// GetClient 获取已认证的 API 客户端
+// 如果提供了 token，直接使用；否则使用用户名密码登录获取 token
+func (m *Manager) GetClient(ctx context.Context, token, username, password string) (*Client, error) {
+	client := NewClient(m.apiEndpoint, "")
+
+	// 设置凭据（用于 token 自动刷新）
+	if username != "" && password != "" {
+		client.SetCredentials(username, password)
+	}
+
+	// 有 token 时，验证其有效性
+	if token != "" {
+		client.SetToken(token)
+		// 尝试用 token 调用一个轻量 API 验证有效性
+		if _, err := client.ListStorages(ctx); err != nil {
+			// token 无效，尝试用密码重新登录
+			if username != "" && password != "" {
+				logrus.Warn("配置的 OpenList token 无效，尝试用用户名密码重新登录")
+				newToken, loginErr := client.GetToken(ctx, username, password)
+				if loginErr != nil {
+					return nil, fmt.Errorf("OpenList token 无效且登录失败: %w", loginErr)
+				}
+				client.SetToken(newToken)
+				return client, nil
+			}
+			return nil, fmt.Errorf("OpenList token 无效且未配置用户名密码")
+		}
+		return client, nil
+	}
+
+	// 无 token，使用用户名密码登录
+	if username != "" && password != "" {
+		newToken, err := client.GetToken(ctx, username, password)
+		if err != nil {
+			return nil, fmt.Errorf("OpenList 登录失败: %w", err)
+		}
+		client.SetToken(newToken)
+		return client, nil
+	}
+
+	// 无凭据，返回无 token 的客户端（部分 API 可能不需要认证）
+	return client, nil
 }

--- a/src/pkg/openlist/manager.go
+++ b/src/pkg/openlist/manager.go
@@ -227,9 +227,11 @@ func (m *Manager) saveInitialCredentials(logFile string) {
 	}
 
 	// 保存到配置
-	config.OpenList.Username = "admin"
-	config.OpenList.Password = initialPassword
-	if err := config.Marshal(); err != nil {
+	if _, err := configs.UpdateWithRetry(func(c *configs.Config) error {
+		c.OpenList.Username = "admin"
+		c.OpenList.Password = initialPassword
+		return nil
+	}, 3, 10*time.Millisecond); err != nil {
 		logrus.WithError(err).Warn("保存 OpenList 初始密码到配置文件失败")
 	} else {
 		logrus.Info("OpenList 首次启动，初始密码已保存到配置文件")

--- a/src/pkg/openlist/manager.go
+++ b/src/pkg/openlist/manager.go
@@ -266,10 +266,16 @@ func (m *Manager) watchProcess() {
 
 	select {
 	case <-m.stopCh:
-		// 正常停止
+		// 正常停止（stopInternal 已负责关闭 m.logFile）
 	default:
-		// 异常退出
+		// 异常退出：关闭日志文件句柄，避免 fd 泄漏
 		if wasRunning {
+			m.mu.Lock()
+			if m.logFile != nil {
+				m.logFile.Close()
+				m.logFile = nil
+			}
+			m.mu.Unlock()
 			logrus.WithError(err).Warn("OpenList 进程异常退出")
 		}
 	}

--- a/src/pkg/openlist/manager.go
+++ b/src/pkg/openlist/manager.go
@@ -34,6 +34,19 @@ func SetGlobalManager(m *Manager) {
 	globalManager = m
 }
 
+// ClearGlobalManagerIf 仅当全局管理器等于 expected 时才清除（CAS 语义）
+// 用于异步清理路径，避免误清已被新实例替换的管理器
+// 返回是否成功清除
+func ClearGlobalManagerIf(expected *Manager) bool {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	if globalManager == expected {
+		globalManager = nil
+		return true
+	}
+	return false
+}
+
 // GetGlobalManager 获取全局 OpenList 管理器
 func GetGlobalManager() *Manager {
 	globalMu.RLock()

--- a/src/pkg/openlist/manager.go
+++ b/src/pkg/openlist/manager.go
@@ -197,9 +197,14 @@ func (m *Manager) saveInitialCredentials(logFile string) {
 		return
 	}
 
-	// 如果已经配置了用户名密码，跳过
+	// 如果已经配置了用户名密码，验证有效性
 	if config.OpenList.Username != "" && config.OpenList.Password != "" {
-		return
+		// 用现有凭据尝试登录，验证是否有效
+		testClient := NewClient(m.apiEndpoint, "")
+		if _, err := testClient.GetToken(context.Background(), config.OpenList.Username, config.OpenList.Password); err == nil {
+			return // 凭据有效，无需更新
+		}
+		// 凭据无效（如占位值 root/root），继续从日志读取真实密码
 	}
 
 	// 读取日志文件查找初始密码
@@ -228,7 +233,7 @@ func (m *Manager) saveInitialCredentials(logFile string) {
 
 	// 验证密码有效性：日志是追加模式，旧密码可能已被用户修改
 	// 只有实际能登录时才保存
-	client := NewClient(fmt.Sprintf("http://127.0.0.1:%d", m.port), "")
+	client := NewClient(m.apiEndpoint, "")
 	if _, err := client.GetToken(context.Background(), "admin", initialPassword); err != nil {
 		logrus.WithError(err).Debug("初始密码验证失败，跳过保存（可能已被修改）")
 		return

--- a/src/pkg/openlist/manager.go
+++ b/src/pkg/openlist/manager.go
@@ -226,6 +226,14 @@ func (m *Manager) saveInitialCredentials(logFile string) {
 		return
 	}
 
+	// 验证密码有效性：日志是追加模式，旧密码可能已被用户修改
+	// 只有实际能登录时才保存
+	client := NewClient(fmt.Sprintf("http://127.0.0.1:%d", m.port), "")
+	if _, err := client.GetToken(context.Background(), "admin", initialPassword); err != nil {
+		logrus.WithError(err).Debug("初始密码验证失败，跳过保存（可能已被修改）")
+		return
+	}
+
 	// 保存到配置
 	if _, err := configs.UpdateWithRetry(func(c *configs.Config) error {
 		c.OpenList.Username = "admin"
@@ -324,6 +332,7 @@ func (m *Manager) GetDataPath() string {
 
 // GetClient 获取已认证的 API 客户端
 // 如果提供了 token，直接使用；否则使用用户名密码登录获取 token
+// token 有效性由 withRetry 在实际 API 调用时自动处理（401/403 时自动刷新）
 func (m *Manager) GetClient(ctx context.Context, token, username, password string) (*Client, error) {
 	client := NewClient(m.apiEndpoint, "")
 
@@ -332,23 +341,10 @@ func (m *Manager) GetClient(ctx context.Context, token, username, password strin
 		client.SetCredentials(username, password)
 	}
 
-	// 有 token 时，验证其有效性
+	// 有 token 时直接使用，不预验证（避免需要管理员权限的 API 调用）
+	// withRetry 会在实际调用遇到 401/403 时自动用密码刷新 token
 	if token != "" {
 		client.SetToken(token)
-		// 尝试用 token 调用一个轻量 API 验证有效性
-		if _, err := client.ListStorages(ctx); err != nil {
-			// token 无效，尝试用密码重新登录
-			if username != "" && password != "" {
-				logrus.Warn("配置的 OpenList token 无效，尝试用用户名密码重新登录")
-				newToken, loginErr := client.GetToken(ctx, username, password)
-				if loginErr != nil {
-					return nil, fmt.Errorf("OpenList token 无效且登录失败: %w", loginErr)
-				}
-				client.SetToken(newToken)
-				return client, nil
-			}
-			return nil, fmt.Errorf("OpenList token 无效且未配置用户名密码")
-		}
 		return client, nil
 	}
 

--- a/src/pkg/openlist/progress.go
+++ b/src/pkg/openlist/progress.go
@@ -3,6 +3,7 @@ package openlist
 import (
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -53,7 +54,7 @@ func NewProgressReader(reader io.Reader, total int64, onProgress func(UploadProg
 func (pr *ProgressReader) Read(p []byte) (n int, err error) {
 	n, err = pr.reader.Read(p)
 	if n > 0 {
-		pr.uploaded += int64(n)
+		atomic.AddInt64(&pr.uploaded, int64(n))
 		pr.addSample(int64(n))
 		pr.maybeReport()
 	}
@@ -102,7 +103,8 @@ func (pr *ProgressReader) maybeReport() {
 	}
 
 	now := time.Now()
-	if now.Sub(pr.lastReport) < pr.reportInterval && pr.uploaded < pr.total {
+	uploaded := atomic.LoadInt64(&pr.uploaded)
+	if now.Sub(pr.lastReport) < pr.reportInterval && uploaded < pr.total {
 		return
 	}
 	pr.lastReport = now
@@ -110,12 +112,12 @@ func (pr *ProgressReader) maybeReport() {
 	elapsed := now.Sub(pr.startTime).Seconds()
 	var avgSpeed int64
 	if elapsed > 0 {
-		avgSpeed = int64(float64(pr.uploaded) / elapsed)
+		avgSpeed = int64(float64(uploaded) / elapsed)
 	}
 
 	instantSpeed := pr.calculateInstantSpeed()
 
-	remaining := pr.total - pr.uploaded
+	remaining := pr.total - uploaded
 	var eta int64
 	if avgSpeed > 0 {
 		eta = remaining / avgSpeed
@@ -123,11 +125,11 @@ func (pr *ProgressReader) maybeReport() {
 
 	var percentage float64
 	if pr.total > 0 {
-		percentage = float64(pr.uploaded) / float64(pr.total) * 100
+		percentage = float64(uploaded) / float64(pr.total) * 100
 	}
 
 	pr.onProgress(UploadProgress{
-		BytesUploaded:       pr.uploaded,
+		BytesUploaded:       uploaded,
 		TotalBytes:          pr.total,
 		SpeedBytesPerSec:    instantSpeed,
 		AvgSpeedBytesPerSec: avgSpeed,

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -787,7 +787,12 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		if err := pipelineManager.EnqueueRecordingTask(info, pipelineConfig, outputFiles); err != nil {
 			r.getLogger().WithError(err).Error("failed to enqueue pipeline task")
 		} else {
-			r.getLogger().Infof("pipeline task enqueued: %d files, %d stages", len(outputFiles), len(pipelineConfig.Stages))
+			// 记录 Pipeline 阶段顺序
+			var stageNames []string
+			for _, stage := range pipelineConfig.Stages {
+				stageNames = append(stageNames, stage.Name)
+			}
+			r.getLogger().Infof("pipeline task enqueued: %d files, stages: %s", len(outputFiles), stageNames)
 		}
 	}
 }

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -792,7 +792,7 @@ func (r *recorder) tryRecord(ctx context.Context) {
 			for _, stage := range pipelineConfig.Stages {
 				stageNames = append(stageNames, stage.Name)
 			}
-			r.getLogger().Infof("pipeline task enqueued: %d files, stages: %s", len(outputFiles), stageNames)
+			r.getLogger().Infof("pipeline task enqueued: %d files, stages: %v", len(outputFiles), stageNames)
 		}
 	}
 }

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -1723,6 +1723,9 @@ func applyConfigUpdates(c *configs.Config, updates map[string]interface{}) error
 			if deleteAfter, ok := cloudUpload["delete_after_upload"].(bool); ok {
 				c.OnRecordFinished.CloudUpload.DeleteAfterUpload = deleteAfter
 			}
+			if deleteAllAfter, ok := cloudUpload["delete_all_after_upload"].(bool); ok {
+				c.OnRecordFinished.CloudUpload.DeleteAllAfterUpload = deleteAllAfter
+			}
 		}
 		// 处理上传时机
 		if uploadTiming, ok := orf["upload_timing"].(string); ok {

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -1709,6 +1709,25 @@ func applyConfigUpdates(c *configs.Config, updates map[string]interface{}) error
 		if deleteSource, ok := orf["burn_delete_source"].(bool); ok {
 			c.OnRecordFinished.BurnDeleteSource = deleteSource
 		}
+		// 处理云上传配置
+		if cloudUpload, ok := orf["cloud_upload"].(map[string]interface{}); ok {
+			if enable, ok := cloudUpload["enable"].(bool); ok {
+				c.OnRecordFinished.CloudUpload.Enable = enable
+			}
+			if storageName, ok := cloudUpload["storage_name"].(string); ok {
+				c.OnRecordFinished.CloudUpload.StorageName = storageName
+			}
+			if uploadPathTmpl, ok := cloudUpload["upload_path_tmpl"].(string); ok {
+				c.OnRecordFinished.CloudUpload.UploadPathTmpl = uploadPathTmpl
+			}
+			if deleteAfter, ok := cloudUpload["delete_after_upload"].(bool); ok {
+				c.OnRecordFinished.CloudUpload.DeleteAfterUpload = deleteAfter
+			}
+		}
+		// 处理上传时机
+		if uploadTiming, ok := orf["upload_timing"].(string); ok {
+			c.OnRecordFinished.UploadTiming = configs.UploadTiming(uploadTiming)
+		}
 	}
 
 	// 处理通知配置
@@ -1846,6 +1865,25 @@ func applyConfigUpdates(c *configs.Config, updates map[string]interface{}) error
 		}
 		if includePrerelease, ok := update["include_prerelease"].(bool); ok {
 			c.Update.IncludePrerelease = includePrerelease
+		}
+	}
+
+	// 处理 OpenList 配置
+	if openlistCfg, ok := updates["openlist"].(map[string]interface{}); ok {
+		if port, ok := openlistCfg["port"].(float64); ok {
+			c.OpenList.Port = int(port)
+		}
+		if dataPath, ok := openlistCfg["data_path"].(string); ok {
+			c.OpenList.DataPath = dataPath
+		}
+		if username, ok := openlistCfg["username"].(string); ok {
+			c.OpenList.Username = username
+		}
+		if password, ok := openlistCfg["password"].(string); ok {
+			c.OpenList.Password = password
+		}
+		if token, ok := openlistCfg["token"].(string); ok {
+			c.OpenList.Token = token
 		}
 	}
 

--- a/src/servers/openlist_handler.go
+++ b/src/servers/openlist_handler.go
@@ -25,12 +25,9 @@ type OpenListStorageHealthResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
-// 全局 OpenList 管理器引用（由 main 设置）
-var globalOpenListManager *openlist.Manager
-
-// SetOpenListManager 设置全局 OpenList 管理器
+// SetOpenListManager 设置全局 OpenList 管理器（保留兼容性，实际设置到 openlist 包）
 func SetOpenListManager(m *openlist.Manager) {
-	globalOpenListManager = m
+	openlist.SetGlobalManager(m)
 }
 
 // getOpenListStatus 获取 OpenList 状态
@@ -45,7 +42,8 @@ func getOpenListStatus(writer http.ResponseWriter, r *http.Request) {
 	}
 
 	// 检查 OpenList 管理器是否存在
-	if globalOpenListManager == nil {
+	mgr := openlist.GetGlobalManager()
+	if mgr == nil {
 		if config.OnRecordFinished.CloudUpload.Enable {
 			response.Errors = append(response.Errors, "OpenList 管理器未初始化")
 		}
@@ -55,7 +53,7 @@ func getOpenListStatus(writer http.ResponseWriter, r *http.Request) {
 	}
 
 	// 检查 OpenList 是否运行
-	response.OpenListRunning = globalOpenListManager.IsRunning()
+	response.OpenListRunning = mgr.IsRunning()
 
 	if !response.OpenListRunning {
 		response.Errors = append(response.Errors, "OpenList 服务未运行")
@@ -64,10 +62,17 @@ func getOpenListStatus(writer http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 尝试获取存储列表
-	client := openlist.NewClient(globalOpenListManager.GetAPIEndpoint(), "")
+	// 使用凭据创建客户端
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
+
+	client, err := mgr.GetClient(ctx, config.OpenList.Token, config.OpenList.Username, config.OpenList.Password)
+	if err != nil {
+		response.Errors = append(response.Errors, "创建 OpenList 客户端失败: "+err.Error())
+		writer.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(writer).Encode(response)
+		return
+	}
 
 	storages, err := client.ListStorages(ctx)
 	if err != nil {
@@ -95,16 +100,25 @@ func checkOpenListStorageHealth(writer http.ResponseWriter, r *http.Request) {
 		Healthy: false,
 	}
 
-	if globalOpenListManager == nil || !globalOpenListManager.IsRunning() {
+	mgr := openlist.GetGlobalManager()
+	if mgr == nil || !mgr.IsRunning() {
 		response.Message = "OpenList 服务未运行"
 		writer.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(writer).Encode(response)
 		return
 	}
 
-	client := openlist.NewClient(globalOpenListManager.GetAPIEndpoint(), "")
+	config := configs.GetCurrentConfig()
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
+
+	client, err := mgr.GetClient(ctx, config.OpenList.Token, config.OpenList.Username, config.OpenList.Password)
+	if err != nil {
+		response.Message = "创建 OpenList 客户端失败: " + err.Error()
+		writer.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(writer).Encode(response)
+		return
+	}
 
 	if err := client.CheckStorageHealth(ctx, storageName); err != nil {
 		response.Message = err.Error()

--- a/src/servers/pipeline_handler.go
+++ b/src/servers/pipeline_handler.go
@@ -165,6 +165,8 @@ func makePipelineCancelTaskHandler(pm *pipeline.Manager) http.HandlerFunc {
 }
 
 // makePipelineRetryTaskHandler 重试任务
+// 支持可选的 JSON body: {"stage_name": "cloud_upload"}
+// 无 body 或 stage_name 为空时全量重试
 func makePipelineRetryTaskHandler(pm *pipeline.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -174,9 +176,27 @@ func makePipelineRetryTaskHandler(pm *pipeline.Manager) http.HandlerFunc {
 			return
 		}
 
-		if err := pm.RetryTask(id); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+		// 解析可选的 JSON body
+		var reqBody struct {
+			StageName string `json:"stage_name"`
+		}
+		if r.Body != nil {
+			// 尝试解析 body，失败不影响（向后兼容无 body 的情况）
+			json.NewDecoder(r.Body).Decode(&reqBody)
+		}
+
+		if reqBody.StageName != "" {
+			// 从指定阶段重试
+			if err := pm.RetryTaskFromStage(id, reqBody.StageName); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			// 全量重试（向后兼容）
+			if err := pm.RetryTask(id); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/src/servers/pipeline_handler.go
+++ b/src/servers/pipeline_handler.go
@@ -2,6 +2,7 @@ package servers
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -181,8 +182,10 @@ func makePipelineRetryTaskHandler(pm *pipeline.Manager) http.HandlerFunc {
 			StageName string `json:"stage_name"`
 		}
 		if r.Body != nil {
-			// 尝试解析 body，失败不影响（向后兼容无 body 的情况）
-			json.NewDecoder(r.Body).Decode(&reqBody)
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil && err != io.EOF {
+				http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 
 		if reqBody.StageName != "" {

--- a/src/tools/remote-tools-config.json
+++ b/src/tools/remote-tools-config.json
@@ -189,36 +189,36 @@
     }
   },
   "openlist": {
-    "v4.1.9": {
+    "v4.2.4": {
       "downloadUrl": {
         "darwin": {
           "amd64": [
-            "https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-darwin-amd64.tar.gz",
-            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-darwin-amd64.tar.gz"
+            "https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-darwin-amd64.tar.gz",
+            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-darwin-amd64.tar.gz"
           ],
           "arm64": [
-            "https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-darwin-arm64.tar.gz",
-            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-darwin-arm64.tar.gz"
+            "https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-darwin-arm64.tar.gz",
+            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-darwin-arm64.tar.gz"
           ]
         },
         "linux": {
           "amd64": [
-            "https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-linux-amd64.tar.gz",
-            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-linux-amd64.tar.gz"
+            "https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-linux-amd64.tar.gz",
+            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-linux-amd64.tar.gz"
           ],
           "arm64": [
-            "https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-linux-arm64.tar.gz",
-            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-linux-arm64.tar.gz"
+            "https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-linux-arm64.tar.gz",
+            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-linux-arm64.tar.gz"
           ],
           "arm": [
-            "https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-linux-armv7.tar.gz",
-            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-linux-armv7.tar.gz"
+            "https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-linux-arm-7.tar.gz",
+            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-linux-arm-7.tar.gz"
           ]
         },
         "windows": {
           "amd64": [
-            "https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-windows-amd64.zip",
-            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.1.9/openlist-windows-amd64.zip"
+            "https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-windows-amd64.zip",
+            "https://bililive-go.com/remotetools/download?downloadurl=https://github.com/OpenListTeam/OpenList/releases/download/v4.2.4/openlist-windows-amd64.zip"
           ]
         }
       },

--- a/src/webapp/src/component/TemplateBuilder.tsx
+++ b/src/webapp/src/component/TemplateBuilder.tsx
@@ -1,0 +1,378 @@
+import React, { useState, useMemo } from 'react';
+import { Form, Input, Tag, Space, Tooltip } from 'antd';
+import { FolderOutlined, FileOutlined } from '@ant-design/icons';
+
+const { TextArea } = Input;
+
+// 变量定义
+export interface TemplateVariable {
+  key: string;
+  label: string;
+  example: string;
+  template: string;
+}
+
+// 预设模板定义
+export interface PresetTemplate {
+  name: string;
+  description: string;
+  template: string;
+}
+
+// 模拟数据（用于预览）
+export interface MockStream {
+  platform: string;
+  platformCN: string;
+  hostName: string;
+  rooms: Array<{
+    roomName: string;
+    date: string;
+    time: string;
+  }>;
+}
+
+// 目录树节点
+interface TreeNode {
+  name: string;
+  isFile: boolean;
+  children?: TreeNode[];
+}
+
+// 构建目录树
+const buildTree = (paths: string[]): TreeNode => {
+  const root: TreeNode = { name: '/', isFile: false, children: [] };
+
+  for (const path of paths) {
+    const parts = path.split('/').filter(Boolean);
+    let current = root;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const isFile = i === parts.length - 1;
+
+      if (!current.children) {
+        current.children = [];
+      }
+
+      let existing = current.children.find((c) => c.name === part);
+      if (!existing) {
+        existing = { name: part, isFile, children: isFile ? undefined : [] };
+        current.children.push(existing);
+      }
+
+      if (!isFile) {
+        current = existing;
+      }
+    }
+  }
+
+  // 排序：文件夹在前，文件在后
+  const sortNodes = (node: TreeNode) => {
+    if (node.children) {
+      node.children.sort((a, b) => {
+        if (a.isFile !== b.isFile) return a.isFile ? 1 : -1;
+        return a.name.localeCompare(b.name);
+      });
+      node.children.forEach(sortNodes);
+    }
+  };
+  sortNodes(root);
+
+  return root;
+};
+
+// 渲染目录树节点
+const TreeNodeComponent: React.FC<{ node: TreeNode; depth: number; maxDepth?: number }> = ({
+  node,
+  depth,
+  maxDepth = 4,
+}) => {
+  if (depth > maxDepth) return null;
+
+  const indent = depth * 20;
+  const isFolder = !node.isFile;
+
+  return (
+    <div>
+      <div
+        style={{
+          paddingLeft: indent,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          lineHeight: '22px',
+          fontSize: 13,
+        }}
+      >
+        {isFolder ? (
+          <FolderOutlined style={{ color: '#faad14', fontSize: 14 }} />
+        ) : (
+          <FileOutlined style={{ color: '#1890ff', fontSize: 14 }} />
+        )}
+        <span style={{ color: isFolder ? '#333' : '#666' }}>{node.name}</span>
+      </div>
+      {isFolder && node.children && depth < maxDepth && (
+        <div>
+          {node.children.map((child, index) => (
+            <TreeNodeComponent key={index} node={child} depth={depth + 1} maxDepth={maxDepth} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// 目录树预览组件
+const DirectoryTreePreview: React.FC<{ paths: string[]; streamCount: number }> = ({ paths, streamCount }) => {
+  const tree = useMemo(() => buildTree(paths), [paths]);
+
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        padding: '12px 16px',
+        background: '#fafafa',
+        borderRadius: 6,
+        border: '1px solid #e8e8e8',
+        maxHeight: 300,
+        overflow: 'auto',
+      }}
+    >
+      <div style={{ fontSize: 12, color: '#666', marginBottom: 8 }}>
+        📁 目录结构预览（含 {streamCount} 位主播的示例录制）
+      </div>
+      <TreeNodeComponent node={tree} depth={0} maxDepth={4} />
+    </div>
+  );
+};
+
+// 检查变量是否应该被禁用（互斥规则）
+const isVariableDisabled = (variable: TemplateVariable, currentTemplate: string): { disabled: boolean; reason?: string } => {
+  if (!currentTemplate) return { disabled: false };
+
+  // 互斥规则：FileName 和 Ext 不能同时使用
+  if (variable.key === 'FileName') {
+    if (currentTemplate.includes('{{ .Ext }}') || currentTemplate.includes('{{.Ext}}')) {
+      return { disabled: true, reason: '已使用「扩展名」，文件名已包含扩展名' };
+    }
+  }
+  if (variable.key === 'Ext') {
+    if (currentTemplate.includes('{{ .FileName }}') || currentTemplate.includes('{{.FileName}}')) {
+      return { disabled: true, reason: '已使用「文件名」，文件名已包含扩展名' };
+    }
+  }
+
+  // 互斥规则：Date 和 DateTime 不能同时使用
+  if (variable.key === 'Date') {
+    if (currentTemplate.includes('2006-01-02 15-04-05')) {
+      return { disabled: true, reason: '已使用「日期时间」，已包含日期' };
+    }
+  }
+  if (variable.key === 'DateTime') {
+    if (currentTemplate.includes('{{ now | date "2006-01-02" }}') || currentTemplate.includes('{{now | date "2006-01-02"}}')) {
+      return { disabled: true, reason: '已使用「日期」，请改用「日期时间」' };
+    }
+  }
+
+  return { disabled: false };
+};
+
+// 组件属性
+interface TemplateBuilderProps {
+  /** 表单字段路径，如 ['on_record_finished', 'cloud_upload', 'upload_path_tmpl'] */
+  name: string[];
+  /** 可用变量列表 */
+  variables: TemplateVariable[];
+  /** 预设模板列表 */
+  presets: PresetTemplate[];
+  /** 模拟数据 */
+  mockData: MockStream[];
+  /** 模板渲染函数：将模板字符串转换为实际路径 */
+  renderTemplate: (template: string, stream: MockStream, room: MockStream['rooms'][0]) => string;
+  /** 输入框占位符 */
+  placeholder?: string;
+  /** 是否显示目录树预览 */
+  showTreePreview?: boolean;
+  /** 输入框宽度 */
+  width?: number;
+}
+
+/**
+ * 通用模板构建器组件
+ * 支持预设模板选择、变量插入、实时预览、目录树展示
+ */
+const TemplateBuilder: React.FC<TemplateBuilderProps> = ({
+  name,
+  variables,
+  presets,
+  mockData,
+  renderTemplate,
+  placeholder = '',
+  showTreePreview = true,
+  width = 500,
+}) => {
+  const form = Form.useFormInstance();
+  const [customMode, setCustomMode] = useState(false);
+
+  // 获取当前模板值
+  const currentTemplate = Form.useWatch(name, form) || '';
+
+  // 检查是否匹配预设模板
+  const matchedPreset = presets.find((t) => t.template === currentTemplate);
+
+  // 选择预设模板
+  const handleSelectPreset = (template: string) => {
+    setCustomMode(false);
+    const fieldValue: any = {};
+    let current = fieldValue;
+    for (let i = 0; i < name.length - 1; i++) {
+      current[name[i]] = {};
+      current = current[name[i]];
+    }
+    current[name[name.length - 1]] = template;
+    form.setFieldsValue(fieldValue);
+  };
+
+  // 插入变量
+  const handleInsertVariable = (variable: TemplateVariable) => {
+    const textarea = document.querySelector(`textarea[name="${name.join('-')}"]`) as HTMLTextAreaElement;
+
+    // 常用分隔符
+    const separators = ['/', '-', '.', '_', ' ', '|'];
+
+    // 智能添加分隔符
+    const getSeparator = (before: string, after: string): string => {
+      if (!before && !after) return '/';
+      if (!before) return '';
+      if (separators.includes(before.slice(-1))) return '';
+      if (before.endsWith('"')) return '/';
+      if (before.endsWith('}')) return '/';
+      return '/';
+    };
+
+    if (textarea) {
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const before = currentTemplate.substring(0, start);
+      const after = currentTemplate.substring(end);
+      const separator = getSeparator(before, after);
+      const newTemplate = before + separator + variable.template + after;
+
+      const fieldValue: any = {};
+      let current = fieldValue;
+      for (let i = 0; i < name.length - 1; i++) {
+        current[name[i]] = {};
+        current = current[name[i]];
+      }
+      current[name[name.length - 1]] = newTemplate;
+      form.setFieldsValue(fieldValue);
+
+      setTimeout(() => {
+        textarea.focus();
+        const newPos = start + separator.length + variable.template.length;
+        textarea.setSelectionRange(newPos, newPos);
+      }, 0);
+    } else {
+      const separator = getSeparator(currentTemplate, '');
+      const newTemplate = currentTemplate + separator + variable.template;
+
+      const fieldValue: any = {};
+      let current = fieldValue;
+      for (let i = 0; i < name.length - 1; i++) {
+        current[name[i]] = {};
+        current = current[name[i]];
+      }
+      current[name[name.length - 1]] = newTemplate;
+      form.setFieldsValue(fieldValue);
+    }
+  };
+
+  // 生成预览路径
+  const previewPaths = useMemo(() => {
+    if (!currentTemplate || !showTreePreview) return [];
+
+    const paths: string[] = [];
+    for (const stream of mockData) {
+      for (const room of stream.rooms) {
+        const path = renderTemplate(currentTemplate, stream, room);
+        paths.push(path);
+      }
+    }
+    return paths;
+  }, [currentTemplate, mockData, renderTemplate, showTreePreview]);
+
+  return (
+    <div>
+      {/* 预设模板选择 */}
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: 8, fontSize: 12, color: '#666' }}>选择预设模板：</div>
+        <Space wrap>
+          {presets.map((preset) => (
+            <Tag
+              key={preset.name}
+              color={!customMode && matchedPreset?.name === preset.name ? 'blue' : 'default'}
+              style={{ cursor: 'pointer', padding: '4px 12px' }}
+              onClick={() => handleSelectPreset(preset.template)}
+            >
+              {preset.name}
+            </Tag>
+          ))}
+          <Tag
+            color={customMode ? 'blue' : 'default'}
+            style={{ cursor: 'pointer', padding: '4px 12px' }}
+            onClick={() => setCustomMode(true)}
+          >
+            自定义
+          </Tag>
+        </Space>
+      </div>
+
+      {/* 变量插入按钮 */}
+      {(customMode || !matchedPreset) && (
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ marginBottom: 8, fontSize: 12, color: '#666' }}>点击插入变量：</div>
+          <Space wrap>
+            {variables.map((variable) => {
+              const { disabled, reason } = isVariableDisabled(variable, currentTemplate);
+              return (
+                <Tooltip key={variable.key} title={disabled ? reason : `示例: ${variable.example}`}>
+                  <Tag
+                    color={disabled ? 'default' : 'green'}
+                    style={{
+                      cursor: disabled ? 'not-allowed' : 'pointer',
+                      padding: '4px 12px',
+                      opacity: disabled ? 0.5 : 1,
+                    }}
+                    onClick={() => !disabled && handleInsertVariable(variable)}
+                  >
+                    {variable.label}
+                  </Tag>
+                </Tooltip>
+              );
+            })}
+          </Space>
+        </div>
+      )}
+
+      {/* 模板输入框 */}
+      <Form.Item name={name} noStyle>
+        <TextArea
+          name={name.join('-')}
+          rows={2}
+          placeholder={placeholder}
+          style={{ width, fontFamily: 'monospace' }}
+          onFocus={() => {
+            if (!matchedPreset) setCustomMode(true);
+          }}
+        />
+      </Form.Item>
+
+      {/* 目录树预览 */}
+      {showTreePreview && previewPaths.length > 0 && (
+        <DirectoryTreePreview paths={previewPaths} streamCount={mockData.length} />
+      )}
+    </div>
+  );
+};
+
+export default TemplateBuilder;

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -173,9 +173,16 @@ const analyzeConfig = (config: any) => {
 
   // after_process 模式：上传最终文件
   if (isAfterProcess && upload) {
-    // 上传第一个视频和封面
+    // 上传最终产物
     if (burn) {
       files['video.mkv'].status = 'uploaded';
+      // burn_delete_source=false 时，源视频也会被上传（未标记 Deletable）
+      if (!burnDelSource) {
+        const src = convert ? 'video.mp4' : 'video.flv';
+        if (files[src] && files[src].status === 'kept') {
+          files[src].status = 'uploaded';
+        }
+      }
     } else if (convert) {
       files['video.mp4'].status = 'uploaded';
     } else {
@@ -196,9 +203,20 @@ const analyzeConfig = (config: any) => {
       if (cover) files['cover.jpg'].status = 'uploaded_deleted';
     } else if (delAfter) {
       // 只删除已上传的文件
-      if (burn) files['video.mkv'].status = 'uploaded_deleted';
-      else if (convert) files['video.mp4'].status = 'uploaded_deleted';
-      else files['video.flv'].status = 'uploaded_deleted';
+      if (burn) {
+        files['video.mkv'].status = 'uploaded_deleted';
+        // burn_delete_source=false 时源视频也被上传，应一并删除
+        if (!burnDelSource) {
+          const src = convert ? 'video.mp4' : 'video.flv';
+          if (files[src] && files[src].status === 'uploaded') {
+            files[src].status = 'uploaded_deleted';
+          }
+        }
+      } else if (convert) {
+        files['video.mp4'].status = 'uploaded_deleted';
+      } else {
+        files['video.flv'].status = 'uploaded_deleted';
+      }
       if (cover) files['cover.jpg'].status = 'uploaded_deleted';
     }
   }

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -44,8 +44,8 @@ const UPLOAD_PRESETS: PresetTemplate[] = [
   },
   {
     name: '简洁归档',
-    description: '按平台/主播归档，文件名带日期',
-    template: '/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02" }}.{{ .Ext }}',
+    description: '按平台/主播归档，文件名带日期时间',
+    template: '/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02 15-04-05" }}.{{ .Ext }}',
   },
   {
     name: '按房间归档',
@@ -95,7 +95,7 @@ const MOCK_DATA: MockStream[] = [
 const renderUploadTemplate = (template: string, stream: MockStream, room: MockStream['rooms'][0]): string => {
   const fileName = `[${room.date} ${room.time}][${stream.hostName}][${room.roomName}].flv`;
   let path = template;
-  path = path.replace(/\{\{ ?\.Platform ?\}\}/g, stream.platform);
+  path = path.replace(/\{\{ ?\.Platform ?\}\}/g, stream.platformCN);
   path = path.replace(/\{\{ ?\.HostName ?\}\}/g, stream.hostName);
   path = path.replace(/\{\{ ?\.RoomName ?\}\}/g, room.roomName);
   path = path.replace(/\{\{ ?\.FileName ?\}\}/g, fileName);
@@ -291,6 +291,27 @@ interface CloudUploadSettingsProps {
 const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form }) => {
   const isEnabled = config.on_record_finished?.cloud_upload?.enable;
 
+  // 订阅表单中影响文件处理预览的字段，使预览实时反映用户编辑
+  const watchedOrf = Form.useWatch('on_record_finished', form);
+  const watchedCloudUpload = Form.useWatch(['on_record_finished', 'cloud_upload'], form);
+
+  // 将表单实时值合并到 config 副本中，供 FileProcessingPreview 使用
+  // Form.useWatch 返回 undefined 时表示字段未被编辑，此时保留 config 中的原始值
+  const liveConfig = useMemo(() => {
+    if (!watchedOrf && !watchedCloudUpload) return config;
+    return {
+      ...config,
+      on_record_finished: {
+        ...config.on_record_finished,
+        ...watchedOrf,
+        cloud_upload: {
+          ...config.on_record_finished?.cloud_upload,
+          ...watchedCloudUpload,
+        },
+      },
+    };
+  }, [config, watchedOrf, watchedCloudUpload]);
+
   // 互斥逻辑：开启一个时关闭另一个
   const handleDeleteAfterChange = (checked: boolean) => {
     if (checked && form) {
@@ -319,7 +340,7 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form 
           <>
             录制结束后自动把视频传到网盘。需要先在{' '}
             <a
-              href={`http://${window.location.hostname}:${config.openlist?.port || 5244}`}
+              href="/remotetools/tool/openlist/"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -333,8 +354,8 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form 
         style={{ marginBottom: 16 }}
       />
 
-      {/* 文件处理预览 */}
-      <FileProcessingPreview config={config} />
+      {/* 文件处理预览 - 使用表单实时值，无需保存即可反映用户编辑 */}
+      <FileProcessingPreview config={liveConfig} />
 
       <ConfigField label="启用云上传" description="录制结束后自动把视频上传到网盘">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'enable']} valuePropName="checked" noStyle>
@@ -369,7 +390,7 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form 
           presets={UPLOAD_PRESETS}
           mockData={MOCK_DATA}
           renderTemplate={renderUploadTemplate}
-          placeholder="/录播归档/{{ .Platform }}/{{ .HostName }}/{{ now | date '2006-01-02' }}/{{ .FileName }}"
+          placeholder={'/录播归档/{{ .Platform }}/{{ .HostName }}/{{ now | date "2006-01-02" }}/{{ .FileName }}'}
           showTreePreview={true}
           width={500}
         />

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Card, Form, Switch, Select, Input, Tag, Alert } from 'antd';
-import { CloudUploadOutlined } from '@ant-design/icons';
+import React, { useMemo } from 'react';
+import { Card, Form, Switch, Select, Input, Tag, Alert, Descriptions } from 'antd';
+import { CloudUploadOutlined, FileOutlined, DeleteOutlined, UploadOutlined } from '@ant-design/icons';
 import TemplateBuilder, { TemplateVariable, PresetTemplate, MockStream } from '../TemplateBuilder';
 
 interface ConfigFieldProps {
@@ -105,17 +105,204 @@ const renderUploadTemplate = (template: string, stream: MockStream, room: MockSt
   return path;
 };
 
+// 分析配置，返回上传文件和本地剩余文件
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const analyzeConfig = (config: any) => {
+  const orf = config.on_record_finished || {};
+  const cu = orf.cloud_upload || {};
+  const isImmediate = orf.upload_timing === 'immediate';
+  const isAfterProcess = !isImmediate;
+
+  // 功能开关
+  const convert = orf.convert_to_mp4 ?? false;
+  const deleteFlv = orf.delete_flv_after_convert ?? false;
+  const burn = orf.burn_subtitles ?? false;
+  const burnDelSource = orf.burn_delete_source ?? false;
+  const burnDelAss = orf.burn_delete_ass ?? false;
+  const cover = orf.save_cover ?? false;
+  const upload = cu.enable ?? false;
+  const delAfter = cu.delete_after_upload ?? false;
+  const delAllAfter = cu.delete_all_after_upload ?? false;
+
+  // 文件状态：uploaded(上传), deleted(删除), kept(保留)
+  const files: Record<string, { ext: string; desc: string; status: string }> = {};
+
+  // 初始文件
+  files['video.flv'] = { ext: '.flv', desc: '原始录制视频', status: 'kept' };
+  files['video.ass'] = { ext: '.ass', desc: '弹幕字幕', status: 'kept' };
+
+  // immediate 模式：先上传原始文件
+  if (isImmediate && upload) {
+    files['video.flv'].status = 'uploaded';
+  }
+
+  // 转码
+  if (convert) {
+    files['video.mp4'] = { ext: '.mp4', desc: '转码后视频', status: 'kept' };
+    if (deleteFlv) {
+      // 如果已经被标记为 uploaded，改为 uploaded_deleted
+      if (files['video.flv'].status === 'uploaded') {
+        files['video.flv'].status = 'uploaded_deleted';
+      } else {
+        files['video.flv'].status = 'deleted';
+      }
+    }
+  }
+
+  // 烧录
+  if (burn) {
+    files['video.mkv'] = { ext: '.mkv', desc: '烧录后视频', status: 'kept' };
+    if (burnDelSource) {
+      // 删除转码后的 mp4 或原始 flv
+      const target = convert ? 'video.mp4' : 'video.flv';
+      if (files[target].status === 'uploaded') {
+        files[target].status = 'uploaded_deleted';
+      } else {
+        files[target].status = 'deleted';
+      }
+    }
+    if (burnDelAss) {
+      files['video.ass'].status = 'deleted';
+    }
+  }
+
+  // 封面
+  if (cover) {
+    files['cover.jpg'] = { ext: '.jpg', desc: '视频封面', status: 'kept' };
+  }
+
+  // after_process 模式：上传最终文件
+  if (isAfterProcess && upload) {
+    // 上传第一个视频和封面
+    if (burn) {
+      files['video.mkv'].status = 'uploaded';
+    } else if (convert) {
+      files['video.mp4'].status = 'uploaded';
+    } else {
+      files['video.flv'].status = 'uploaded';
+    }
+    if (cover) {
+      files['cover.jpg'].status = 'uploaded';
+    }
+
+    // 删除逻辑
+    if (delAllAfter) {
+      // 删除全部
+      Object.values(files).forEach(f => { f.status = 'deleted'; });
+      // 但上传的文件标记为 uploaded_deleted
+      if (burn) files['video.mkv'].status = 'uploaded_deleted';
+      else if (convert) files['video.mp4'].status = 'uploaded_deleted';
+      else files['video.flv'].status = 'uploaded_deleted';
+      if (cover) files['cover.jpg'].status = 'uploaded_deleted';
+    } else if (delAfter) {
+      // 只删除已上传的文件
+      if (burn) files['video.mkv'].status = 'uploaded_deleted';
+      else if (convert) files['video.mp4'].status = 'uploaded_deleted';
+      else files['video.flv'].status = 'uploaded_deleted';
+      if (cover) files['cover.jpg'].status = 'uploaded_deleted';
+    }
+  }
+
+  // 兜底逻辑：清理无关联视频文件的 .ass 文件
+  if (files['video.ass'] && files['video.ass'].status === 'kept') {
+    const hasVideo = Object.entries(files).some(([name, f]) => {
+      if (name === 'video.ass') return false;
+      const ext = f.ext.toLowerCase();
+      return (ext === '.flv' || ext === '.mp4' || ext === '.mkv') && f.status !== 'deleted' && f.status !== 'uploaded_deleted';
+    });
+    if (!hasVideo) {
+      files['video.ass'].status = 'deleted';
+    }
+  }
+
+  // 分类结果
+  const uploaded: string[] = [];
+  const deleted: string[] = [];
+  const kept: string[] = [];
+
+  Object.entries(files).forEach(([, f]) => {
+    const name = f.desc + ' (' + f.ext + ')';
+    if (f.status === 'uploaded') {
+      uploaded.push(name);
+      kept.push(name); // 上传但本地保留
+    } else if (f.status === 'uploaded_deleted') {
+      uploaded.push(name);
+      deleted.push(name);
+    } else if (f.status === 'deleted') {
+      deleted.push(name);
+    } else {
+      kept.push(name);
+    }
+  });
+
+  return { uploaded, deleted, kept };
+};
+
+// 文件处理预览组件
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const FileProcessingPreview: React.FC<{ config: any }> = ({ config }) => {
+  const result = useMemo(() => analyzeConfig(config), [config]);
+
+  if (!config.on_record_finished?.cloud_upload?.enable) {
+    return null;
+  }
+
+  return (
+    <Card
+      size="small"
+      title={<><FileOutlined /> 文件处理预览</>}
+      style={{ marginBottom: 16, background: '#fafafa' }}
+    >
+      <Descriptions column={1} size="small" labelStyle={{ width: 100 }}>
+        <Descriptions.Item label={<><UploadOutlined /> 上传文件</>}>
+          {result.uploaded.length > 0
+            ? result.uploaded.map((f, i) => <Tag key={i} color="blue">{f}</Tag>)
+            : <Tag>无</Tag>
+          }
+        </Descriptions.Item>
+        <Descriptions.Item label={<><DeleteOutlined /> 删除文件</>}>
+          {result.deleted.length > 0
+            ? result.deleted.map((f, i) => <Tag key={i} color="red">{f}</Tag>)
+            : <Tag>无</Tag>
+          }
+        </Descriptions.Item>
+        <Descriptions.Item label={<><FileOutlined /> 本地保留</>}>
+          {result.kept.length > 0
+            ? result.kept.map((f, i) => <Tag key={i} color="green">{f}</Tag>)
+            : <Tag>无（全部清理）</Tag>
+          }
+        </Descriptions.Item>
+      </Descriptions>
+    </Card>
+  );
+};
+
 interface CloudUploadSettingsProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form?: any; // Form instance for mutual exclusion
 }
 
 /**
  * 云盘上传设置组件
  * 用于 GlobalSettings 中显示云上传配置
  */
-const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config }) => {
+const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form }) => {
   const isEnabled = config.on_record_finished?.cloud_upload?.enable;
+
+  // 互斥逻辑：开启一个时关闭另一个
+  const handleDeleteAfterChange = (checked: boolean) => {
+    if (checked && form) {
+      form.setFieldValue(['on_record_finished', 'cloud_upload', 'delete_all_after_upload'], false);
+    }
+  };
+
+  const handleDeleteAllAfterChange = (checked: boolean) => {
+    if (checked && form) {
+      form.setFieldValue(['on_record_finished', 'cloud_upload', 'delete_after_upload'], false);
+    }
+  };
 
   return (
     <Card
@@ -145,6 +332,10 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config }) => 
         showIcon
         style={{ marginBottom: 16 }}
       />
+
+      {/* 文件处理预览 */}
+      <FileProcessingPreview config={config} />
+
       <ConfigField label="启用云上传" description="录制结束后自动把视频上传到网盘">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'enable']} valuePropName="checked" noStyle>
           <Switch />
@@ -184,9 +375,14 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config }) => 
         />
       </div>
 
-      <ConfigField label="上传后删除本地文件" description="仅对「处理完再上传」生效。「先上传再处理」模式下，文件删除由转码、烧录等设置控制">
+      <ConfigField label="上传后删除本地文件" description="选「处理完再上传」时，上传成功后仅删除已上传的文件（如最终视频），不影响其他中间文件。选「先上传再处理」时此开关无效">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'delete_after_upload']} valuePropName="checked" noStyle>
-          <Switch />
+          <Switch onChange={handleDeleteAfterChange} />
+        </Form.Item>
+      </ConfigField>
+      <ConfigField label="上传后删除全部文件" description="选「处理完再上传」时，上传成功后删除所有本地文件（含中间产物）。选「先上传再处理」时此开关无效">
+        <Form.Item name={['on_record_finished', 'cloud_upload', 'delete_all_after_upload']} valuePropName="checked" noStyle>
+          <Switch onChange={handleDeleteAllAfterChange} />
         </Form.Item>
       </ConfigField>
 

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -340,13 +340,30 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form 
           <>
             录制结束后自动把视频传到网盘。需要先在{' '}
             <a
-              href="/remotetools/tool/openlist/"
+              href={`http://${window.location.hostname}:${config.openlist?.port || 5244}`}
               target="_blank"
               rel="noopener noreferrer"
             >
               OpenList 管理页面
             </a>{' '}
-            添加网盘。
+            添加网盘。{' '}
+            {config.openlist?.username && config.openlist?.password && (
+              <>
+                <span style={{ color: '#999', fontSize: 12 }}>
+                  (登录凭据: {config.openlist.username} / {config.openlist.password})
+                </span>{' '}
+              </>
+            )}
+            <span style={{ color: '#999', fontSize: 12 }}>
+              (如无法访问，尝试{' '}
+              <a
+                href="/remotetools/tool/openlist/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                通过代理访问
+              </a>)
+            </span>
           </>
         }
         type="info"

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -289,6 +289,11 @@ const FileProcessingPreview: React.FC<{ config: any }> = ({ config }) => {
           }
         </Descriptions.Item>
       </Descriptions>
+      <div style={{ marginTop: 12, fontSize: 12, color: '#888', lineHeight: 1.8 }}>
+        <div>💡 <b>说明：</b>开启「转换后删除 FLV」或「烧录后删除源视频」后，只会上传最终成品（MP4 或 MKV）。</div>
+        <div style={{ paddingLeft: 16 }}>如果不开启，原始视频也会一并上传到云端（相当于云端保存了两份视频）。</div>
+        <div style={{ paddingLeft: 16 }}>上方预览会根据你当前的设置实时显示哪些文件会被上传、删除或保留。</div>
+      </div>
     </Card>
   );
 };

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -160,6 +160,13 @@ const analyzeConfig = (config: any) => {
       } else {
         files[target].status = 'deleted';
       }
+    } else {
+      // burn_delete_source=false：源视频保留在 BurnSubtitlesStage output 中
+      // immediate 模式下已在 pipeline 开头被上传，after_process 模式下也会被上传
+      const src = convert ? 'video.mp4' : 'video.flv';
+      if (files[src] && files[src].status === 'kept') {
+        files[src].status = 'uploaded';
+      }
     }
     if (burnDelAss) {
       files['video.ass'].status = 'deleted';
@@ -176,13 +183,7 @@ const analyzeConfig = (config: any) => {
     // 上传最终产物
     if (burn) {
       files['video.mkv'].status = 'uploaded';
-      // burn_delete_source=false 时，源视频也会被上传（未标记 Deletable）
-      if (!burnDelSource) {
-        const src = convert ? 'video.mp4' : 'video.flv';
-        if (files[src] && files[src].status === 'kept') {
-          files[src].status = 'uploaded';
-        }
-      }
+      // 源视频已在烧录阶段标记为 uploaded（burnDelSource=false 时）
     } else if (convert) {
       files['video.mp4'].status = 'uploaded';
     } else {
@@ -194,30 +195,21 @@ const analyzeConfig = (config: any) => {
 
     // 删除逻辑
     if (delAllAfter) {
-      // 删除全部
+      // 删除全部：先保存已上传文件的状态，再全部标记删除，最后恢复已上传的标记
+      const uploadedStatus: Record<string, string> = {};
+      Object.entries(files).forEach(([name, f]) => {
+        if (f.status === 'uploaded') uploadedStatus[name] = f.status;
+      });
       Object.values(files).forEach(f => { f.status = 'deleted'; });
-      // 但上传的文件标记为 uploaded_deleted
-      if (burn) files['video.mkv'].status = 'uploaded_deleted';
-      else if (convert) files['video.mp4'].status = 'uploaded_deleted';
-      else files['video.flv'].status = 'uploaded_deleted';
-      if (cover) files['cover.jpg'].status = 'uploaded_deleted';
+      // 恢复已上传文件为 uploaded_deleted
+      Object.entries(uploadedStatus).forEach(([name]) => {
+        files[name].status = 'uploaded_deleted';
+      });
     } else if (delAfter) {
       // 只删除已上传的文件
-      if (burn) {
-        files['video.mkv'].status = 'uploaded_deleted';
-        // burn_delete_source=false 时源视频也被上传，应一并删除
-        if (!burnDelSource) {
-          const src = convert ? 'video.mp4' : 'video.flv';
-          if (files[src] && files[src].status === 'uploaded') {
-            files[src].status = 'uploaded_deleted';
-          }
-        }
-      } else if (convert) {
-        files['video.mp4'].status = 'uploaded_deleted';
-      } else {
-        files['video.flv'].status = 'uploaded_deleted';
-      }
-      if (cover) files['cover.jpg'].status = 'uploaded_deleted';
+      Object.entries(files).forEach(([, f]) => {
+        if (f.status === 'uploaded') f.status = 'uploaded_deleted';
+      });
     }
   }
 

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Card, Form, Switch, Select, Input, Tag, Alert } from 'antd';
 import { CloudUploadOutlined } from '@ant-design/icons';
-
-const { TextArea } = Input;
+import TemplateBuilder, { TemplateVariable, PresetTemplate, MockStream } from '../TemplateBuilder';
 
 interface ConfigFieldProps {
   label: string;
@@ -25,6 +24,87 @@ const ConfigField: React.FC<ConfigFieldProps> = ({ label, description, children 
   </div>
 );
 
+// 上传路径模板 - 可用变量
+const UPLOAD_VARIABLES: TemplateVariable[] = [
+  { key: 'Platform', label: '平台', example: 'bilibili', template: '{{ .Platform }}' },
+  { key: 'HostName', label: '主播名', example: '小辞炒糍粑', template: '{{ .HostName }}' },
+  { key: 'RoomName', label: '房间名', example: '中午好今天单排！', template: '{{ .RoomName }}' },
+  { key: 'FileName', label: '文件名', example: '[2026-08-05][小辞炒糍粑].flv', template: '{{ .FileName }}' },
+  { key: 'Date', label: '日期', example: '2026-08-05', template: '{{ now | date "2006-01-02" }}' },
+  { key: 'DateTime', label: '日期时间', example: '2026-08-05 15-04-05', template: '{{ now | date "2006-01-02 15-04-05" }}' },
+  { key: 'Ext', label: '扩展名', example: 'flv', template: '{{ .Ext }}' },
+];
+
+// 上传路径模板 - 预设模板
+const UPLOAD_PRESETS: PresetTemplate[] = [
+  {
+    name: '按日期归档',
+    description: '按平台/主播/日期归档',
+    template: '/录播归档/{{ .Platform }}/{{ .HostName }}/{{ now | date "2006-01-02" }}/{{ .FileName }}',
+  },
+  {
+    name: '简洁归档',
+    description: '按平台/主播归档，文件名带日期',
+    template: '/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02" }}.{{ .Ext }}',
+  },
+  {
+    name: '按房间归档',
+    description: '按平台/主播/房间名归档',
+    template: '/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}/{{ .FileName }}',
+  },
+  {
+    name: '原始文件名',
+    description: '保留原始文件名，按平台/主播归档',
+    template: '/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}',
+  },
+];
+
+// 模拟数据（用于预览）
+const MOCK_DATA: MockStream[] = [
+  {
+    platform: 'bilibili',
+    platformCN: '哔哩哔哩',
+    hostName: '小辞炒糍粑',
+    rooms: [
+      { roomName: '中午好今天单排！', date: '2026-08-05', time: '12-00-00' },
+      { roomName: '晚上吃鸡', date: '2026-08-05', time: '20-00-00' },
+      { roomName: '中午好今天单排！', date: '2026-08-06', time: '12-00-00' },
+    ],
+  },
+  {
+    platform: 'bilibili',
+    platformCN: '哔哩哔哩',
+    hostName: '老番茄',
+    rooms: [
+      { roomName: '杂谈闲聊', date: '2026-08-05', time: '19-00-00' },
+      { roomName: '杂谈闲聊', date: '2026-08-07', time: '19-00-00' },
+    ],
+  },
+  {
+    platform: 'douyu',
+    platformCN: '斗鱼',
+    hostName: '一条小团团',
+    rooms: [
+      { roomName: '团团的直播间', date: '2026-08-05', time: '21-00-00' },
+      { roomName: '团团的直播间', date: '2026-08-06', time: '21-00-00' },
+    ],
+  },
+];
+
+// 渲染上传路径模板
+const renderUploadTemplate = (template: string, stream: MockStream, room: MockStream['rooms'][0]): string => {
+  const fileName = `[${room.date} ${room.time}][${stream.hostName}][${room.roomName}].flv`;
+  let path = template;
+  path = path.replace(/\{\{ ?\.Platform ?\}\}/g, stream.platform);
+  path = path.replace(/\{\{ ?\.HostName ?\}\}/g, stream.hostName);
+  path = path.replace(/\{\{ ?\.RoomName ?\}\}/g, room.roomName);
+  path = path.replace(/\{\{ ?\.FileName ?\}\}/g, fileName);
+  path = path.replace(/\{\{ ?\.Ext ?\}\}/g, 'flv');
+  path = path.replace(/\{\{ ?now \| date "2006-01-02" ?\}\}/g, room.date);
+  path = path.replace(/\{\{ ?now \| date "2006-01-02 15-04-05" ?\}\}/g, `${room.date} ${room.time}`);
+  return path;
+};
+
 interface CloudUploadSettingsProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
@@ -43,74 +123,92 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config }) => 
       size="small"
       style={{ marginBottom: 16 }}
       extra={
-        <Tag color={isEnabled ? 'green' : 'default'}>
-          {isEnabled ? '已启用' : '未启用'}
-        </Tag>
+        <Tag color={isEnabled ? 'green' : 'default'}>{isEnabled ? '已启用' : '未启用'}</Tag>
       }
     >
       <Alert
-        message="云盘自动上传功能"
+        message="云盘自动上传"
         description={
           <>
-            录制完成后自动上传到网盘。需要先在{' '}
-            <a href="/remotetools/tool/openlist/" target="_blank" rel="noopener noreferrer">
+            录制结束后自动把视频传到网盘。需要先在{' '}
+            <a
+              href={`http://${window.location.hostname}:${config.openlist?.port || 5244}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               OpenList 管理页面
             </a>{' '}
-            配置网盘存储。
+            添加网盘。
           </>
         }
         type="info"
         showIcon
         style={{ marginBottom: 16 }}
       />
-      <ConfigField
-        label="启用云上传"
-        description="开启后录制完成的视频会自动上传到配置的网盘"
-      >
+      <ConfigField label="启用云上传" description="录制结束后自动把视频上传到网盘">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'enable']} valuePropName="checked" noStyle>
           <Switch />
         </Form.Item>
       </ConfigField>
-      <ConfigField
-        label="上传时机"
-        description="选择何时开始上传：立即上传原始文件，或等待后处理（修复/转码）完成后上传"
-      >
+      <ConfigField label="上传时机" description="选择上传哪种文件：原始录制文件 or 处理后的最终文件">
         <Form.Item name={['on_record_finished', 'upload_timing']} noStyle>
-          <Select style={{ width: 250 }} placeholder="选择上传时机">
-            <Select.Option value="">使用默认（立即）</Select.Option>
-            <Select.Option value="immediate">立即上传原始文件</Select.Option>
-            <Select.Option value="after_process">后处理完成后上传</Select.Option>
+          <Select style={{ width: 350 }} placeholder="选择上传时机">
+            <Select.Option value="">处理完再上传（默认）</Select.Option>
+            <Select.Option value="immediate">先上传再处理</Select.Option>
+            <Select.Option value="after_process">处理完再上传</Select.Option>
           </Select>
         </Form.Item>
       </ConfigField>
-      <ConfigField
-        label="存储名称"
-        description="在 OpenList 中配置的存储名称，例如：115、阿里云盘"
-      >
+      <div style={{ marginTop: -12, marginBottom: 16, marginLeft: 140, color: '#888', fontSize: 12 }}>
+        <div><b>先上传再处理</b>：录制结束后立刻上传原始文件，然后再做修复、转码、烧录</div>
+        <div><b>处理完再上传</b>：先做修复、转码、烧录，全部完成后再上传最终文件</div>
+      </div>
+      <ConfigField label="存储名称" description="你在 OpenList 里添加的网盘名称，比如 115、阿里云盘">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'storage_name']} noStyle>
           <Input placeholder="例如: 115" style={{ width: 200 }} />
         </Form.Item>
       </ConfigField>
-      <ConfigField
-        label="上传路径模板"
-        description='支持变量: {{ .Platform }}, {{ .HostName }}, {{ .RoomName }}, {{ .Ext }}, {{ now | date "2006-01-02" }}'
-      >
-        <Form.Item name={['on_record_finished', 'cloud_upload', 'upload_path_tmpl']} noStyle>
-          <TextArea
-            rows={2}
-            placeholder='/录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02" }}.{{ .Ext }}'
-            style={{ width: 500 }}
-          />
-        </Form.Item>
-      </ConfigField>
-      <ConfigField
-        label="上传后删除本地文件"
-        description="上传成功后自动删除本地文件以节省空间"
-      >
+
+      {/* 上传路径模板 - 使用通用 TemplateBuilder 组件 */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>上传路径模板</div>
+        <TemplateBuilder
+          name={['on_record_finished', 'cloud_upload', 'upload_path_tmpl']}
+          variables={UPLOAD_VARIABLES}
+          presets={UPLOAD_PRESETS}
+          mockData={MOCK_DATA}
+          renderTemplate={renderUploadTemplate}
+          placeholder="/录播归档/{{ .Platform }}/{{ .HostName }}/{{ now | date '2006-01-02' }}/{{ .FileName }}"
+          showTreePreview={true}
+          width={500}
+        />
+      </div>
+
+      <ConfigField label="上传后删除本地文件" description="仅对「处理完再上传」生效。「先上传再处理」模式下，文件删除由转码、烧录等设置控制">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'delete_after_upload']} valuePropName="checked" noStyle>
           <Switch />
         </Form.Item>
       </ConfigField>
+
+      <Card type="inner" title="OpenList 认证配置" size="small" style={{ marginTop: 16, marginBottom: 8 }}>
+        <Alert
+          message="关于账号密码"
+          description={<>首次启动程序时会自动生成密码并填入下方，无需手动操作。如果在 OpenList 网页改了密码，程序会自动重新登录。</>}
+          type="info"
+          showIcon
+          style={{ marginBottom: 16 }}
+        />
+        <ConfigField label="管理员用户名" description="首次启动自动填入，一般不需要改">
+          <Form.Item name={['openlist', 'username']} noStyle>
+            <Input placeholder="admin" style={{ width: 200 }} />
+          </Form.Item>
+        </ConfigField>
+        <ConfigField label="管理员密码" description="首次启动自动填入，一般不需要改">
+          <Form.Item name={['openlist', 'password']} noStyle>
+            <Input.Password placeholder="首次启动后自动填充" style={{ width: 200 }} />
+          </Form.Item>
+        </ConfigField>
+      </Card>
     </Card>
   );
 };

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -146,6 +146,12 @@ const analyzeConfig = (config: any) => {
       } else {
         files['video.flv'].status = 'deleted';
       }
+    } else {
+      // delete_flv_after_convert=false：源视频保留在 ConvertMp4Stage output 中
+      // immediate 模式下已在 pipeline 开头被上传，after_process 模式下也会被上传
+      if (files['video.flv'].status === 'kept') {
+        files['video.flv'].status = 'uploaded';
+      }
     }
   }
 

--- a/src/webapp/src/component/config-info/index.tsx
+++ b/src/webapp/src/component/config-info/index.tsx
@@ -31,7 +31,7 @@ const { TextArea } = Input;
 // 功能开关：代理配置（开发中，设为 false 隐藏 UI）
 // 与后端 configs.EnableProxyConfig 对应
 const ENABLE_PROXY_CONFIG = false;
-const ENABLE_CLOUD_UPLOAD_SETTINGS = false;
+const ENABLE_CLOUD_UPLOAD_SETTINGS = true;
 const { Panel } = Collapse;
 
 // 配置项类型定义
@@ -79,6 +79,26 @@ interface EffectiveConfig {
     delete_flv_after_convert: boolean;
     custom_commandline: string;
     fix_flv_at_first: boolean;
+    cloud_upload: {
+      enable: boolean;
+      storage_name: string;
+      upload_path_tmpl: string;
+      delete_after_upload: boolean;
+    };
+    upload_timing: string;
+    burn_subtitles: boolean;
+    burn_subtitles_codec: string;
+    burn_subtitles_crf: string;
+    burn_subtitles_preset: string;
+    burn_delete_ass: boolean;
+    burn_delete_source: boolean;
+  };
+  openlist: {
+    port: number;
+    data_path: string;
+    username: string;
+    password: string;
+    token: string;
   };
   timeout_in_us: number;
   timeout_in_seconds: number;

--- a/src/webapp/src/component/config-info/index.tsx
+++ b/src/webapp/src/component/config-info/index.tsx
@@ -84,6 +84,7 @@ interface EffectiveConfig {
       storage_name: string;
       upload_path_tmpl: string;
       delete_after_upload: boolean;
+      delete_all_after_upload: boolean;
     };
     upload_timing: string;
     burn_subtitles: boolean;
@@ -685,7 +686,7 @@ const GlobalSettings: React.FC<{
               <Switch />
             </Form.Item>
           </ConfigField>
-          <ConfigField label="转换后删除 FLV" description="MP4 转换成功后删除原始 FLV 文件">
+          <ConfigField label="转换后删除 FLV" description="MP4 转换成功后标记原始 FLV 为待删除，全部处理阶段完成后才真正删除">
             <Form.Item name={['on_record_finished', 'delete_flv_after_convert']} valuePropName="checked" noStyle>
               <Switch />
             </Form.Item>
@@ -703,7 +704,7 @@ const GlobalSettings: React.FC<{
         </Card>
 
         {/* 云盘上传设置（开发中） */}
-        {ENABLE_CLOUD_UPLOAD_SETTINGS && <CloudUploadSettings config={config} />}
+        {ENABLE_CLOUD_UPLOAD_SETTINGS && <CloudUploadSettings config={config} form={form} />}
 
         {/* 高级设置 */}
         <Card title="高级设置" size="small" style={{ marginBottom: 16 }}>

--- a/src/webapp/src/component/danmaku-config/index.tsx
+++ b/src/webapp/src/component/danmaku-config/index.tsx
@@ -569,6 +569,7 @@ const DanmakuSettings: React.FC = () => {
               label="烧录后删除 ASS 文件"
               name="burn_delete_ass"
               valuePropName="checked"
+              extra="烧录成功后标记 ASS 文件为待删除，全部处理阶段完成后才真正删除"
             >
               <Switch />
             </Form.Item>
@@ -576,7 +577,7 @@ const DanmakuSettings: React.FC = () => {
               label="烧录后删除源视频"
               name="burn_delete_source"
               valuePropName="checked"
-              extra="删除烧录前的 MP4/FLV 源文件，仅保留 MKV"
+              extra="烧录成功后标记源视频为待删除，全部处理阶段完成后才真正删除。仅保留 MKV"
             >
               <Switch />
             </Form.Item>

--- a/src/webapp/src/component/pipeline-task-list/index.tsx
+++ b/src/webapp/src/component/pipeline-task-list/index.tsx
@@ -229,11 +229,19 @@ class PipelineTaskList extends Component<object, PipelineTaskListState> {
     }
   };
 
-  handleRetry = async (taskId: number) => {
+  handleRetry = async (taskId: number, stageName?: string) => {
     try {
-      const res = await fetch(`/api/pipeline/tasks/${taskId}/retry`, { method: 'POST' });
+      const body: any = {};
+      if (stageName) {
+        body.stage_name = stageName;
+      }
+      const res = await fetch(`/api/pipeline/tasks/${taskId}/retry`, {
+        method: 'POST',
+        headers: stageName ? { 'Content-Type': 'application/json' } : undefined,
+        body: stageName ? JSON.stringify(body) : undefined,
+      });
       if (res.ok) {
-        message.success('任务已重新排队');
+        message.success(stageName ? `从 ${this.getStageLabel(stageName)} 阶段重试` : '任务已重新排队');
         this.loadData();
       } else {
         message.error('重试失败');
@@ -291,6 +299,7 @@ class PipelineTaskList extends Component<object, PipelineTaskListState> {
       'extract_cover': '提取封面',
       'cloud_upload': '云盘上传',
       'custom_command': '自定义命令',
+      'burn_subtitles': '烧录字幕',
     };
     return labels[stageName] || stageName;
   };
@@ -450,6 +459,9 @@ class PipelineTaskList extends Component<object, PipelineTaskListState> {
     const results = task.stage_results || [];
     if (results.length === 0) return null;
 
+    // 是否允许阶段级重试（Failed/Cancelled/Completed 状态）
+    const canRetryStage = task.can_retry && (task.status === 'failed' || task.status === 'cancelled' || task.status === 'completed');
+
     return (
       <Collapse size="small" style={{ marginTop: 12 }}>
         {results.map((result, index) => (
@@ -460,6 +472,19 @@ class PipelineTaskList extends Component<object, PipelineTaskListState> {
                 <Text>{this.getStageLabel(result.stage_name)}</Text>
                 {result.status === 'failed' && (
                   <Text type="danger">失败</Text>
+                )}
+                {canRetryStage && (result.status === 'completed' || result.status === 'failed') && (
+                  <Button
+                    type="link"
+                    size="small"
+                    icon={<PlayCircleOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      this.handleRetry(task.id, result.stage_name);
+                    }}
+                  >
+                    从此阶段重试
+                  </Button>
                 )}
               </Space>
             }
@@ -568,7 +593,7 @@ class PipelineTaskList extends Component<object, PipelineTaskListState> {
                 取消任务
               </Button>
             )}
-            {(task.status === 'failed' || task.status === 'cancelled') && task.can_retry && (
+            {(task.status === 'failed' || task.status === 'cancelled' || task.status === 'completed') && task.can_retry && (
               <Button icon={<PlayCircleOutlined />} onClick={() => this.handleRetry(task.id)}>
                 重新执行
               </Button>

--- a/tests/e2e/config.spec.ts
+++ b/tests/e2e/config.spec.ts
@@ -29,9 +29,9 @@ test.describe('设置页面测试', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  test('云盘上传设置已隐藏', async ({ page }) => {
+  test('云盘上传设置已显示', async ({ page }) => {
     await expect(page.getByRole('main')).toBeVisible();
-    await expect(page.getByText('云盘上传')).toHaveCount(0);
+    await expect(page.getByText('云盘上传')).toHaveCount(1);
   });
 
   test('输入框可以编辑', async ({ page }) => {

--- a/tests/e2e/config.spec.ts
+++ b/tests/e2e/config.spec.ts
@@ -31,7 +31,7 @@ test.describe('设置页面测试', () => {
 
   test('云盘上传设置已显示', async ({ page }) => {
     await expect(page.getByRole('main')).toBeVisible();
-    await expect(page.getByText('云盘上传')).toHaveCount(1);
+    await expect(page.getByText('云盘上传').first()).toBeVisible();
   });
 
   test('输入框可以编辑', async ({ page }) => {

--- a/tests/e2e/fixtures/test-config.template.yml
+++ b/tests/e2e/fixtures/test-config.template.yml
@@ -43,7 +43,7 @@ on_record_finished:
   cloud_upload:
     enable: false
     storage_name: ""
-    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .RoomName }}-{{ now | date "2006-01-02" }}.{{ .Ext }}
+    upload_path_tmpl: /录播归档/{{ .Platform }}/{{ .HostName }}/{{ .FileName }}
     delete_after_upload: false
   upload_timing: after_process
 timeout_in_us: 60000000

--- a/tests/e2e/fixtures/test-config.template.yml
+++ b/tests/e2e/fixtures/test-config.template.yml
@@ -101,6 +101,9 @@ proxy:
 openlist:
   port: 5244
   data_path: ""
+  username: ""
+  password: ""
+  token: ""
 update:
   auto_check: false
   check_interval_hours: 6


### PR DESCRIPTION
openlist上传接入与易用性优化
易用性主要是可视化上传文件的处理逻辑，这样大家都容易上手。
<img width="641" height="437" alt="image" src="https://github.com/user-attachments/assets/48bdad41-5275-4631-8cc1-0e20faf66a9b" />
<img width="618" height="178" alt="image" src="https://github.com/user-attachments/assets/74086790-e2be-4166-a5d1-28c08f6e55fa" />

上传状态管理这块我没有做上传进度回调，感觉没必要，可能会加个重启上传任务功能，避免网络啥的导致上传失败忘记传了。这块还没做设计。
目前我把后处理删文件逻辑都改成管线成功才删除，失败保留。这样对上传来说比较好，不会跑一半成功就误删除了，后续整个链路会异常