### PR TITLE
fix(notify): 修复录制摘要通知在 Pipeline 处理前发送导致文件列表不准确

### DIFF
--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -826,6 +826,11 @@ func main() {
 		if inst.PipelineManager != nil {
 			inst.PipelineManager.Close(ctx)
 		}
+		// 等待异步通知 goroutine（如 Telegram/Email 摘要发送）完成
+		// 必须在 PipelineManager.Close 之后——pipeline 回调可能触发最后的通知
+		if rm, ok := inst.RecorderManager.(recorders.Manager); ok {
+			rm.WaitForNotifications()
+		}
 		// 关闭直播间状态管理器
 		if liveStateManager != nil {
 			liveStateManager.Close()

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -354,6 +354,7 @@ type CloudUpload struct {
 	UploadPathTmpl      string   `yaml:"upload_path_tmpl" json:"upload_path_tmpl"`                           // 上传路径模板
 	DeleteAfterUpload   bool     `yaml:"delete_after_upload" json:"delete_after_upload"`                     // 上传成功后仅删除已上传的文件
 	DeleteAllAfterUpload bool    `yaml:"delete_all_after_upload" json:"delete_all_after_upload"`             // 上传成功后删除全部文件（含中间产物）
+	UploadSubtitles     bool     `yaml:"upload_subtitles" json:"upload_subtitles"`                           // 是否上传关联的 .ass 弹幕字幕文件
 	AdditionalStorages  []string `yaml:"additional_storages,omitempty" json:"additional_storages,omitempty"` // 额外存储（支持多目标上传）
 }
 

--- a/src/notify/send.go
+++ b/src/notify/send.go
@@ -317,12 +317,17 @@ func SendPipelineRecordingSummary(
 
 	var title, body string
 	if allUploaded {
-		// 所有文件已上传并删除：显示原始文件列表 + 上传状态
-		if len(originalFiles) == 0 {
+		// 所有文件已上传并删除：显示实际上传的文件列表
+		displayFiles := finalFiles
+		if len(displayFiles) == 0 {
+			// 回退：finalFiles 为空时用 originalFiles
+			displayFiles = originalFiles
+		}
+		if len(displayFiles) == 0 {
 			return
 		}
 		title = fmt.Sprintf("%s 录制完成", hostName)
-		body = buildUploadedSummaryBody(platform, originalFiles)
+		body = buildUploadedSummaryBody(platform, displayFiles)
 	} else if len(kept) > 0 {
 		// 有文件保留在磁盘：显示保留的文件列表
 		title, body = buildRecordingSummaryMessage(hostName, platform, kept, outputPath)

--- a/src/notify/send.go
+++ b/src/notify/send.go
@@ -16,8 +16,9 @@ import (
 
 // RecordingFileDetail 录制文件详情
 type RecordingFileDetail struct {
-	Name string // 文件名（不含路径）
-	Size int64  // 文件大小（字节）
+	Name     string // 文件名（不含路径）
+	Size     int64  // 文件大小（字节）
+	Uploaded bool   // 是否已上传到云端（用于摘要消息标注）
 }
 
 // SendNotification 发送统一通知函数
@@ -250,6 +251,29 @@ func buildRecordingSummaryMessage(hostName, platform string, files []RecordingFi
 	return
 }
 
+// buildUploadedSummaryBody 构造"已上传到云端"场景的录制摘要消息体
+// 与 buildRecordingSummaryMessage 类似，但标注文件已上传、不显示磁盘空间
+func buildUploadedSummaryBody(platform string, files []RecordingFileDetail) string {
+	const maxDisplayFiles = 30
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "平台：%s\n", platform)
+	fmt.Fprintf(&sb, "录制文件：%d 个（已上传到云端）\n", len(files))
+	var totalSize int64
+	for i, f := range files {
+		totalSize += f.Size
+		if i < maxDisplayFiles {
+			fmt.Fprintf(&sb, "  %d. %s (%s)\n", i+1, f.Name, formatFileSize(f.Size))
+		}
+	}
+	if len(files) > maxDisplayFiles {
+		fmt.Fprintf(&sb, "  ... 还有 %d 个文件未显示\n", len(files)-maxDisplayFiles)
+	}
+	fmt.Fprintf(&sb, "总大小：%s\n", formatFileSize(totalSize))
+	fmt.Fprintf(&sb, "本地文件已清理")
+	return sb.String()
+}
+
 // SendRecordingSummary 录制结束后发送录制文件摘要通知
 // outputPath 为录制输出路径，用于获取剩余磁盘空间
 func SendRecordingSummary(logger *livelogger.LiveLogger, hostName, platform string, files []RecordingFileDetail, outputPath string) {
@@ -262,7 +286,55 @@ func SendRecordingSummary(logger *livelogger.LiveLogger, hostName, platform stri
 	}
 
 	title, body := buildRecordingSummaryMessage(hostName, platform, files, outputPath)
+	sendToAllChannels(cfg, logger, title, body)
+}
 
+// SendPipelineRecordingSummary Pipeline 完成后发送录制摘要通知
+// originalFiles: 原始录制文件列表（allUploaded 时用于显示）
+// finalFiles: Pipeline 处理后的最终文件列表（含 Uploaded 标记）
+func SendPipelineRecordingSummary(
+	logger *livelogger.LiveLogger,
+	hostName, platform string,
+	originalFiles, finalFiles []RecordingFileDetail,
+	outputPath string,
+) {
+	cfg := configs.GetCurrentConfig()
+	if cfg == nil || !cfg.Notify.SendRecordingSummary {
+		return
+	}
+
+	// 分离已上传文件和保留文件
+	var kept []RecordingFileDetail
+	allUploaded := len(finalFiles) > 0
+	for _, f := range finalFiles {
+		if f.Uploaded {
+			// 已上传文件不显示在最终列表中（已从磁盘删除）
+		} else {
+			allUploaded = false
+			kept = append(kept, f)
+		}
+	}
+
+	var title, body string
+	if allUploaded {
+		// 所有文件已上传并删除：显示原始文件列表 + 上传状态
+		if len(originalFiles) == 0 {
+			return
+		}
+		title = fmt.Sprintf("%s 录制完成", hostName)
+		body = buildUploadedSummaryBody(platform, originalFiles)
+	} else if len(kept) > 0 {
+		// 有文件保留在磁盘：显示保留的文件列表
+		title, body = buildRecordingSummaryMessage(hostName, platform, kept, outputPath)
+	} else {
+		return
+	}
+
+	sendToAllChannels(cfg, logger, title, body)
+}
+
+// sendToAllChannels 向所有已启用的通知通道推送摘要消息
+func sendToAllChannels(cfg *configs.Config, logger *livelogger.LiveLogger, title, body string) {
 	// Telegram
 	if cfg.Notify.Telegram.Enable {
 		msg := fmt.Sprintf("%s\n%s", title, body)

--- a/src/notify/send.go
+++ b/src/notify/send.go
@@ -250,6 +250,29 @@ func buildRecordingSummaryMessage(hostName, platform string, files []RecordingFi
 	return
 }
 
+// buildUploadedSummaryBody 构造"已上传到云端"场景的录制摘要消息体
+// 与 buildRecordingSummaryMessage 类似，但标注文件已上传、不显示磁盘空间
+func buildUploadedSummaryBody(platform string, files []RecordingFileDetail) string {
+	const maxDisplayFiles = 30
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "平台：%s\n", platform)
+	fmt.Fprintf(&sb, "录制文件：%d 个（已上传到云端）\n", len(files))
+	var totalSize int64
+	for i, f := range files {
+		totalSize += f.Size
+		if i < maxDisplayFiles {
+			fmt.Fprintf(&sb, "  %d. %s (%s)\n", i+1, f.Name, formatFileSize(f.Size))
+		}
+	}
+	if len(files) > maxDisplayFiles {
+		fmt.Fprintf(&sb, "  ... 还有 %d 个文件未显示\n", len(files)-maxDisplayFiles)
+	}
+	fmt.Fprintf(&sb, "总大小：%s\n", formatFileSize(totalSize))
+	fmt.Fprintf(&sb, "本地文件已清理")
+	return sb.String()
+}
+
 // SendRecordingSummary 录制结束后发送录制文件摘要通知
 // outputPath 为录制输出路径，用于获取剩余磁盘空间
 func SendRecordingSummary(logger *livelogger.LiveLogger, hostName, platform string, files []RecordingFileDetail, outputPath string) {
@@ -262,7 +285,46 @@ func SendRecordingSummary(logger *livelogger.LiveLogger, hostName, platform stri
 	}
 
 	title, body := buildRecordingSummaryMessage(hostName, platform, files, outputPath)
+	sendToAllChannels(cfg, logger, title, body)
+}
 
+// SendPipelineRecordingSummary Pipeline 完成后发送录制摘要通知
+// originalFiles: 原始录制文件列表（allUploadedAndDeleted 时用于显示）
+// finalFiles: Pipeline 处理后的最终文件列表
+// allUploadedAndDeleted: 所有文件已上传并删除（显示上传状态而非磁盘文件）
+func SendPipelineRecordingSummary(
+	logger *livelogger.LiveLogger,
+	hostName, platform string,
+	originalFiles, finalFiles []RecordingFileDetail,
+	outputPath string,
+	allUploadedAndDeleted bool,
+) {
+	cfg := configs.GetCurrentConfig()
+	if cfg == nil || !cfg.Notify.SendRecordingSummary {
+		return
+	}
+
+	var title, body string
+	if allUploadedAndDeleted {
+		// 所有文件已上传并删除：显示原始文件列表 + 上传状态
+		if len(originalFiles) == 0 {
+			return
+		}
+		title = fmt.Sprintf("%s 录制完成", hostName)
+		body = buildUploadedSummaryBody(platform, originalFiles)
+	} else {
+		// 有文件保留或 Pipeline 失败：显示最终文件列表
+		if len(finalFiles) == 0 {
+			return
+		}
+		title, body = buildRecordingSummaryMessage(hostName, platform, finalFiles, outputPath)
+	}
+
+	sendToAllChannels(cfg, logger, title, body)
+}
+
+// sendToAllChannels 向所有已启用的通知通道推送摘要消息
+func sendToAllChannels(cfg *configs.Config, logger *livelogger.LiveLogger, title, body string) {
 	// Telegram
 	if cfg.Notify.Telegram.Enable {
 		msg := fmt.Sprintf("%s\n%s", title, body)

--- a/src/notify/send.go
+++ b/src/notify/send.go
@@ -274,6 +274,54 @@ func buildUploadedSummaryBody(platform string, files []RecordingFileDetail) stri
 	return sb.String()
 }
 
+// buildMixedSummaryBody 构造"部分上传、部分本地保留"场景的消息体
+func buildMixedSummaryBody(platform string, uploaded, kept []RecordingFileDetail, outputPath string) string {
+	const maxDisplayFiles = 30
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "平台：%s\n", platform)
+
+	// 已上传部分
+	fmt.Fprintf(&sb, "已上传到云端：%d 个\n", len(uploaded))
+	var uploadedSize int64
+	for i, f := range uploaded {
+		uploadedSize += f.Size
+		if i < maxDisplayFiles {
+			fmt.Fprintf(&sb, "  %d. %s (%s)\n", i+1, f.Name, formatFileSize(f.Size))
+		}
+	}
+	if len(uploaded) > maxDisplayFiles {
+		fmt.Fprintf(&sb, "  ... 还有 %d 个文件未显示\n", len(uploaded)-maxDisplayFiles)
+	}
+	fmt.Fprintf(&sb, "上传总大小：%s\n", formatFileSize(uploadedSize))
+
+	// 本地保留部分
+	fmt.Fprintf(&sb, "本地保留：%d 个\n", len(kept))
+	var keptSize int64
+	for i, f := range kept {
+		keptSize += f.Size
+		if i < maxDisplayFiles {
+			fmt.Fprintf(&sb, "  %d. %s (%s)\n", i+1, f.Name, formatFileSize(f.Size))
+		}
+	}
+	if len(kept) > maxDisplayFiles {
+		fmt.Fprintf(&sb, "  ... 还有 %d 个文件未显示\n", len(kept)-maxDisplayFiles)
+	}
+	fmt.Fprintf(&sb, "本地总大小：%s", formatFileSize(keptSize))
+	if outputPath != "" {
+		if free, err := getDiskFreeSpace(outputPath); err == nil {
+			fmt.Fprintf(&sb, "\n剩余磁盘空间：%s", formatFileSize(int64(free)))
+		}
+	}
+	return sb.String()
+}
+
+// buildRecordingSummaryMessageBody 构造纯本地保留的消息体（不含 title）
+func buildRecordingSummaryMessageBody(platform string, files []RecordingFileDetail, outputPath string) string {
+	_, body := buildRecordingSummaryMessage("", platform, files, outputPath)
+	return body
+}
+
 // SendRecordingSummary 录制结束后发送录制文件摘要通知
 // outputPath 为录制输出路径，用于获取剩余磁盘空间
 func SendRecordingSummary(logger *livelogger.LiveLogger, hostName, platform string, files []RecordingFileDetail, outputPath string) {
@@ -303,34 +351,33 @@ func SendPipelineRecordingSummary(
 		return
 	}
 
-	// 分离已上传文件和保留文件
+	// 分离已上传文件和本地保留文件
+	var uploaded []RecordingFileDetail
 	var kept []RecordingFileDetail
-	allUploaded := len(finalFiles) > 0
 	for _, f := range finalFiles {
 		if f.Uploaded {
-			// 已上传文件不显示在最终列表中（已从磁盘删除）
+			uploaded = append(uploaded, f)
 		} else {
-			allUploaded = false
 			kept = append(kept, f)
 		}
 	}
 
 	var title, body string
-	if allUploaded {
-		// 所有文件已上传并删除：显示实际上传的文件列表
-		displayFiles := finalFiles
-		if len(displayFiles) == 0 {
-			// 回退：finalFiles 为空时用 originalFiles
-			displayFiles = originalFiles
-		}
-		if len(displayFiles) == 0 {
-			return
-		}
+	if len(uploaded) > 0 && len(kept) == 0 {
+		// 所有文件已上传：显示上传文件列表
 		title = fmt.Sprintf("%s 录制完成", hostName)
-		body = buildUploadedSummaryBody(platform, displayFiles)
+		body = buildUploadedSummaryBody(platform, uploaded)
+	} else if len(uploaded) > 0 && len(kept) > 0 {
+		// 部分上传、部分保留：显示两段
+		title = fmt.Sprintf("%s 录制完成", hostName)
+		body = buildMixedSummaryBody(platform, uploaded, kept, outputPath)
 	} else if len(kept) > 0 {
-		// 有文件保留在磁盘：显示保留的文件列表
+		// 全部本地保留
 		title, body = buildRecordingSummaryMessage(hostName, platform, kept, outputPath)
+	} else if len(originalFiles) > 0 {
+		// finalFiles 为空，回退到 originalFiles
+		title = fmt.Sprintf("%s 录制完成", hostName)
+		body = buildRecordingSummaryMessageBody(platform, originalFiles, outputPath)
 	} else {
 		return
 	}

--- a/src/pipeline/config.go
+++ b/src/pipeline/config.go
@@ -32,6 +32,8 @@ const (
 	OptionCommand = "command"
 	// OptionFileTypes 处理的文件类型过滤
 	OptionFileTypes = "file_types"
+	// OptionUploadSubtitles 是否上传关联的 .ass 弹幕字幕文件
+	OptionUploadSubtitles = "upload_subtitles"
 	// OptionCodec 视频编码器
 	OptionCodec = "codec"
 	// OptionCrf CRF 质量值
@@ -85,6 +87,7 @@ func ConvertLegacyConfig(legacy *configs.OnRecordFinished) *PipelineConfig {
 			OptionDeleteAllAfter: legacy.CloudUpload.DeleteAllAfterUpload,
 			OptionUploadTiming:   string(legacy.UploadTiming),
 			OptionFileTypes:      []string{string(FileTypeVideo), string(FileTypeCover)},
+			OptionUploadSubtitles: legacy.CloudUpload.UploadSubtitles,
 		},
 	}
 	hasCloudUpload := legacy.CloudUpload.Enable && legacy.CloudUpload.StorageName != ""

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -177,7 +177,20 @@ func (e *Executor) Execute(
 		return results, ctx.Ctx.Err()
 	}
 	// 保存最后阶段输出的快照（用于回调提取上传文件详情），再执行清理
-	ctx.LastStageFiles = files
+	// 必须深拷贝 Metadata，因为 deleteMarkedFiles 会清除 Metadata["uploaded"]，
+	// FileInfo.Metadata 是 map（引用类型），浅拷贝会共享同一 map
+	snapshot := make([]FileInfo, len(files))
+	for i, f := range files {
+		cp := f
+		if f.Metadata != nil {
+			cp.Metadata = make(map[string]any, len(f.Metadata))
+			for k, v := range f.Metadata {
+				cp.Metadata[k] = v
+			}
+		}
+		snapshot[i] = cp
+	}
+	ctx.LastStageFiles = snapshot
 	keptFiles := e.deleteMarkedFiles(files)
 	if len(results) > 0 {
 		results[len(results)-1].OutputFiles = keptFiles

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -67,6 +67,7 @@ func (e *Executor) Execute(
 
 	files := initialFiles
 	results := make([]StageResult, 0, len(config.Stages))
+	ctx.UploadedPaths = make(map[string]bool)
 	stageIndex := 0
 
 	for i, stageCfg := range config.Stages {
@@ -165,6 +166,54 @@ func (e *Executor) Execute(
 			"stage_name":   stageCfg.Name,
 			"output_count": len(output),
 		}).Debug("stage completed")
+	}
+
+	// 去重：多个阶段可能添加同名文件（如 cloud_upload 上传 .ass 后，burn 又添加 Deletable 副本）
+	// 保留第一个出现的（保留最早阶段的 Metadata，如 uploaded 标记）
+	seen := map[string]int{}
+	var deduped []FileInfo
+	for _, f := range files {
+		if idx, exists := seen[f.Path]; exists {
+			// 合并 Deletable 标记到已有条目
+			if f.Deletable && !deduped[idx].Deletable {
+				deduped[idx].Deletable = true
+			}
+			continue
+		}
+		seen[f.Path] = len(deduped)
+		deduped = append(deduped, f)
+	}
+	files = deduped
+
+	// 重新标记被后续阶段替换的已上传文件
+	// immediate 模式下 cloud_upload 最先执行，后续阶段（fix_flv）
+	// 创建新 FileInfo 替换原始文件，丢失 Metadata["uploaded"]。
+	// 通过 UploadedPaths 按基名+扩展名匹配，为同类型的替换文件恢复上传标记。
+	// 不匹配不同扩展名的派生文件（如 .flv 上传后生成的 .mp4/.mkv 不应标记为 uploaded）。
+	if len(ctx.UploadedPaths) > 0 {
+		for uploadedPath := range ctx.UploadedPaths {
+			uploadedBase := strings.TrimSuffix(filepath.Base(uploadedPath), filepath.Ext(uploadedPath))
+			uploadedExt := strings.ToLower(filepath.Ext(uploadedPath))
+			for i, f := range files {
+				if f.Metadata != nil {
+					if u, ok := f.Metadata["uploaded"].(bool); ok && u {
+						continue // 已有标记，跳过
+					}
+				}
+				ext := strings.ToLower(filepath.Ext(f.Path))
+				if ext != uploadedExt {
+					continue // 不同扩展名，不是直接替换
+				}
+				fileBase := strings.TrimSuffix(filepath.Base(f.Path), ext)
+				if fileBase == uploadedBase {
+					if files[i].Metadata == nil {
+						files[i].Metadata = map[string]any{}
+					}
+					files[i].Metadata["uploaded"] = true
+					e.logger.Infof("恢复上传标记: %s (匹配 %s)", f.Path, filepath.Base(uploadedPath))
+				}
+			}
+		}
 	}
 
 	// 全部成功：执行延迟删除，并让最终结果反映磁盘上的文件

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -335,6 +335,10 @@ func (e *Executor) cleanupOrphanedAssFiles(allFiles []FileInfo, keptFiles []File
 	for _, f := range keptFiles {
 		ext := strings.ToLower(filepath.Ext(f.Path))
 		if ext == ".ass" {
+			// 先检查 .ass 是否还在磁盘上（可能已被 deleteMarkedFiles 删除）
+			if _, err := os.Stat(f.Path); os.IsNotExist(err) {
+				continue // 已被删除，不加入 kept
+			}
 			dir := filepath.Dir(f.Path)
 			base := strings.TrimSuffix(filepath.Base(f.Path), ".ass")
 			key := filepath.Join(dir, base)

--- a/src/pipeline/executor.go
+++ b/src/pipeline/executor.go
@@ -114,6 +114,9 @@ func (e *Executor) Execute(
 			output, commands, logs, err = e.executeStage(ctx, stageCfg, files)
 		}
 
+		// 回填新产出文件的 Size（阶段内构造 FileInfo 时可能未 stat）
+		backfillFileSizes(output)
+
 		// 记录结果
 		result := StageResult{
 			StageName:  stageCfg.Name,
@@ -173,6 +176,8 @@ func (e *Executor) Execute(
 		}
 		return results, ctx.Ctx.Err()
 	}
+	// 保存最后阶段输出的快照（用于回调提取上传文件详情），再执行清理
+	ctx.LastStageFiles = files
 	keptFiles := e.deleteMarkedFiles(files)
 	if len(results) > 0 {
 		results[len(results)-1].OutputFiles = keptFiles
@@ -470,6 +475,18 @@ func deduplicateFiles(files []FileInfo) []FileInfo {
 		}
 	}
 	return result
+}
+
+// backfillFileSizes 对 Size 为 0 的文件执行 os.Stat 回填大小
+// 阶段内构造 FileInfo 时可能未 stat，导致摘要通知漏掉这些文件
+func backfillFileSizes(files []FileInfo) {
+	for i := range files {
+		if files[i].Size == 0 {
+			if fi, err := os.Stat(files[i].Path); err == nil {
+				files[i].Size = fi.Size()
+			}
+		}
+	}
 }
 
 // getTimeNow 获取当前时间（可用于测试时 mock）

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -30,6 +30,7 @@ type Manager struct {
 	executor      *Executor
 	config        *ManagerConfig
 	runningTasks  map[int64]context.CancelFunc
+	taskCallbacks map[int64]func(*PipelineTask) // 按 task.ID 索引的完成回调（不经过持久化）
 	mu            sync.RWMutex
 	wg            sync.WaitGroup
 	eventDispatch events.Dispatcher
@@ -71,6 +72,7 @@ func NewManager(ctx context.Context, store Store, config *ManagerConfig, dispatc
 		executor:      NewExecutor(logrus.StandardLogger()),
 		config:        config,
 		runningTasks:  make(map[int64]context.CancelFunc),
+		taskCallbacks: make(map[int64]func(*PipelineTask)),
 		eventDispatch: dispatcher,
 	}
 
@@ -282,9 +284,16 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 	// 广播任务状态变化
 	m.broadcastTaskUpdate(task)
 
-	// 调用任务完成回调（recorder 用于追踪 Pipeline 状态并统一发送摘要）
-	if task.OnTaskComplete != nil {
-		task.OnTaskComplete(task)
+	// 调用任务完成回调（从 Manager 注册表查找，避免 SQLite 反序列化丢失）
+	m.mu.RLock()
+	callback := m.taskCallbacks[task.ID]
+	m.mu.RUnlock()
+	if callback != nil {
+		callback(task)
+		// 调用后清理注册表
+		m.mu.Lock()
+		delete(m.taskCallbacks, task.ID)
+		m.mu.Unlock()
 	}
 }
 
@@ -349,9 +358,20 @@ func (m *Manager) EnqueueRecordingTask(
 
 	// 创建任务
 	task := NewPipelineTask(NewRecordInfo(info), pipelineConfig, files)
-	task.OnTaskComplete = onTaskComplete
 
-	return m.EnqueueTask(task)
+	if err := m.EnqueueTask(task); err != nil {
+		return err
+	}
+
+	// 任务入队成功后注册回调（此时 task.ID 已由 store.AssignID 填充）
+	// 回调存储在 Manager 内存中，不经过持久化，避免 SQLite 反序列化丢失
+	if onTaskComplete != nil {
+		m.mu.Lock()
+		m.taskCallbacks[task.ID] = onTaskComplete
+		m.mu.Unlock()
+	}
+
+	return nil
 }
 
 // CancelTask 取消任务

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -396,6 +396,17 @@ func (m *Manager) CancelTask(taskID int64) error {
 			return err
 		}
 		m.broadcastTaskUpdate(task)
+
+		// 触发完成回调（recorder 需要递减 pipelinePendingCount）
+		m.mu.RLock()
+		callback := m.taskCallbacks[taskID]
+		m.mu.RUnlock()
+		if callback != nil {
+			callback(task)
+			m.mu.Lock()
+			delete(m.taskCallbacks, taskID)
+			m.mu.Unlock()
+		}
 	}
 
 	return nil

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bililive-go/bililive-go/src/configs"
 	"github.com/bililive-go/bililive-go/src/instance"
 	"github.com/bililive-go/bililive-go/src/live"
+	"github.com/bililive-go/bililive-go/src/notify"
 	"github.com/bililive-go/bililive-go/src/pkg/events"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 	bilisentry "github.com/bililive-go/bililive-go/src/pkg/sentry"
@@ -277,6 +278,9 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 
 	// 广播任务状态变化
 	m.broadcastTaskUpdate(task)
+
+	// 发送录制摘要通知（仅对录制任务，非手动上传）
+	m.sendRecordingSummaryIfNeeded(task)
 }
 
 // broadcastTaskUpdate 广播任务更新事件
@@ -284,6 +288,92 @@ func (m *Manager) broadcastTaskUpdate(task *PipelineTask) {
 	if m.eventDispatch != nil {
 		m.eventDispatch.DispatchEvent(events.NewEvent(PipelineTaskUpdateEvent, task))
 	}
+}
+
+// sendRecordingSummaryIfNeeded 在 Pipeline 任务完成后发送录制摘要通知
+// 仅对录制任务（LiveID 非 "manual-upload"）发送，手动上传不发通知
+func (m *Manager) sendRecordingSummaryIfNeeded(task *PipelineTask) {
+	// 跳过手动上传任务
+	if task.RecordInfo.LiveID == "manual-upload" {
+		return
+	}
+
+	// 仅在完成或失败时发送
+	if task.Status != PipelineStatusCompleted && task.Status != PipelineStatusFailed {
+		return
+	}
+
+	// 获取输出路径（用于查询剩余磁盘空间）
+	outputPath := ""
+	if len(task.InitialFiles) > 0 {
+		outputPath = filepath.Dir(task.InitialFiles[0].Path)
+	}
+
+	logger := livelogger.New(livelogger.DefaultBufferSize, logrus.Fields{
+		"platform": task.RecordInfo.Platform,
+		"host":     task.RecordInfo.HostName,
+	})
+
+	switch task.Status {
+	case PipelineStatusCompleted:
+		finalFiles := task.CurrentFiles // deleteMarkedFiles 后的保留文件
+
+		if len(finalFiles) == 0 {
+			// 所有文件已上传并删除：从 InitialFiles 构建原始文件列表（Size 已预存）
+			originalDetails := fileInfoToDetails(task.InitialFiles)
+			notify.SendPipelineRecordingSummary(
+				logger,
+				task.RecordInfo.HostName,
+				task.RecordInfo.Platform,
+				originalDetails, // originalFiles（显示用）
+				nil,             // finalFiles
+				outputPath,
+				true, // allUploadedAndDeleted
+			)
+		} else {
+			// 有文件保留：显示最终文件列表
+			fileDetails := fileInfoToDetails(finalFiles)
+			notify.SendPipelineRecordingSummary(
+				logger,
+				task.RecordInfo.HostName,
+				task.RecordInfo.Platform,
+				nil,         // originalFiles（不需要）
+				fileDetails, // finalFiles
+				outputPath,
+				false,
+			)
+		}
+
+	case PipelineStatusFailed:
+		// Pipeline 失败：文件仍在磁盘，用原始文件列表
+		fileDetails := fileInfoToDetails(task.InitialFiles)
+		if len(fileDetails) > 0 {
+			notify.SendPipelineRecordingSummary(
+				logger,
+				task.RecordInfo.HostName,
+				task.RecordInfo.Platform,
+				nil,         // originalFiles（不需要）
+				fileDetails, // finalFiles（失败时=原始文件）
+				outputPath,
+				false,
+			)
+		}
+	}
+}
+
+// fileInfoToDetails 将 FileInfo 切片转换为 RecordingFileDetail 切片
+// 使用 FileInfo 中预存的 Size，无需再次 stat 文件
+func fileInfoToDetails(files []FileInfo) []notify.RecordingFileDetail {
+	details := make([]notify.RecordingFileDetail, 0, len(files))
+	for _, f := range files {
+		if f.Size > 0 {
+			details = append(details, notify.RecordingFileDetail{
+				Name: filepath.Base(f.Path),
+				Size: f.Size,
+			})
+		}
+	}
+	return details
 }
 
 // EnqueueTask 添加任务到队列

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -284,16 +284,14 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 	// 广播任务状态变化
 	m.broadcastTaskUpdate(task)
 
-	// 调用任务完成回调（从 Manager 注册表查找，避免 SQLite 反序列化丢失）
-	m.mu.RLock()
+	// 原子地取出并删除回调，确保每个任务的回调至多触发一次
+	// 避免 executeTask 和 CancelTask 并发时双发回调
+	m.mu.Lock()
 	callback := m.taskCallbacks[task.ID]
-	m.mu.RUnlock()
+	delete(m.taskCallbacks, task.ID)
+	m.mu.Unlock()
 	if callback != nil {
 		callback(task)
-		// 调用后清理注册表
-		m.mu.Lock()
-		delete(m.taskCallbacks, task.ID)
-		m.mu.Unlock()
 	}
 }
 
@@ -321,9 +319,17 @@ func FileInfoToDetails(files []FileInfo) []notify.RecordingFileDetail {
 }
 
 // EnqueueTask 添加任务到队列
-func (m *Manager) EnqueueTask(task *PipelineTask) error {
+// onTaskComplete: 任务完成回调（可选），在异步调度前注册，避免竞态窗口
+func (m *Manager) EnqueueTask(task *PipelineTask, onTaskComplete func(*PipelineTask)) error {
 	if err := m.store.CreateTask(m.ctx, task); err != nil {
 		return fmt.Errorf("failed to create pipeline task: %w", err)
+	}
+
+	// 在异步调度前注册回调，确保 executeTask 读取时回调已就绪
+	if onTaskComplete != nil {
+		m.mu.Lock()
+		m.taskCallbacks[task.ID] = onTaskComplete
+		m.mu.Unlock()
 	}
 
 	logrus.WithFields(logrus.Fields{
@@ -359,19 +365,8 @@ func (m *Manager) EnqueueRecordingTask(
 	// 创建任务
 	task := NewPipelineTask(NewRecordInfo(info), pipelineConfig, files)
 
-	if err := m.EnqueueTask(task); err != nil {
-		return err
-	}
-
-	// 任务入队成功后注册回调（此时 task.ID 已由 store.AssignID 填充）
-	// 回调存储在 Manager 内存中，不经过持久化，避免 SQLite 反序列化丢失
-	if onTaskComplete != nil {
-		m.mu.Lock()
-		m.taskCallbacks[task.ID] = onTaskComplete
-		m.mu.Unlock()
-	}
-
-	return nil
+	// 入队并注册回调（EnqueueTask 内部在异步调度前完成注册，避免竞态窗口）
+	return m.EnqueueTask(task, onTaskComplete)
 }
 
 // CancelTask 取消任务
@@ -397,15 +392,13 @@ func (m *Manager) CancelTask(taskID int64) error {
 		}
 		m.broadcastTaskUpdate(task)
 
-		// 触发完成回调（recorder 需要递减 pipelinePendingCount）
-		m.mu.RLock()
+		// 原子地取出并删除回调，避免与 executeTask 并发时双发
+		m.mu.Lock()
 		callback := m.taskCallbacks[taskID]
-		m.mu.RUnlock()
+		delete(m.taskCallbacks, taskID)
+		m.mu.Unlock()
 		if callback != nil {
 			callback(task)
-			m.mu.Lock()
-			delete(m.taskCallbacks, taskID)
-			m.mu.Unlock()
 		}
 	}
 
@@ -714,7 +707,7 @@ func (m *Manager) EnqueueUploadTask(absPaths []string) (enqueued int, skipped []
 		files := []FileInfo{NewVideoFileInfo(absPath)}
 		task := NewPipelineTask(recordInfo, uploadConfig, files)
 
-		if enqueueErr := m.EnqueueTask(task); enqueueErr != nil {
+		if enqueueErr := m.EnqueueTask(task, nil); enqueueErr != nil {
 			skipped = append(skipped, filepath.Base(absPath)+" - 入队失败: "+enqueueErr.Error())
 			continue
 		}

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -672,6 +672,7 @@ func (m *Manager) EnqueueUploadTask(absPaths []string) (enqueued int, skipped []
 					OptionDeleteAllAfter: cu.DeleteAllAfterUpload,
 					OptionUploadTiming:   "after_process", // 手动上传无后续处理阶段，始终允许删除标记（不继承全局 upload_timing）
 					OptionFileTypes:      []string{string(FileTypeVideo), string(FileTypeCover)},
+					OptionUploadSubtitles: cu.UploadSubtitles,
 				},
 			},
 		},

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bililive-go/bililive-go/src/configs"
 	"github.com/bililive-go/bililive-go/src/instance"
 	"github.com/bililive-go/bililive-go/src/live"
+	"github.com/bililive-go/bililive-go/src/notify"
 	"github.com/bililive-go/bililive-go/src/pkg/events"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 	bilisentry "github.com/bililive-go/bililive-go/src/pkg/sentry"
@@ -270,6 +271,9 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 		logrus.WithField("task_id", task.ID).Info("pipeline task completed successfully")
 	}
 
+	// 保存最后阶段输出的快照（清理前），用于回调提取上传文件详情
+	task.LastStageFiles = pipelineCtx.LastStageFiles
+
 	// 更新任务状态
 	if err := m.store.UpdateTask(m.ctx, task); err != nil {
 		logrus.WithError(err).Error("failed to update pipeline task status after execution")
@@ -277,6 +281,11 @@ func (m *Manager) executeTask(ctx context.Context, task *PipelineTask) {
 
 	// 广播任务状态变化
 	m.broadcastTaskUpdate(task)
+
+	// 调用任务完成回调（recorder 用于追踪 Pipeline 状态并统一发送摘要）
+	if task.OnTaskComplete != nil {
+		task.OnTaskComplete(task)
+	}
 }
 
 // broadcastTaskUpdate 广播任务更新事件
@@ -284,6 +293,22 @@ func (m *Manager) broadcastTaskUpdate(task *PipelineTask) {
 	if m.eventDispatch != nil {
 		m.eventDispatch.DispatchEvent(events.NewEvent(PipelineTaskUpdateEvent, task))
 	}
+}
+
+// FileInfoToDetails 将 FileInfo 切片转换为 RecordingFileDetail 切片
+// 使用 FileInfo 中预存的 Size，无需再次 stat 文件
+// 仅包含视频和其他类型文件，排除封面（封面不在录制摘要中展示）
+func FileInfoToDetails(files []FileInfo) []notify.RecordingFileDetail {
+	details := make([]notify.RecordingFileDetail, 0, len(files))
+	for _, f := range files {
+		if f.Size > 0 && f.Type != FileTypeCover {
+			details = append(details, notify.RecordingFileDetail{
+				Name: filepath.Base(f.Path),
+				Size: f.Size,
+			})
+		}
+	}
+	return details
 }
 
 // EnqueueTask 添加任务到队列
@@ -309,10 +334,12 @@ func (m *Manager) EnqueueTask(task *PipelineTask) error {
 
 // EnqueueRecordingTask 创建并入队录制完成后的处理任务
 // 这是 recorder.go 调用的主要入口
+// onTaskComplete: 任务完成回调（可选），用于通知 recorder 任务结束
 func (m *Manager) EnqueueRecordingTask(
 	info *live.Info,
 	pipelineConfig *PipelineConfig,
 	outputFiles []string,
+	onTaskComplete func(task *PipelineTask),
 ) error {
 	// 构建文件信息列表
 	files := make([]FileInfo, len(outputFiles))
@@ -322,6 +349,7 @@ func (m *Manager) EnqueueRecordingTask(
 
 	// 创建任务
 	task := NewPipelineTask(NewRecordInfo(info), pipelineConfig, files)
+	task.OnTaskComplete = onTaskComplete
 
 	return m.EnqueueTask(task)
 }
@@ -644,7 +672,7 @@ func (m *Manager) EnqueueUploadTask(absPaths []string) (enqueued int, skipped []
 		platform, hostName := inferUploadPathInfo(relPath)
 
 		recordInfo := RecordInfo{
-			LiveID:      types.LiveID("manual-upload"),
+			LiveID:      types.LiveID(ManualUploadLiveID),
 			Platform:    platform,              // 用于上传路径模板：{{ .Platform }}
 			HostName:    hostName,              // 用于上传路径模板：{{ .HostName }}
 			RoomName:    "",                    // 手动上传无房间名，不影响路径模板

--- a/src/pipeline/manager.go
+++ b/src/pipeline/manager.go
@@ -319,18 +319,19 @@ func FileInfoToDetails(files []FileInfo) []notify.RecordingFileDetail {
 }
 
 // EnqueueTask 添加任务到队列
-// onTaskComplete: 任务完成回调（可选），在异步调度前注册，避免竞态窗口
+// onTaskComplete: 任务完成回调（可选），在任务对调度器可见前注册
 func (m *Manager) EnqueueTask(task *PipelineTask, onTaskComplete func(*PipelineTask)) error {
+	// 持锁覆盖 CreateTask + 回调注册，阻塞 pollLoop 的 scheduleNextTasks（需 RLock）
+	// 确保任务对调度器可见时回调已就绪
+	m.mu.Lock()
 	if err := m.store.CreateTask(m.ctx, task); err != nil {
+		m.mu.Unlock()
 		return fmt.Errorf("failed to create pipeline task: %w", err)
 	}
-
-	// 在异步调度前注册回调，确保 executeTask 读取时回调已就绪
 	if onTaskComplete != nil {
-		m.mu.Lock()
 		m.taskCallbacks[task.ID] = onTaskComplete
-		m.mu.Unlock()
 	}
+	m.mu.Unlock()
 
 	logrus.WithFields(logrus.Fields{
 		"task_id":       task.ID,

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -314,6 +314,9 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 						output = append(output, pipeline.FileInfo{
 							Path: assPath,
 							Type: pipeline.FileTypeOther,
+							Metadata: map[string]any{
+								"uploaded": true, // 全部上传成功，字幕文件将一并删除，标记为已上传
+							},
 						})
 						assAdded[assPath] = true
 						ctx.Logger.Infof("delete_all 模式：关联字幕文件 %s", assPath)
@@ -351,6 +354,34 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 					}
 					output[i].Metadata["uploaded"] = true
 					count++
+				}
+			}
+			// 已上传的视频文件会被删除，其关联的 .ass 字幕文件也应标记为已上传
+			// 避免摘要将已删除的字幕文件误显为本地保留文件
+			for _, f := range output {
+				ext := strings.ToLower(filepath.Ext(f.Path))
+				if ext != ".flv" && ext != ".mp4" && ext != ".mkv" && ext != ".ts" {
+					continue
+				}
+				assPath := strings.TrimSuffix(f.Path, ext) + ".ass"
+				if _, err := os.Stat(assPath); err == nil {
+					alreadyInOutput := false
+					for _, of := range output {
+						if of.Path == assPath {
+							alreadyInOutput = true
+							break
+						}
+					}
+					if !alreadyInOutput {
+						output = append(output, pipeline.FileInfo{
+							Path: assPath,
+							Type: pipeline.FileTypeOther,
+							Metadata: map[string]any{
+								"uploaded": true,
+							},
+						})
+						ctx.Logger.Infof("delete_uploaded 模式：关联字幕文件 %s", assPath)
+					}
 				}
 			}
 			s.logs += fmt.Sprintf("全部上传成功，已标记 %d 个已上传文件待删除\n", count)

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -320,6 +320,11 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 		s.logs += fmt.Sprintf("上传成功: %s -> %s/%s\n", fileName, s.storageName, targetPath)
 		ctx.Logger.Infof("文件上传成功: %s -> %s/%s", fileName, s.storageName, targetPath)
+		// 标记已上传（立即设置，不依赖后续删除逻辑块，确保 immediate 模式下也有标记）
+		if file.Metadata == nil {
+			file.Metadata = map[string]any{}
+		}
+		file.Metadata["uploaded"] = true
 		uploadedIndices[len(output)] = true // 记录上传成功的文件索引
 		output = append(output, file)
 

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -325,6 +325,10 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 			file.Metadata = map[string]any{}
 		}
 		file.Metadata["uploaded"] = true
+		// 记录上传路径，用于后续阶段替换文件后重新标记
+		if ctx.UploadedPaths != nil {
+			ctx.UploadedPaths[file.Path] = true
+		}
 		uploadedIndices[len(output)] = true // 记录上传成功的文件索引
 		output = append(output, file)
 

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -229,9 +229,12 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 
 	for _, file := range input {
 		// 跳过标记为待删除的中间文件（由其他阶段产出，不应上传）
+		// 例外：uploadSubtitles 时放行 Deletable 的 .ass（如 burn_delete_ass 标记的字幕）
 		if file.Deletable {
-			output = append(output, file)
-			continue
+			if !s.uploadSubtitles || strings.ToLower(filepath.Ext(file.Path)) != ".ass" {
+				output = append(output, file)
+				continue
+			}
 		}
 
 		// 文件类型过滤（uploadSubtitles 时放行 .ass 字幕文件）
@@ -329,6 +332,18 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 					ctx.Logger.Warnf("保存上传标记失败: %v", markErr)
 				}
 			}
+		}
+	}
+
+	// 为已上传的 Deletable 文件标记 Metadata["uploaded"]（如 burn_delete_ass 标记的 .ass）
+	// 这些文件在上传循环中被放行（uploadSubtitles），但 Deletable 跳过逻辑未标记 uploaded
+	for i, f := range output {
+		if uploadedIndices[i] && f.Deletable {
+			if f.Metadata == nil {
+				f.Metadata = map[string]any{}
+			}
+			f.Metadata["uploaded"] = true
+			output[i] = f
 		}
 	}
 

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -97,27 +97,29 @@ func (s *ExtractCoverStage) GetLogs() string {
 
 // CloudUploadStage 云上传阶段
 type CloudUploadStage struct {
-	config         pipeline.StageConfig
-	storageName    string
-	pathTemplate   string
-	deleteAfter    bool   // 仅删除已上传的文件
-	deleteAllAfter bool   // 删除全部文件（含中间产物）
-	uploadTiming   string // immediate 或 after_process
-	fileTypes      []string // 过滤的文件类型，空表示所有
-	commands       []string
-	logs           string
+	config          pipeline.StageConfig
+	storageName     string
+	pathTemplate    string
+	deleteAfter     bool   // 仅删除已上传的文件
+	deleteAllAfter  bool   // 删除全部文件（含中间产物）
+	uploadTiming    string // immediate 或 after_process
+	fileTypes       []string // 过滤的文件类型，空表示所有
+	uploadSubtitles bool   // 是否上传关联的 .ass 弹幕字幕文件
+	commands        []string
+	logs            string
 }
 
 // NewCloudUploadStage 创建云上传阶段工厂
 func NewCloudUploadStage(config pipeline.StageConfig) (pipeline.Stage, error) {
 	return &CloudUploadStage{
-		config:         config,
-		storageName:    config.GetStringOption(pipeline.OptionStorage, ""),
-		pathTemplate:   config.GetStringOption(pipeline.OptionPathTemplate, ""),
-		deleteAfter:    config.GetBoolOption(pipeline.OptionDeleteAfter, false),
-		deleteAllAfter: config.GetBoolOption(pipeline.OptionDeleteAllAfter, false),
-		uploadTiming:   config.GetStringOption(pipeline.OptionUploadTiming, ""),
-		fileTypes:      config.GetStringSliceOption(pipeline.OptionFileTypes),
+		config:          config,
+		storageName:     config.GetStringOption(pipeline.OptionStorage, ""),
+		pathTemplate:    config.GetStringOption(pipeline.OptionPathTemplate, ""),
+		deleteAfter:     config.GetBoolOption(pipeline.OptionDeleteAfter, false),
+		deleteAllAfter:  config.GetBoolOption(pipeline.OptionDeleteAllAfter, false),
+		uploadTiming:    config.GetStringOption(pipeline.OptionUploadTiming, ""),
+		fileTypes:       config.GetStringSliceOption(pipeline.OptionFileTypes),
+		uploadSubtitles: config.GetBoolOption(pipeline.OptionUploadSubtitles, false),
 	}, nil
 }
 
@@ -179,6 +181,52 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 	// 与最终视频（如录播姬生成的多分段 _PART 文件），无需额外限制
 	uploadedIndices := map[int]bool{} // 记录实际上传的文件在 output 中的索引
 
+	// 上传弹幕字幕：扫描 input 中的视频文件，从磁盘发现关联的 .ass 文件并加入 input
+	if s.uploadSubtitles {
+		assAdded := map[string]bool{}
+		var discovered []pipeline.FileInfo
+		for _, f := range input {
+			ext := strings.ToLower(filepath.Ext(f.Path))
+			if ext != ".flv" && ext != ".mp4" && ext != ".mkv" && ext != ".ts" {
+				continue
+			}
+			assPath := strings.TrimSuffix(f.Path, ext) + ".ass"
+			if assAdded[assPath] {
+				continue
+			}
+			if info, err := os.Stat(assPath); err == nil && info.Size() > 0 {
+				// 检查 input 和 discovered 中是否已存在
+				alreadyExists := false
+				for _, of := range input {
+					if of.Path == assPath {
+						alreadyExists = true
+						break
+					}
+				}
+				if !alreadyExists {
+					for _, of := range discovered {
+						if of.Path == assPath {
+							alreadyExists = true
+							break
+						}
+					}
+				}
+				if !alreadyExists {
+					discovered = append(discovered, pipeline.FileInfo{
+						Path: assPath,
+						Size: info.Size(),
+						Type: pipeline.FileTypeOther,
+					})
+					assAdded[assPath] = true
+					ctx.Logger.Infof("发现关联弹幕字幕文件: %s", assPath)
+				}
+			}
+		}
+		if len(discovered) > 0 {
+			input = append(input, discovered...)
+		}
+	}
+
 	for _, file := range input {
 		// 跳过标记为待删除的中间文件（由其他阶段产出，不应上传）
 		if file.Deletable {
@@ -186,10 +234,12 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 			continue
 		}
 
-		// 文件类型过滤
+		// 文件类型过滤（uploadSubtitles 时放行 .ass 字幕文件）
 		if len(s.fileTypes) > 0 && !s.matchFileType(file.Type) {
-			output = append(output, file)
-			continue
+			if !s.uploadSubtitles || strings.ToLower(filepath.Ext(file.Path)) != ".ass" {
+				output = append(output, file)
+				continue
+			}
 		}
 
 		// 检查文件是否存在
@@ -358,7 +408,10 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 			}
 			// 已上传的视频文件会被删除，其关联的 .ass 字幕文件也应标记为已上传
 			// 避免摘要将已删除的字幕文件误显为本地保留文件
-			for _, f := range output {
+			for i, f := range output {
+				if !uploadedIndices[i] {
+					continue // 仅处理已上传成功的视频文件
+				}
 				ext := strings.ToLower(filepath.Ext(f.Path))
 				if ext != ".flv" && ext != ".mp4" && ext != ".mkv" && ext != ".ts" {
 					continue

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -377,11 +377,9 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 					}
 					if !alreadyInOutput {
 						output = append(output, pipeline.FileInfo{
-							Path: assPath,
-							Type: pipeline.FileTypeOther,
-							Metadata: map[string]any{
-								"uploaded": true, // 全部上传成功，字幕文件将一并删除，标记为已上传
-							},
+							Path:      assPath,
+							Type:      pipeline.FileTypeOther,
+							Deletable: true, // 标记为可删除，由 executor 统一清理
 						})
 						assAdded[assPath] = true
 						ctx.Logger.Infof("delete_all 模式：关联字幕文件 %s", assPath)
@@ -421,8 +419,9 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 					count++
 				}
 			}
-			// 已上传的视频文件会被删除，其关联的 .ass 字幕文件也应标记为已上传
+			// 已上传的视频文件会被删除，其关联的 .ass 字幕文件也应标记为可删除
 			// 避免摘要将已删除的字幕文件误显为本地保留文件
+			// 注意：这些 .ass 未被上传到云存储，不标记 uploaded，仅标记 Deletable
 			for i, f := range output {
 				if !uploadedIndices[i] {
 					continue // 仅处理已上传成功的视频文件
@@ -442,11 +441,9 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 					}
 					if !alreadyInOutput {
 						output = append(output, pipeline.FileInfo{
-							Path: assPath,
-							Type: pipeline.FileTypeOther,
-							Metadata: map[string]any{
-								"uploaded": true,
-							},
+							Path:      assPath,
+							Type:      pipeline.FileTypeOther,
+							Deletable: true, // 标记为可删除，由 executor 统一清理
 						})
 						ctx.Logger.Infof("delete_uploaded 模式：关联字幕文件 %s", assPath)
 					}

--- a/src/pipeline/stages/extract_cover.go
+++ b/src/pipeline/stages/extract_cover.go
@@ -334,6 +334,10 @@ func (s *CloudUploadStage) Execute(ctx *pipeline.PipelineContext, input []pipeli
 					output[i].Metadata = map[string]any{}
 				}
 				output[i].Metadata["delete_all"] = true
+				// 为实际上传的文件标记 uploaded（供回调提取上传文件详情）
+				if uploadedIndices[i] {
+					output[i].Metadata["uploaded"] = true
+				}
 			}
 			s.logs += fmt.Sprintf("全部上传成功，已标记 %d 个文件待删除（含中间产物）\n", len(output))
 			ctx.Logger.Infof("全部上传成功，已标记 %d 个文件待删除（含中间产物）", len(output))

--- a/src/pipeline/types.go
+++ b/src/pipeline/types.go
@@ -4,6 +4,7 @@ package pipeline
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/bililive-go/bililive-go/src/live"
@@ -14,6 +15,9 @@ import (
 
 // PipelineTaskUpdateEvent 管道任务更新事件
 const PipelineTaskUpdateEvent events.EventType = "PipelineTaskUpdate"
+
+// ManualUploadLiveID 手动上传任务的 LiveID 标识
+const ManualUploadLiveID = "manual-upload"
 
 // FileType 文件类型
 type FileType string
@@ -30,18 +34,23 @@ const (
 // FileInfo 表示管道中流转的文件信息
 type FileInfo struct {
 	Path       string         `json:"path"`                  // 文件绝对路径
+	Size       int64          `json:"size,omitempty"`        // 文件大小（字节），在任务创建时记录
 	Type       FileType       `json:"type"`                  // 文件类型
 	SourcePath string         `json:"source_path,omitempty"` // 来源文件路径（用于追踪转换链）
 	Metadata   map[string]any `json:"metadata,omitempty"`    // 额外元数据
 	Deletable  bool           `json:"deletable,omitempty"`   // 标记此文件在管道全部成功后可删除
 }
 
-// NewVideoFileInfo 创建视频文件信息
+// NewVideoFileInfo 创建视频文件信息，自动记录文件大小
 func NewVideoFileInfo(path string) FileInfo {
-	return FileInfo{
+	fi := FileInfo{
 		Path: path,
 		Type: FileTypeVideo,
 	}
+	if stat, err := os.Stat(path); err == nil {
+		fi.Size = stat.Size()
+	}
+	return fi
 }
 
 // NewCoverFileInfo 创建封面文件信息
@@ -84,6 +93,10 @@ type PipelineContext struct {
 
 	// FFmpegPath 是 ffmpeg 可执行文件的路径
 	FFmpegPath string
+
+	// LastStageFiles 最后阶段输出的文件快照（清理前保存）
+	// 用于回调提取上传文件详情，因为 deleteMarkedFiles 会删除文件
+	LastStageFiles []FileInfo
 }
 
 // Stage 管道阶段接口
@@ -243,6 +256,8 @@ type PipelineTask struct {
 	CompletedAt    *time.Time      `json:"completed_at,omitempty"`
 	ErrorMessage   string          `json:"error_message,omitempty"`
 	CanRetry       bool            `json:"can_retry"` // 是否可以重试
+	OnTaskComplete func(task *PipelineTask) `json:"-"` // 任务完成回调（不持久化）
+	LastStageFiles []FileInfo      `json:"-"` // 最后阶段输出文件（清理前快照，不持久化）
 }
 
 // NewPipelineTask 创建新的管道任务

--- a/src/pipeline/types.go
+++ b/src/pipeline/types.go
@@ -256,7 +256,6 @@ type PipelineTask struct {
 	CompletedAt    *time.Time      `json:"completed_at,omitempty"`
 	ErrorMessage   string          `json:"error_message,omitempty"`
 	CanRetry       bool            `json:"can_retry"` // 是否可以重试
-	OnTaskComplete func(task *PipelineTask) `json:"-"` // 任务完成回调（不持久化）
 	LastStageFiles []FileInfo      `json:"-"` // 最后阶段输出文件（清理前快照，不持久化）
 }
 

--- a/src/pipeline/types.go
+++ b/src/pipeline/types.go
@@ -97,6 +97,11 @@ type PipelineContext struct {
 	// LastStageFiles 最后阶段输出的文件快照（清理前保存）
 	// 用于回调提取上传文件详情，因为 deleteMarkedFiles 会删除文件
 	LastStageFiles []FileInfo
+
+	// UploadedPaths 记录 cloud_upload 阶段成功上传的文件路径
+	// 用于在所有阶段执行完毕后，为被后续阶段替换的文件重新标记 Metadata["uploaded"]
+	// （如 fix_flv 替换 .flv 后，新 FileInfo 丢失上传标记）
+	UploadedPaths map[string]bool
 }
 
 // Stage 管道阶段接口

--- a/src/pipeline/types.go
+++ b/src/pipeline/types.go
@@ -4,6 +4,7 @@ package pipeline
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/bililive-go/bililive-go/src/live"
@@ -30,18 +31,23 @@ const (
 // FileInfo 表示管道中流转的文件信息
 type FileInfo struct {
 	Path       string         `json:"path"`                  // 文件绝对路径
+	Size       int64          `json:"size,omitempty"`        // 文件大小（字节），在任务创建时记录
 	Type       FileType       `json:"type"`                  // 文件类型
 	SourcePath string         `json:"source_path,omitempty"` // 来源文件路径（用于追踪转换链）
 	Metadata   map[string]any `json:"metadata,omitempty"`    // 额外元数据
 	Deletable  bool           `json:"deletable,omitempty"`   // 标记此文件在管道全部成功后可删除
 }
 
-// NewVideoFileInfo 创建视频文件信息
+// NewVideoFileInfo 创建视频文件信息，自动记录文件大小
 func NewVideoFileInfo(path string) FileInfo {
-	return FileInfo{
+	fi := FileInfo{
 		Path: path,
 		Type: FileTypeVideo,
 	}
+	if stat, err := os.Stat(path); err == nil {
+		fi.Size = stat.Size()
+	}
+	return fi
 }
 
 // NewCoverFileInfo 创建封面文件信息

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -73,6 +73,8 @@ type Manager interface {
 	GetRecorderStatus(ctx context.Context, liveId types.LiveID) (map[string]interface{}, error)
 	// GetActiveRecordingsCount 获取当前活跃的录制数量
 	GetActiveRecordingsCount() int
+	// WaitForNotifications 等待所有异步通知 goroutine 完成（关闭流程中使用）
+	WaitForNotifications()
 }
 
 // for test
@@ -86,6 +88,7 @@ type manager struct {
 	statusTicker *time.Ticker
 	statusStopCh chan struct{}
 	statusWg     sync.WaitGroup // 用于等待广播 goroutine 退出
+	notifyWg     sync.WaitGroup // 跟踪异步通知 goroutine（sendAccumulatedSummary），关闭时等待
 	// restartingCount 追踪正在执行 CloseForRestart 的旧 recorder 数量。
 	// RestartRecorder 在释放锁后才执行 oldRecorder.CloseForRestart()，
 	// 此期间 map 中只有新 recorder，但旧 recorder 仍在收尾运行。
@@ -169,6 +172,12 @@ func (m *manager) Close(ctx context.Context) {
 	inst.WaitGroup.Done()
 }
 
+// WaitForNotifications 等待所有异步通知 goroutine 完成
+// 应在 PipelineManager.Close 之后调用，确保所有 pipeline 回调触发的通知已完成
+func (m *manager) WaitForNotifications() {
+	m.notifyWg.Wait()
+}
+
 func (m *manager) AddRecorder(ctx context.Context, live live.Live) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -180,11 +189,15 @@ func (m *manager) addRecorderLocked(ctx context.Context, live live.Live) error {
 	if _, ok := m.savers[live.GetLiveId()]; ok {
 		return ErrRecorderExist
 	}
-	recorder, err := newRecorder(ctx, live)
+	rec, err := newRecorder(ctx, live)
 	if err != nil {
 		return err
 	}
-	m.savers[live.GetLiveId()] = recorder
+	// 设置通知 WaitGroup，使异步摘要发送 goroutine 可被关闭流程等待
+	if recTyped, ok := rec.(*recorder); ok {
+		recTyped.notifyWg = &m.notifyWg
+	}
+	m.savers[live.GetLiveId()] = rec
 
 	cfg := configs.GetCurrentConfig()
 	if cfg != nil {
@@ -192,12 +205,12 @@ func (m *manager) addRecorderLocked(ctx context.Context, live live.Live) error {
 			bilisentry.GoWithContext(ctx, func(ctx context.Context) { m.cronRestart(ctx, live) })
 		}
 	}
-	if err := recorder.Start(ctx); err != nil {
+	if err := rec.Start(ctx); err != nil {
 		// Start 失败时从 map 删除并异步 Close 新 recorder，防止泄漏/僵尸实例
 		// 使用异步 Close 避免在持锁时执行耗时操作（如等待 ffmpeg 进程退出），
 		// 防止长时间阻塞其他 manager 操作
 		delete(m.savers, live.GetLiveId())
-		bilisentry.Go(recorder.Close)
+		bilisentry.Go(rec.Close)
 		return err
 	}
 	return nil
@@ -241,6 +254,11 @@ func (m *manager) RestartRecorder(ctx context.Context, live live.Live) error {
 		return err
 	}
 	newRec := m.savers[live.GetLiveId()]
+	// 设置分段重启摘要屏障：阻止新 recorder 在 Pipeline 状态转移前发送摘要
+	if newRecTyped, ok := newRec.(*recorder); ok {
+		newRecTyped.transferWg = &sync.WaitGroup{}
+		newRecTyped.transferWg.Add(1)
+	}
 	// restartingCount 必须在释放锁之前递增，否则 Unlock 到 Add(1) 之间
 	// LiveEnd 可能移除新 recorder 并看到 restartingCount==0，
 	// 导致 GetActiveRecordingsCount() 误判为"无活跃录制"触发优雅更新
@@ -279,6 +297,8 @@ func (m *manager) RestartRecorder(ctx context.Context, live live.Live) error {
 		if oldRecTyped, ok := oldRecorder.(*recorder); ok {
 			newRecTyped.TransferPipelineState(oldRecTyped)
 		}
+		// 释放摘要屏障：转移已完成（或无需转移），允许新 recorder 发送摘要
+		newRecTyped.transferWg.Done()
 	}
 
 	return nil

--- a/src/recorders/manager.go
+++ b/src/recorders/manager.go
@@ -274,6 +274,13 @@ func (m *manager) RestartRecorder(ctx context.Context, live live.Live) error {
 		}
 	}
 
+	// 4. 转移 Pipeline 状态（确保旧分段的 Pipeline 结果不丢失）
+	if newRecTyped, ok := newRec.(*recorder); ok {
+		if oldRecTyped, ok := oldRecorder.(*recorder); ok {
+			newRecTyped.TransferPipelineState(oldRecTyped)
+		}
+	}
+
 	return nil
 }
 

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -291,7 +291,10 @@ type recorder struct {
 	pipelineMu sync.Mutex
 	// pipelineDetails 收集各 Pipeline 任务的最终文件详情
 	// 任务完成时通过回调写入，录制结束时读取用于构造摘要
-	pipelineDetails []notify.RecordingFileDetail
+	// 使用指针，分段重启时新旧 recorder 共享同一底层数据
+	pipelineDetails *[]notify.RecordingFileDetail
+	// summarySent 标记摘要已发送，防止 defer 和回调并发双发
+	summarySent bool
 
 	// 当前录制的流信息（来自平台 API）
 	currentStreamInfo *live.AvailableStreamInfo
@@ -325,14 +328,15 @@ func NewRecorder(ctx context.Context, live live.Live) (Recorder, error) {
 	inst := instance.GetInstance(ctx)
 
 	return &recorder{
-		Live:       live,
-		cache:      inst.Cache,
-		startTime:  time.Now(),
-		ed:         inst.EventDispatcher.(events.Dispatcher),
-		state:      begin,
-		stop:       make(chan struct{}),
-		done:       make(chan struct{}),
-		parserLock: new(sync.RWMutex),
+		Live:            live,
+		cache:           inst.Cache,
+		startTime:       time.Now(),
+		ed:              inst.EventDispatcher.(events.Dispatcher),
+		state:           begin,
+		stop:            make(chan struct{}),
+		done:            make(chan struct{}),
+		parserLock:      new(sync.RWMutex),
+		pipelineDetails: new([]notify.RecordingFileDetail),
 	}, nil
 }
 
@@ -795,12 +799,20 @@ func (r *recorder) tryRecord(ctx context.Context) {
 			return
 		}
 
+		// 先递增 pending 计数（在入队前，避免任务被异步调度完成后回调递减到 -1）
+		r.pipelineMu.Lock()
+		r.pipelinePendingCount++
+		r.pipelineMu.Unlock()
+
 		// 入队 Pipeline 任务
 		if err := pipelineManager.EnqueueRecordingTask(info, pipelineConfig, outputFiles, r.onPipelineTaskComplete); err != nil {
 			r.getLogger().WithError(err).Error("failed to enqueue pipeline task")
+			// 入队失败，回滚计数
+			r.pipelineMu.Lock()
+			r.pipelinePendingCount--
+			r.pipelineMu.Unlock()
 		} else {
 			r.pipelineEnqueued = true
-			r.pipelinePendingCount++
 			// 记录 Pipeline 阶段顺序
 			var stageNames []string
 			for _, stage := range pipelineConfig.Stages {
@@ -974,13 +986,20 @@ func (r *recorder) accumulateRecordedFiles(files ...string) {
 func (r *recorder) sendAccumulatedSummary() {
 	r.pipelineMu.Lock()
 	pendingCount := r.pipelinePendingCount
-	r.pipelineMu.Unlock()
-
+	// 幂等保护：防止 defer 和回调并发双发
+	if r.summarySent {
+		r.pipelineMu.Unlock()
+		return
+	}
 	// Pipeline 任务尚未全部完成，等待回调触发最终摘要
 	if r.pipelineEnqueued && pendingCount > 0 {
+		r.pipelineMu.Unlock()
 		r.getLogger().Infof("Pipeline 任务尚未全部完成（剩余 %d 个），延迟摘要推送", pendingCount)
 		return
 	}
+	// 标记摘要已发送（在实际发送前，防止并发双发）
+	r.summarySent = true
+	r.pipelineMu.Unlock()
 
 	r.recordedFilesMu.Lock()
 	defer r.recordedFilesMu.Unlock()
@@ -988,7 +1007,7 @@ func (r *recorder) sendAccumulatedSummary() {
 		r.getLogger().Infof("录制摘要推送已抑制（分段重启），累积 %d 个文件将传递给新 recorder", len(r.recordedFiles))
 		return
 	}
-	if len(r.recordedFiles) == 0 && len(r.pipelineDetails) == 0 {
+	if len(r.recordedFiles) == 0 && len(*r.pipelineDetails) == 0 {
 		r.getLogger().Info("无录制文件，跳过摘要推送")
 		return
 	}
@@ -1003,12 +1022,12 @@ func (r *recorder) sendAccumulatedSummary() {
 	}
 
 	// 使用 Pipeline 收集的最终文件详情（如有），否则用录制累积的原始文件
-	if len(r.pipelineDetails) > 0 {
+	if len((*r.pipelineDetails)) > 0 {
 		// 合并未被 Pipeline 覆盖的录制文件（如某分段因 stages==0 未入队）
-		merged := r.pipelineDetails
+		merged := (*r.pipelineDetails)
 		if len(r.recordedFiles) > 0 {
 			inPipeline := map[string]bool{}
-			for _, d := range r.pipelineDetails {
+			for _, d := range (*r.pipelineDetails) {
 				inPipeline[d.Name] = true
 			}
 			for _, f := range r.recordedFiles {
@@ -1063,23 +1082,23 @@ func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
 			// 所有文件已上传并删除：从 LastStageFiles 提取真正上传的文件
 			uploadedDetails := extractUploadedDetails(task.LastStageFiles)
 			if len(uploadedDetails) > 0 {
-				r.pipelineDetails = append(r.pipelineDetails, uploadedDetails...)
+				(*r.pipelineDetails) = append((*r.pipelineDetails), uploadedDetails...)
 			} else {
 				// 回退：无上传标记时用原始文件
 				for _, d := range pipeline.FileInfoToDetails(task.InitialFiles) {
 					d.Uploaded = true
-					r.pipelineDetails = append(r.pipelineDetails, d)
+					(*r.pipelineDetails) = append((*r.pipelineDetails), d)
 				}
 			}
 		} else {
-			r.pipelineDetails = append(r.pipelineDetails, pipeline.FileInfoToDetails(finalFiles)...)
+			(*r.pipelineDetails) = append((*r.pipelineDetails), pipeline.FileInfoToDetails(finalFiles)...)
 		}
 	case pipeline.PipelineStatusFailed, pipeline.PipelineStatusCancelled:
 		// 失败/取消时优先用 CurrentFiles（最后成功阶段的输出），回退到 InitialFiles
 		if len(task.CurrentFiles) > 0 {
-			r.pipelineDetails = append(r.pipelineDetails, pipeline.FileInfoToDetails(task.CurrentFiles)...)
+			(*r.pipelineDetails) = append((*r.pipelineDetails), pipeline.FileInfoToDetails(task.CurrentFiles)...)
 		} else {
-			r.pipelineDetails = append(r.pipelineDetails, pipeline.FileInfoToDetails(task.InitialFiles)...)
+			(*r.pipelineDetails) = append((*r.pipelineDetails), pipeline.FileInfoToDetails(task.InitialFiles)...)
 		}
 	}
 
@@ -1275,6 +1294,30 @@ func (r *recorder) SetInitialRecordedFiles(files []notify.RecordingFileDetail) {
 	r.recordedFilesMu.Unlock()
 	// 日志不依赖 r.recordedFiles，移到锁外减少持有时间
 	r.getLogger().Infof("继承上一个 recorder 的 %d 个录制文件", len(files))
+}
+
+// TransferPipelineState 从旧 recorder 转移 Pipeline 状态
+// 分段重启时由 RestartRecorder 调用，确保旧分段的 Pipeline 结果不丢失
+func (r *recorder) TransferPipelineState(old *recorder) {
+	r.pipelineMu.Lock()
+	defer r.pipelineMu.Unlock()
+
+	old.pipelineMu.Lock()
+	defer old.pipelineMu.Unlock()
+
+	// 合并 Pipeline 状态
+	r.pipelineEnqueued = r.pipelineEnqueued || old.pipelineEnqueued
+	r.pipelinePendingCount += old.pipelinePendingCount
+
+	// 合并文件详情（旧 recorder 的详情追加到新 recorder）
+	*r.pipelineDetails = append(*r.pipelineDetails, *old.pipelineDetails...)
+
+	// 将旧 recorder 的详情指针指向新 recorder 的共享数据
+	// 这样旧 recorder 的回调写入时，数据会存到新 recorder 能读取的位置
+	old.pipelineDetails = r.pipelineDetails
+
+	r.getLogger().Infof("继承 Pipeline 状态：pending=%d, details=%d 个文件",
+		old.pipelinePendingCount, len(*old.pipelineDetails))
 }
 
 func (r *recorder) getLogger() *livelogger.LiveLogger {

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -1004,7 +1004,20 @@ func (r *recorder) sendAccumulatedSummary() {
 
 	// 使用 Pipeline 收集的最终文件详情（如有），否则用录制累积的原始文件
 	if len(r.pipelineDetails) > 0 {
-		r.getLogger().Infof("推送 Pipeline 录制摘要：%d 个文件", len(r.pipelineDetails))
+		// 合并未被 Pipeline 覆盖的录制文件（如某分段因 stages==0 未入队）
+		merged := r.pipelineDetails
+		if len(r.recordedFiles) > 0 {
+			inPipeline := map[string]bool{}
+			for _, d := range r.pipelineDetails {
+				inPipeline[d.Name] = true
+			}
+			for _, f := range r.recordedFiles {
+				if !inPipeline[f.Name] {
+					merged = append(merged, f)
+				}
+			}
+		}
+		r.getLogger().Infof("推送 Pipeline 录制摘要：%d 个文件", len(merged))
 		hostName := ""
 		platform := r.Live.GetPlatformCNName()
 		if obj, cacheErr := r.cache.Get(r.Live); cacheErr == nil {
@@ -1017,7 +1030,7 @@ func (r *recorder) sendAccumulatedSummary() {
 			hostName,
 			platform,
 			r.recordedFiles,     // originalFiles（allUploaded 时显示用）
-			r.pipelineDetails,   // finalFiles
+			merged,              // finalFiles（含未入队分段的文件）
 			outputPath,
 		)
 	} else {
@@ -1071,9 +1084,6 @@ func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
 	}
 
 	remaining := r.pipelinePendingCount
-
-	// 防止回调被重复执行（如内存中重试场景）
-	task.OnTaskComplete = nil
 
 	r.pipelineMu.Unlock()
 

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -1090,6 +1090,8 @@ func (r *recorder) sendAccumulatedSummary() {
 					merged = append(merged, f)
 				}
 			}
+			// 清理无关联视频的 .ass 文件（DAA/executor 可能已删除视频但 .ass 从 recordedFiles 加入）
+			merged = filterOrphanedAssFromDetails(merged)
 		}
 		r.getLogger().Infof("推送 Pipeline 录制摘要：%d 个文件", len(merged))
 		hostName := ""
@@ -1231,6 +1233,33 @@ func collectSourceNames(sourceNames map[string]bool, fileSets ...[]pipeline.File
 			}
 		}
 	}
+}
+
+// filterOrphanedAssFromDetails 从文件详情列表中移除无关联视频的 .ass 文件
+// 当 DAA/executor 删除了视频但 .ass 从 recordedFiles 加入 merged 时，
+// 需要清理这些孤立的 .ass，避免通知误显为本地保留
+func filterOrphanedAssFromDetails(details []notify.RecordingFileDetail) []notify.RecordingFileDetail {
+	videoExts := map[string]bool{".flv": true, ".mp4": true, ".mkv": true, ".ts": true}
+	videoBases := map[string]bool{}
+	for _, d := range details {
+		ext := strings.ToLower(filepath.Ext(d.Name))
+		if videoExts[ext] {
+			base := strings.TrimSuffix(d.Name, ext)
+			videoBases[base] = true
+		}
+	}
+	var result []notify.RecordingFileDetail
+	for _, d := range details {
+		ext := strings.ToLower(filepath.Ext(d.Name))
+		if ext == ".ass" {
+			base := strings.TrimSuffix(d.Name, ".ass")
+			if !videoBases[base] {
+				continue // 无关联视频，跳过
+			}
+		}
+		result = append(result, d)
+	}
+	return result
 }
 
 func (r *recorder) logStreamURLRetry(err error) {

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -265,6 +265,20 @@ var (
 	_ danmakuRecorder = (*danmaku.DouyuDanmakuRecorder)(nil)
 )
 
+// pipelineSharedState 封装可在分段重启时共享的 Pipeline 状态
+// 分段重启时新旧 recorder 通过指针重定向共享同一份状态，
+// 确保旧任务的回调能正确递减新 recorder 的计数器
+type pipelineSharedState struct {
+	mu             sync.Mutex
+	pendingCount   int                          // 尚未完成的 Pipeline 任务数
+	enqueued       bool                         // 是否有 Pipeline 任务已入队
+	summarySent    bool                         // 摘要是否已发送（幂等保护）
+	runExited      bool                         // run() 是否已退出（defer 中置位，回调中检查）
+	details        []notify.RecordingFileDetail // 收集的文件详情
+	sourceNames    map[string]bool              // 被 Pipeline 消费的原始文件名（用于合并时排除已删除的源文件）
+	onAllTasksDone func()                       // 所有任务完成时的回调（分段重启时设置）
+}
+
 type recorder struct {
 	Live       live.Live
 	ed         events.Dispatcher
@@ -281,20 +295,9 @@ type recorder struct {
 	currentFileLock sync.RWMutex
 	currentFilePath string
 
-	// pipelineEnqueued 标记 Pipeline 任务已入队，由 Pipeline Manager 负责发送录制摘要
-	// 避免 recorder 在 Pipeline 处理完成前发送不准确的原始文件列表
-	pipelineEnqueued bool
-	// pipelinePendingCount 追踪尚未完成的 Pipeline 任务数量
-	// 仅当所有任务完成且录制结束后，才发送统一的录制摘要
-	pipelinePendingCount int
-	// pipelineMu 保护 pipelinePendingCount 和 pipelineDetails 的并发访问
-	pipelineMu sync.Mutex
-	// pipelineDetails 收集各 Pipeline 任务的最终文件详情
-	// 任务完成时通过回调写入，录制结束时读取用于构造摘要
-	// 使用指针，分段重启时新旧 recorder 共享同一底层数据
-	pipelineDetails *[]notify.RecordingFileDetail
-	// summarySent 标记摘要已发送，防止 defer 和回调并发双发
-	summarySent bool
+	// pipelineState 封装 Pipeline 相关的共享状态
+	// 使用指针，分段重启时新旧 recorder 共享同一份状态
+	pipelineState *pipelineSharedState
 
 	// 当前录制的流信息（来自平台 API）
 	currentStreamInfo *live.AvailableStreamInfo
@@ -336,7 +339,9 @@ func NewRecorder(ctx context.Context, live live.Live) (Recorder, error) {
 		stop:            make(chan struct{}),
 		done:            make(chan struct{}),
 		parserLock:      new(sync.RWMutex),
-		pipelineDetails: new([]notify.RecordingFileDetail),
+		pipelineState: &pipelineSharedState{
+			sourceNames: make(map[string]bool),
+		},
 	}, nil
 }
 
@@ -800,19 +805,19 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		}
 
 		// 先递增 pending 计数（在入队前，避免任务被异步调度完成后回调递减到 -1）
-		r.pipelineMu.Lock()
-		r.pipelinePendingCount++
-		r.pipelineMu.Unlock()
+		r.pipelineState.mu.Lock()
+		r.pipelineState.pendingCount++
+		r.pipelineState.mu.Unlock()
 
 		// 入队 Pipeline 任务
 		if err := pipelineManager.EnqueueRecordingTask(info, pipelineConfig, outputFiles, r.onPipelineTaskComplete); err != nil {
 			r.getLogger().WithError(err).Error("failed to enqueue pipeline task")
 			// 入队失败，回滚计数
-			r.pipelineMu.Lock()
-			r.pipelinePendingCount--
-			r.pipelineMu.Unlock()
+			r.pipelineState.mu.Lock()
+			r.pipelineState.pendingCount--
+			r.pipelineState.mu.Unlock()
 		} else {
-			r.pipelineEnqueued = true
+			r.pipelineState.enqueued = true
 			// 记录 Pipeline 阶段顺序
 			var stageNames []string
 			for _, stage := range pipelineConfig.Stages {
@@ -935,7 +940,14 @@ func (r *recorder) selectPreferredStream(streamInfos []*live.StreamUrlInfo) (ret
 
 func (r *recorder) run(ctx context.Context) {
 	defer close(r.done)
-	defer r.sendAccumulatedSummary()
+	defer func() {
+		// 标记 run() 已退出，使回调在 remaining==0 时直接发送摘要，
+		// 而不是等待 r.done 通道关闭（避免 defer 执行顺序导致的漏发窗口）
+		r.pipelineState.mu.Lock()
+		r.pipelineState.runExited = true
+		r.pipelineState.mu.Unlock()
+		r.sendAccumulatedSummary()
+	}()
 
 	const minRetryInterval = 5 * time.Second
 
@@ -984,22 +996,22 @@ func (r *recorder) accumulateRecordedFiles(files ...string) {
 // sendAccumulatedSummary 录制结束后统一推送录制文件摘要通知
 // 在 run() 退出时通过 defer 调用，确保所有分段文件汇总为一条通知
 func (r *recorder) sendAccumulatedSummary() {
-	r.pipelineMu.Lock()
-	pendingCount := r.pipelinePendingCount
+	r.pipelineState.mu.Lock()
+	pendingCount := r.pipelineState.pendingCount
 	// 幂等保护：防止 defer 和回调并发双发
-	if r.summarySent {
-		r.pipelineMu.Unlock()
+	if r.pipelineState.summarySent {
+		r.pipelineState.mu.Unlock()
 		return
 	}
 	// Pipeline 任务尚未全部完成，等待回调触发最终摘要
-	if r.pipelineEnqueued && pendingCount > 0 {
-		r.pipelineMu.Unlock()
+	if r.pipelineState.enqueued && pendingCount > 0 {
+		r.pipelineState.mu.Unlock()
 		r.getLogger().Infof("Pipeline 任务尚未全部完成（剩余 %d 个），延迟摘要推送", pendingCount)
 		return
 	}
 	// 标记摘要已发送（在实际发送前，防止并发双发）
-	r.summarySent = true
-	r.pipelineMu.Unlock()
+	r.pipelineState.summarySent = true
+	r.pipelineState.mu.Unlock()
 
 	r.recordedFilesMu.Lock()
 	defer r.recordedFilesMu.Unlock()
@@ -1007,7 +1019,7 @@ func (r *recorder) sendAccumulatedSummary() {
 		r.getLogger().Infof("录制摘要推送已抑制（分段重启），累积 %d 个文件将传递给新 recorder", len(r.recordedFiles))
 		return
 	}
-	if len(r.recordedFiles) == 0 && len(*r.pipelineDetails) == 0 {
+	if len(r.recordedFiles) == 0 && len(r.pipelineState.details) == 0 {
 		r.getLogger().Info("无录制文件，跳过摘要推送")
 		return
 	}
@@ -1022,13 +1034,17 @@ func (r *recorder) sendAccumulatedSummary() {
 	}
 
 	// 使用 Pipeline 收集的最终文件详情（如有），否则用录制累积的原始文件
-	if len((*r.pipelineDetails)) > 0 {
+	if len(r.pipelineState.details) > 0 {
 		// 合并未被 Pipeline 覆盖的录制文件（如某分段因 stages==0 未入队）
-		merged := (*r.pipelineDetails)
+		merged := r.pipelineState.details
 		if len(r.recordedFiles) > 0 {
 			inPipeline := map[string]bool{}
-			for _, d := range (*r.pipelineDetails) {
+			for _, d := range r.pipelineState.details {
 				inPipeline[d.Name] = true
+			}
+			// 排除已被 Pipeline 转换并删除的源文件（如 convert_mp4 delete_source 场景）
+			for name := range r.pipelineState.sourceNames {
+				inPipeline[name] = true
 			}
 			for _, f := range r.recordedFiles {
 				if !inPipeline[f.Name] {
@@ -1071,8 +1087,8 @@ func (r *recorder) sendAccumulatedSummary() {
 // onPipelineTaskComplete Pipeline 任务完成回调
 // 由 Pipeline Manager 在 executeTask 结束时调用
 func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
-	r.pipelineMu.Lock()
-	r.pipelinePendingCount--
+	r.pipelineState.mu.Lock()
+	r.pipelineState.pendingCount--
 
 	// 收集任务的最终文件详情
 	switch task.Status {
@@ -1082,42 +1098,50 @@ func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
 			// 所有文件已上传并删除：从 LastStageFiles 提取真正上传的文件
 			uploadedDetails := extractUploadedDetails(task.LastStageFiles)
 			if len(uploadedDetails) > 0 {
-				(*r.pipelineDetails) = append((*r.pipelineDetails), uploadedDetails...)
+				r.pipelineState.details = append(r.pipelineState.details, uploadedDetails...)
 			} else {
 				// 回退：无上传标记时用原始文件
 				for _, d := range pipeline.FileInfoToDetails(task.InitialFiles) {
 					d.Uploaded = true
-					(*r.pipelineDetails) = append((*r.pipelineDetails), d)
+					r.pipelineState.details = append(r.pipelineState.details, d)
 				}
 			}
 		} else {
-			(*r.pipelineDetails) = append((*r.pipelineDetails), pipeline.FileInfoToDetails(finalFiles)...)
+			r.pipelineState.details = append(r.pipelineState.details, pipeline.FileInfoToDetails(finalFiles)...)
 		}
 	case pipeline.PipelineStatusFailed, pipeline.PipelineStatusCancelled:
 		// 失败/取消时优先用 CurrentFiles（最后成功阶段的输出），回退到 InitialFiles
 		if len(task.CurrentFiles) > 0 {
-			(*r.pipelineDetails) = append((*r.pipelineDetails), pipeline.FileInfoToDetails(task.CurrentFiles)...)
+			r.pipelineState.details = append(r.pipelineState.details, pipeline.FileInfoToDetails(task.CurrentFiles)...)
 		} else {
-			(*r.pipelineDetails) = append((*r.pipelineDetails), pipeline.FileInfoToDetails(task.InitialFiles)...)
+			r.pipelineState.details = append(r.pipelineState.details, pipeline.FileInfoToDetails(task.InitialFiles)...)
 		}
 	}
 
-	remaining := r.pipelinePendingCount
+	// 收集被 Pipeline 转换的原始文件名（SourcePath），用于摘要合并时排除已删除的源文件
+	collectSourceNames(r.pipelineState.sourceNames, task.CurrentFiles, task.LastStageFiles)
 
-	r.pipelineMu.Unlock()
+	remaining := r.pipelineState.pendingCount
+	runExited := r.pipelineState.runExited
+	onAllDone := r.pipelineState.onAllTasksDone
+
+	r.pipelineState.mu.Unlock()
 
 	r.getLogger().Infof("Pipeline 任务完成（状态: %s），剩余 %d 个任务", task.Status, remaining)
 
 	// 所有任务完成且录制已结束，发送统一摘要
 	// 使用 goroutine 避免通知发送（Telegram/Email 等）阻塞 Pipeline 任务槽位
 	if remaining == 0 {
-		select {
-		case <-r.done:
+		if r.suppressSummary {
+			// 分段重启场景：旧 recorder 已抑制，通过共享回调触发新 recorder 的摘要
+			if onAllDone != nil {
+				onAllDone()
+			}
+		} else if runExited {
 			// run() 已退出，异步发送摘要（不阻塞 executeTask）
 			go r.sendAccumulatedSummary()
-		default:
-			// run() 仍在运行，等待 run() 退出时由 sendAccumulatedSummary 发送
 		}
+		// run() 仍在运行且未抑制：等待 run() 退出时由 defer 中的 sendAccumulatedSummary 发送
 	}
 }
 
@@ -1139,6 +1163,19 @@ func extractUploadedDetails(files []pipeline.FileInfo) []notify.RecordingFileDet
 		}
 	}
 	return details
+}
+
+// collectSourceNames 从 Pipeline 输出文件中收集被转换的原始文件名
+// 当 convert_mp4/burn_subtitles 等阶段转换文件时，输出文件的 SourcePath 指向原始文件
+// 这些原始文件可能已被 Pipeline 删除，摘要合并时需要排除，避免将已删除的源文件重新纳入
+func collectSourceNames(sourceNames map[string]bool, fileSets ...[]pipeline.FileInfo) {
+	for _, files := range fileSets {
+		for _, f := range files {
+			if f.SourcePath != "" {
+				sourceNames[filepath.Base(f.SourcePath)] = true
+			}
+		}
+	}
 }
 
 func (r *recorder) logStreamURLRetry(err error) {
@@ -1299,25 +1336,37 @@ func (r *recorder) SetInitialRecordedFiles(files []notify.RecordingFileDetail) {
 // TransferPipelineState 从旧 recorder 转移 Pipeline 状态
 // 分段重启时由 RestartRecorder 调用，确保旧分段的 Pipeline 结果不丢失
 func (r *recorder) TransferPipelineState(old *recorder) {
-	r.pipelineMu.Lock()
-	defer r.pipelineMu.Unlock()
+	r.pipelineState.mu.Lock()
+	defer r.pipelineState.mu.Unlock()
 
-	old.pipelineMu.Lock()
-	defer old.pipelineMu.Unlock()
+	old.pipelineState.mu.Lock()
+	defer old.pipelineState.mu.Unlock()
 
 	// 合并 Pipeline 状态
-	r.pipelineEnqueued = r.pipelineEnqueued || old.pipelineEnqueued
-	r.pipelinePendingCount += old.pipelinePendingCount
+	r.pipelineState.enqueued = r.pipelineState.enqueued || old.pipelineState.enqueued
+	r.pipelineState.pendingCount += old.pipelineState.pendingCount
 
 	// 合并文件详情（旧 recorder 的详情追加到新 recorder）
-	*r.pipelineDetails = append(*r.pipelineDetails, *old.pipelineDetails...)
+	r.pipelineState.details = append(r.pipelineState.details, old.pipelineState.details...)
 
-	// 将旧 recorder 的详情指针指向新 recorder 的共享数据
-	// 这样旧 recorder 的回调写入时，数据会存到新 recorder 能读取的位置
-	old.pipelineDetails = r.pipelineDetails
+	// 合并已被 Pipeline 消费的原始文件名
+	for name := range old.pipelineState.sourceNames {
+		r.pipelineState.sourceNames[name] = true
+	}
+
+	// 关键：将旧 recorder 的 pipelineState 指针重定向到新 recorder 的共享状态
+	// 这样旧任务完成时的回调会操作新 recorder 的计数器
+	old.pipelineState = r.pipelineState
+
+	// 设置回调：旧任务全部完成时，由旧回调触发新 recorder 的摘要发送
+	if old.suppressSummary {
+		r.pipelineState.onAllTasksDone = func() {
+			go r.sendAccumulatedSummary()
+		}
+	}
 
 	r.getLogger().Infof("继承 Pipeline 状态：pending=%d, details=%d 个文件",
-		old.pipelinePendingCount, len(*old.pipelineDetails))
+		r.pipelineState.pendingCount, len(r.pipelineState.details))
 }
 
 func (r *recorder) getLogger() *livelogger.LiveLogger {

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -281,6 +281,18 @@ type recorder struct {
 	currentFileLock sync.RWMutex
 	currentFilePath string
 
+	// pipelineEnqueued 标记 Pipeline 任务已入队，由 Pipeline Manager 负责发送录制摘要
+	// 避免 recorder 在 Pipeline 处理完成前发送不准确的原始文件列表
+	pipelineEnqueued bool
+	// pipelinePendingCount 追踪尚未完成的 Pipeline 任务数量
+	// 仅当所有任务完成且录制结束后，才发送统一的录制摘要
+	pipelinePendingCount int
+	// pipelineMu 保护 pipelinePendingCount 和 pipelineDetails 的并发访问
+	pipelineMu sync.Mutex
+	// pipelineDetails 收集各 Pipeline 任务的最终文件详情
+	// 任务完成时通过回调写入，录制结束时读取用于构造摘要
+	pipelineDetails []notify.RecordingFileDetail
+
 	// 当前录制的流信息（来自平台 API）
 	currentStreamInfo *live.AvailableStreamInfo
 
@@ -784,9 +796,11 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		}
 
 		// 入队 Pipeline 任务
-		if err := pipelineManager.EnqueueRecordingTask(info, pipelineConfig, outputFiles); err != nil {
+		if err := pipelineManager.EnqueueRecordingTask(info, pipelineConfig, outputFiles, r.onPipelineTaskComplete); err != nil {
 			r.getLogger().WithError(err).Error("failed to enqueue pipeline task")
 		} else {
+			r.pipelineEnqueued = true
+			r.pipelinePendingCount++
 			// 记录 Pipeline 阶段顺序
 			var stageNames []string
 			for _, stage := range pipelineConfig.Stages {
@@ -958,22 +972,26 @@ func (r *recorder) accumulateRecordedFiles(files ...string) {
 // sendAccumulatedSummary 录制结束后统一推送录制文件摘要通知
 // 在 run() 退出时通过 defer 调用，确保所有分段文件汇总为一条通知
 func (r *recorder) sendAccumulatedSummary() {
+	r.pipelineMu.Lock()
+	pendingCount := r.pipelinePendingCount
+	r.pipelineMu.Unlock()
+
+	// Pipeline 任务尚未全部完成，等待回调触发最终摘要
+	if r.pipelineEnqueued && pendingCount > 0 {
+		r.getLogger().Infof("Pipeline 任务尚未全部完成（剩余 %d 个），延迟摘要推送", pendingCount)
+		return
+	}
+
 	r.recordedFilesMu.Lock()
 	defer r.recordedFilesMu.Unlock()
 	if r.suppressSummary {
 		r.getLogger().Infof("录制摘要推送已抑制（分段重启），累积 %d 个文件将传递给新 recorder", len(r.recordedFiles))
 		return
 	}
-	if len(r.recordedFiles) == 0 {
+	if len(r.recordedFiles) == 0 && len(r.pipelineDetails) == 0 {
 		r.getLogger().Info("无录制文件，跳过摘要推送")
 		return
 	}
-	obj, err := r.cache.Get(r.Live)
-	if err != nil {
-		r.getLogger().WithError(err).Error("获取直播信息失败，无法推送录制摘要")
-		return
-	}
-	info := obj.(*live.Info)
 
 	// 获取录制输出路径，用于查询剩余磁盘空间
 	cfg := configs.GetCurrentConfig()
@@ -984,8 +1002,114 @@ func (r *recorder) sendAccumulatedSummary() {
 		outputPath = resolved.OutPutPath
 	}
 
-	r.getLogger().Infof("推送录制摘要：%d 个文件", len(r.recordedFiles))
-	notify.SendRecordingSummary(r.getLogger(), info.HostName, r.Live.GetPlatformCNName(), r.recordedFiles, outputPath)
+	// 使用 Pipeline 收集的最终文件详情（如有），否则用录制累积的原始文件
+	if len(r.pipelineDetails) > 0 {
+		r.getLogger().Infof("推送 Pipeline 录制摘要：%d 个文件", len(r.pipelineDetails))
+		hostName := ""
+		platform := r.Live.GetPlatformCNName()
+		if obj, cacheErr := r.cache.Get(r.Live); cacheErr == nil {
+			if info, ok := obj.(*live.Info); ok {
+				hostName = info.HostName
+			}
+		}
+		notify.SendPipelineRecordingSummary(
+			r.getLogger(),
+			hostName,
+			platform,
+			r.recordedFiles,     // originalFiles（allUploaded 时显示用）
+			r.pipelineDetails,   // finalFiles
+			outputPath,
+		)
+	} else {
+		// Pipeline 未产出有效文件详情，回退到录制累积
+		if len(r.recordedFiles) == 0 {
+			return
+		}
+		obj, err := r.cache.Get(r.Live)
+		if err != nil {
+			r.getLogger().WithError(err).Error("获取直播信息失败，无法推送录制摘要")
+			return
+		}
+		info := obj.(*live.Info)
+		r.getLogger().Infof("推送录制摘要：%d 个文件", len(r.recordedFiles))
+		notify.SendRecordingSummary(r.getLogger(), info.HostName, r.Live.GetPlatformCNName(), r.recordedFiles, outputPath)
+	}
+}
+
+// onPipelineTaskComplete Pipeline 任务完成回调
+// 由 Pipeline Manager 在 executeTask 结束时调用
+func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
+	r.pipelineMu.Lock()
+	r.pipelinePendingCount--
+
+	// 收集任务的最终文件详情
+	switch task.Status {
+	case pipeline.PipelineStatusCompleted:
+		finalFiles := task.CurrentFiles
+		if len(finalFiles) == 0 {
+			// 所有文件已上传并删除：从 LastStageFiles 提取真正上传的文件
+			uploadedDetails := extractUploadedDetails(task.LastStageFiles)
+			if len(uploadedDetails) > 0 {
+				r.pipelineDetails = append(r.pipelineDetails, uploadedDetails...)
+			} else {
+				// 回退：无上传标记时用原始文件
+				for _, d := range pipeline.FileInfoToDetails(task.InitialFiles) {
+					d.Uploaded = true
+					r.pipelineDetails = append(r.pipelineDetails, d)
+				}
+			}
+		} else {
+			r.pipelineDetails = append(r.pipelineDetails, pipeline.FileInfoToDetails(finalFiles)...)
+		}
+	case pipeline.PipelineStatusFailed, pipeline.PipelineStatusCancelled:
+		// 失败/取消时优先用 CurrentFiles（最后成功阶段的输出），回退到 InitialFiles
+		if len(task.CurrentFiles) > 0 {
+			r.pipelineDetails = append(r.pipelineDetails, pipeline.FileInfoToDetails(task.CurrentFiles)...)
+		} else {
+			r.pipelineDetails = append(r.pipelineDetails, pipeline.FileInfoToDetails(task.InitialFiles)...)
+		}
+	}
+
+	remaining := r.pipelinePendingCount
+
+	// 防止回调被重复执行（如内存中重试场景）
+	task.OnTaskComplete = nil
+
+	r.pipelineMu.Unlock()
+
+	r.getLogger().Infof("Pipeline 任务完成（状态: %s），剩余 %d 个任务", task.Status, remaining)
+
+	// 所有任务完成且录制已结束，发送统一摘要
+	// 使用 goroutine 避免通知发送（Telegram/Email 等）阻塞 Pipeline 任务槽位
+	if remaining == 0 {
+		select {
+		case <-r.done:
+			// run() 已退出，异步发送摘要（不阻塞 executeTask）
+			go r.sendAccumulatedSummary()
+		default:
+			// run() 仍在运行，等待 run() 退出时由 sendAccumulatedSummary 发送
+		}
+	}
+}
+
+// extractUploadedDetails 从最后阶段输出文件中提取有上传标记的文件详情
+// CloudUploadStage 会为成功上传的文件设置 Metadata["uploaded"]=true
+func extractUploadedDetails(files []pipeline.FileInfo) []notify.RecordingFileDetail {
+	var details []notify.RecordingFileDetail
+	for _, f := range files {
+		if f.Metadata != nil {
+			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
+				if f.Size > 0 {
+					details = append(details, notify.RecordingFileDetail{
+						Name:     filepath.Base(f.Path),
+						Size:     f.Size,
+						Uploaded: true,
+					})
+				}
+			}
+		}
+	}
+	return details
 }
 
 func (r *recorder) logStreamURLRetry(err error) {

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -281,6 +281,10 @@ type recorder struct {
 	currentFileLock sync.RWMutex
 	currentFilePath string
 
+	// pipelineEnqueued 标记 Pipeline 任务已入队，由 Pipeline Manager 负责发送录制摘要
+	// 避免 recorder 在 Pipeline 处理完成前发送不准确的原始文件列表
+	pipelineEnqueued bool
+
 	// 当前录制的流信息（来自平台 API）
 	currentStreamInfo *live.AvailableStreamInfo
 
@@ -787,6 +791,7 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		if err := pipelineManager.EnqueueRecordingTask(info, pipelineConfig, outputFiles); err != nil {
 			r.getLogger().WithError(err).Error("failed to enqueue pipeline task")
 		} else {
+			r.pipelineEnqueued = true
 			// 记录 Pipeline 阶段顺序
 			var stageNames []string
 			for _, stage := range pipelineConfig.Stages {
@@ -960,6 +965,12 @@ func (r *recorder) accumulateRecordedFiles(files ...string) {
 func (r *recorder) sendAccumulatedSummary() {
 	r.recordedFilesMu.Lock()
 	defer r.recordedFilesMu.Unlock()
+	// Pipeline 已入队，由 Pipeline Manager 在任务完成后发送摘要，
+	// 确保通知反映 Pipeline 处理后的最终文件状态（而非原始录制文件）
+	if r.pipelineEnqueued {
+		r.getLogger().Infof("Pipeline 任务已入队，跳过录制摘要推送（由 Pipeline Manager 负责）")
+		return
+	}
 	if r.suppressSummary {
 		r.getLogger().Infof("录制摘要推送已抑制（分段重启），累积 %d 个文件将传递给新 recorder", len(r.recordedFiles))
 		return

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -1136,6 +1136,8 @@ func (r *recorder) sendAccumulatedSummary() {
 // onPipelineTaskComplete Pipeline 任务完成回调
 // 由 Pipeline Manager 在 executeTask 结束时调用
 func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
+	r.getLogger().Infof("Pipeline 回调触发：状态=%s, CurrentFiles=%d, LastStageFiles=%d, InitialFiles=%d",
+		task.Status, len(task.CurrentFiles), len(task.LastStageFiles), len(task.InitialFiles))
 	// 沿 redirect 链找到当前活跃的共享状态
 	// 支持连续重启 A→B→C 场景：A 的回调通过 resolveState 找到 C 的状态
 	ps := resolveState(r.pipelineState)
@@ -1146,21 +1148,27 @@ func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
 	// 收集任务的最终文件详情
 	switch task.Status {
 	case pipeline.PipelineStatusCompleted:
-		finalFiles := task.CurrentFiles
-		if len(finalFiles) == 0 {
-			// 所有文件已上传并删除：从 LastStageFiles 提取真正上传的文件
-			uploadedDetails := extractUploadedDetails(task.LastStageFiles)
-			if len(uploadedDetails) > 0 {
-				ps.details = append(ps.details, uploadedDetails...)
-			} else {
-				// 回退：无上传标记时用原始文件
-				for _, d := range pipeline.FileInfoToDetails(task.InitialFiles) {
-					d.Uploaded = true
-					ps.details = append(ps.details, d)
-				}
+		// 始终从 LastStageFiles 提取已上传的文件（含 Metadata["uploaded"] 标记）
+		uploadedDetails := extractUploadedDetails(task.LastStageFiles)
+		if len(uploadedDetails) > 0 {
+			ps.details = append(ps.details, uploadedDetails...)
+		}
+		// 合并本地保留的文件（CurrentFiles 中未被上传标记覆盖的文件）
+		uploadedNames := map[string]bool{}
+		for _, d := range uploadedDetails {
+			uploadedNames[d.Name] = true
+		}
+		for _, d := range pipeline.FileInfoToDetails(task.CurrentFiles) {
+			if !uploadedNames[d.Name] {
+				ps.details = append(ps.details, d)
 			}
-		} else {
-			ps.details = append(ps.details, pipeline.FileInfoToDetails(finalFiles)...)
+		}
+		// 回退：无上传标记且无保留文件时用 InitialFiles
+		if len(uploadedDetails) == 0 && len(task.CurrentFiles) == 0 {
+			for _, d := range pipeline.FileInfoToDetails(task.InitialFiles) {
+				d.Uploaded = true
+				ps.details = append(ps.details, d)
+			}
 		}
 	case pipeline.PipelineStatusFailed, pipeline.PipelineStatusCancelled:
 		// 失败/取消时优先用 CurrentFiles（最后成功阶段的输出），回退到 InitialFiles
@@ -1215,18 +1223,24 @@ func extractUploadedDetails(files []pipeline.FileInfo) []notify.RecordingFileDet
 		if f.Type == pipeline.FileTypeCover {
 			continue
 		}
+		uploaded := false
 		if f.Metadata != nil {
-			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
-				if f.Size > 0 {
-					details = append(details, notify.RecordingFileDetail{
-						Name:     filepath.Base(f.Path),
-						Size:     f.Size,
-						Uploaded: true,
-					})
-				}
+			if u, ok := f.Metadata["uploaded"].(bool); ok && u {
+				uploaded = true
 			}
 		}
+		if uploaded && f.Size > 0 {
+			details = append(details, notify.RecordingFileDetail{
+				Name:     filepath.Base(f.Path),
+				Size:     f.Size,
+				Uploaded: true,
+			})
+		}
 	}
+	logrus.WithFields(logrus.Fields{
+		"input_count":    len(files),
+		"uploaded_count": len(details),
+	}).Debug("extractUploadedDetails")
 	return details
 }
 

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -266,7 +266,7 @@ var (
 )
 
 // pipelineSharedState 封装可在分段重启时共享的 Pipeline 状态
-// 分段重启时新旧 recorder 通过指针重定向共享同一份状态，
+// 分段重启时新旧 recorder 通过 redirect 链共享同一份状态，
 // 确保旧任务的回调能正确递减新 recorder 的计数器
 type pipelineSharedState struct {
 	mu             sync.Mutex
@@ -277,6 +277,27 @@ type pipelineSharedState struct {
 	details        []notify.RecordingFileDetail // 收集的文件详情
 	sourceNames    map[string]bool              // 被 Pipeline 消费的原始文件名（用于合并时排除已删除的源文件）
 	onAllTasksDone func()                       // 所有任务完成时的回调（分段重启时设置）
+	suppressSummary bool                        // 为 true 时，run() 退出不推送摘要（分段重启场景），用 mu 保护
+	redirectedTo    *pipelineSharedState         // 分段重启时重定向到新 recorder 的共享状态
+}
+
+// resolveState 沿 redirect 链找到当前活跃的 pipelineSharedState。
+// 使用无锁遍历 + 锁内验证的方式，避免与 TransferPipelineState 产生死锁。
+// 返回时调用者持有 result.mu 锁。
+func resolveState(state *pipelineSharedState) *pipelineSharedState {
+	for {
+		// 无锁遍历找到链尾候选
+		final := state
+		for final.redirectedTo != nil {
+			final = final.redirectedTo
+		}
+		// 锁住候选状态，验证没有被并发重定向
+		final.mu.Lock()
+		if final.redirectedTo == nil {
+			return final // 调用者持有 final.mu 锁
+		}
+		final.mu.Unlock()
+	}
 }
 
 type recorder struct {
@@ -318,8 +339,7 @@ type recorder struct {
 
 	// done 在 run() 退出时关闭，用于 CloseForRestart 等待 goroutine 完成
 	done chan struct{}
-	// suppressSummary 为 true 时，run() 退出不推送摘要（分段重启场景）
-	suppressSummary bool
+	// suppressSummary 已移入 pipelineSharedState，用 pipelineState.mu 保护
 
 	retryLogMu              sync.Mutex
 	lastRetryLogKey         string
@@ -1011,15 +1031,18 @@ func (r *recorder) sendAccumulatedSummary() {
 	}
 	// 标记摘要已发送（在实际发送前，防止并发双发）
 	r.pipelineState.summarySent = true
+	suppressSummary := r.pipelineState.suppressSummary
+	pipelineDetails := r.pipelineState.details
+	pipelineSourceNames := r.pipelineState.sourceNames
 	r.pipelineState.mu.Unlock()
 
 	r.recordedFilesMu.Lock()
 	defer r.recordedFilesMu.Unlock()
-	if r.suppressSummary {
+	if suppressSummary {
 		r.getLogger().Infof("录制摘要推送已抑制（分段重启），累积 %d 个文件将传递给新 recorder", len(r.recordedFiles))
 		return
 	}
-	if len(r.recordedFiles) == 0 && len(r.pipelineState.details) == 0 {
+	if len(r.recordedFiles) == 0 && len(pipelineDetails) == 0 {
 		r.getLogger().Info("无录制文件，跳过摘要推送")
 		return
 	}
@@ -1034,16 +1057,16 @@ func (r *recorder) sendAccumulatedSummary() {
 	}
 
 	// 使用 Pipeline 收集的最终文件详情（如有），否则用录制累积的原始文件
-	if len(r.pipelineState.details) > 0 {
+	if len(pipelineDetails) > 0 {
 		// 合并未被 Pipeline 覆盖的录制文件（如某分段因 stages==0 未入队）
-		merged := r.pipelineState.details
+		merged := pipelineDetails
 		if len(r.recordedFiles) > 0 {
 			inPipeline := map[string]bool{}
-			for _, d := range r.pipelineState.details {
+			for _, d := range pipelineDetails {
 				inPipeline[d.Name] = true
 			}
 			// 排除已被 Pipeline 转换并删除的源文件（如 convert_mp4 delete_source 场景）
-			for name := range r.pipelineState.sourceNames {
+			for name := range pipelineSourceNames {
 				inPipeline[name] = true
 			}
 			for _, f := range r.recordedFiles {
@@ -1087,8 +1110,12 @@ func (r *recorder) sendAccumulatedSummary() {
 // onPipelineTaskComplete Pipeline 任务完成回调
 // 由 Pipeline Manager 在 executeTask 结束时调用
 func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
-	r.pipelineState.mu.Lock()
-	r.pipelineState.pendingCount--
+	// 沿 redirect 链找到当前活跃的共享状态
+	// 支持连续重启 A→B→C 场景：A 的回调通过 resolveState 找到 C 的状态
+	ps := resolveState(r.pipelineState)
+	// ps.mu 已被 resolveState 锁住
+
+	ps.pendingCount--
 
 	// 收集任务的最终文件详情
 	switch task.Status {
@@ -1098,58 +1125,60 @@ func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
 			// 所有文件已上传并删除：从 LastStageFiles 提取真正上传的文件
 			uploadedDetails := extractUploadedDetails(task.LastStageFiles)
 			if len(uploadedDetails) > 0 {
-				r.pipelineState.details = append(r.pipelineState.details, uploadedDetails...)
+				ps.details = append(ps.details, uploadedDetails...)
 			} else {
 				// 回退：无上传标记时用原始文件
 				for _, d := range pipeline.FileInfoToDetails(task.InitialFiles) {
 					d.Uploaded = true
-					r.pipelineState.details = append(r.pipelineState.details, d)
+					ps.details = append(ps.details, d)
 				}
 			}
 		} else {
-			r.pipelineState.details = append(r.pipelineState.details, pipeline.FileInfoToDetails(finalFiles)...)
+			ps.details = append(ps.details, pipeline.FileInfoToDetails(finalFiles)...)
 		}
 	case pipeline.PipelineStatusFailed, pipeline.PipelineStatusCancelled:
 		// 失败/取消时优先用 CurrentFiles（最后成功阶段的输出），回退到 InitialFiles
 		if len(task.CurrentFiles) > 0 {
-			r.pipelineState.details = append(r.pipelineState.details, pipeline.FileInfoToDetails(task.CurrentFiles)...)
+			ps.details = append(ps.details, pipeline.FileInfoToDetails(task.CurrentFiles)...)
 		} else {
-			r.pipelineState.details = append(r.pipelineState.details, pipeline.FileInfoToDetails(task.InitialFiles)...)
+			ps.details = append(ps.details, pipeline.FileInfoToDetails(task.InitialFiles)...)
 		}
 	}
 
 	// 收集被 Pipeline 转换的原始文件名（SourcePath），用于摘要合并时排除已删除的源文件
-	collectSourceNames(r.pipelineState.sourceNames, task.CurrentFiles, task.LastStageFiles)
+	collectSourceNames(ps.sourceNames, task.CurrentFiles, task.LastStageFiles)
 
-	remaining := r.pipelineState.pendingCount
-	runExited := r.pipelineState.runExited
-	onAllDone := r.pipelineState.onAllTasksDone
+	remaining := ps.pendingCount
+	runExited := ps.runExited
+	onAllDone := ps.onAllTasksDone
 
-	r.pipelineState.mu.Unlock()
+	ps.mu.Unlock()
 
 	r.getLogger().Infof("Pipeline 任务完成（状态: %s），剩余 %d 个任务", task.Status, remaining)
 
 	// 所有任务完成且录制已结束，发送统一摘要
 	// 使用 goroutine 避免通知发送（Telegram/Email 等）阻塞 Pipeline 任务槽位
 	if remaining == 0 {
-		if r.suppressSummary {
-			// 分段重启场景：旧 recorder 已抑制，通过共享回调触发新 recorder 的摘要
-			if onAllDone != nil {
-				onAllDone()
-			}
+		if onAllDone != nil {
+			// 分段重启场景：通过共享回调触发摘要（回调内部检查 runExited）
+			onAllDone()
 		} else if runExited {
-			// run() 已退出，异步发送摘要（不阻塞 executeTask）
+			// 非分段重启场景：run() 已退出，异步发送摘要
 			go r.sendAccumulatedSummary()
 		}
-		// run() 仍在运行且未抑制：等待 run() 退出时由 defer 中的 sendAccumulatedSummary 发送
+		// run() 仍在运行且无回调：等待 run() 退出时由 defer 中的 sendAccumulatedSummary 发送
 	}
 }
 
 // extractUploadedDetails 从最后阶段输出文件中提取有上传标记的文件详情
 // CloudUploadStage 会为成功上传的文件设置 Metadata["uploaded"]=true
+// 排除封面文件（封面不在录制摘要中展示，与 FileInfoToDetails 保持一致）
 func extractUploadedDetails(files []pipeline.FileInfo) []notify.RecordingFileDetail {
 	var details []notify.RecordingFileDetail
 	for _, f := range files {
+		if f.Type == pipeline.FileTypeCover {
+			continue
+		}
 		if f.Metadata != nil {
 			if uploaded, ok := f.Metadata["uploaded"].(bool); ok && uploaded {
 				if f.Size > 0 {
@@ -1310,9 +1339,9 @@ func (r *recorder) Close() {
 }
 
 func (r *recorder) CloseForRestart() []notify.RecordingFileDetail {
-	r.recordedFilesMu.Lock()
-	r.suppressSummary = true
-	r.recordedFilesMu.Unlock()
+	r.pipelineState.mu.Lock()
+	r.pipelineState.suppressSummary = true
+	r.pipelineState.mu.Unlock()
 	r.Close()
 	<-r.done // 等待 run() 完全退出，确保最后一个文件已累积
 	r.recordedFilesMu.Lock()
@@ -1335,35 +1364,50 @@ func (r *recorder) SetInitialRecordedFiles(files []notify.RecordingFileDetail) {
 
 // TransferPipelineState 从旧 recorder 转移 Pipeline 状态
 // 分段重启时由 RestartRecorder 调用，确保旧分段的 Pipeline 结果不丢失
+// 使用 redirect 链替代指针覆盖，支持连续重启 A→B→C 场景
 func (r *recorder) TransferPipelineState(old *recorder) {
 	r.pipelineState.mu.Lock()
 	defer r.pipelineState.mu.Unlock()
 
-	old.pipelineState.mu.Lock()
-	defer old.pipelineState.mu.Unlock()
+	// 沿 old 的 redirect 链找到最终活跃状态（可能经过多次重启 A→B→C→...）
+	oldState := resolveState(old.pipelineState)
+	// 此时 oldState.mu 已被 resolveState 锁住
 
 	// 合并 Pipeline 状态
-	r.pipelineState.enqueued = r.pipelineState.enqueued || old.pipelineState.enqueued
-	r.pipelineState.pendingCount += old.pipelineState.pendingCount
+	r.pipelineState.enqueued = r.pipelineState.enqueued || oldState.enqueued
+	r.pipelineState.pendingCount += oldState.pendingCount
+	// 注意：suppressSummary 不合并。该标志表示"我是被重启的 recorder，不发摘要"，
+	// 新 recorder 从未调用 CloseForRestart，应保持自己的 suppressSummary=false。
+	// 回调通过 onAllTasksDone（含 runExited 检查）触发，不依赖 suppressSummary 传播。
 
 	// 合并文件详情（旧 recorder 的详情追加到新 recorder）
-	r.pipelineState.details = append(r.pipelineState.details, old.pipelineState.details...)
+	r.pipelineState.details = append(r.pipelineState.details, oldState.details...)
 
 	// 合并已被 Pipeline 消费的原始文件名
-	for name := range old.pipelineState.sourceNames {
+	for name := range oldState.sourceNames {
 		r.pipelineState.sourceNames[name] = true
 	}
 
-	// 关键：将旧 recorder 的 pipelineState 指针重定向到新 recorder 的共享状态
-	// 这样旧任务完成时的回调会操作新 recorder 的计数器
-	old.pipelineState = r.pipelineState
-
-	// 设置回调：旧任务全部完成时，由旧回调触发新 recorder 的摘要发送
-	if old.suppressSummary {
-		r.pipelineState.onAllTasksDone = func() {
+	// 设置回调：旧任务全部完成时，触发摘要发送
+	// 回调与 suppressSummary 解耦：suppressSummary 是 recorder 级别的抑制标志，
+	// 回调是 pipeline 级别的完成通知。多跳 A→B→C 场景下，A 的回调通过 redirect
+	// 链解析到 C 的状态，如果只在 suppressSummary=true 时设置回调，B→C 转移时
+	// B.suppressSummary=false 导致 C 没有回调，A 的摘要永远发不出。
+	// runExited 检查确保只在新 recorder 已退出时发送，避免录制中提前发出摘要。
+	r.pipelineState.onAllTasksDone = func() {
+		r.pipelineState.mu.Lock()
+		shouldSend := r.pipelineState.runExited
+		r.pipelineState.mu.Unlock()
+		if shouldSend {
 			go r.sendAccumulatedSummary()
 		}
+		// run() 未退出时不发送：新 recorder 的 defer 会在退出时检查并发送
 	}
+
+	// 关键：设置 redirect 链，使旧 recorder 及更早的 recorder 的回调
+	// 能通过 resolveState 找到当前活跃的共享状态
+	oldState.redirectedTo = r.pipelineState
+	oldState.mu.Unlock()
 
 	r.getLogger().Infof("继承 Pipeline 状态：pending=%d, details=%d 个文件",
 		r.pipelineState.pendingCount, len(r.pipelineState.details))

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -316,6 +316,10 @@ type recorder struct {
 	currentFileLock sync.RWMutex
 	currentFilePath string
 
+	// closeForRestart 标记当前 recorder 正在分段重启，run() 退出时不发送摘要。
+	// 在 CloseForRestart 中设置（早于 Close），run() 的 defer 中检查。
+	closeForRestart atomic.Bool
+
 	// pipelineState 封装 Pipeline 相关的共享状态
 	// 使用指针，分段重启时新旧 recorder 共享同一份状态
 	pipelineState *pipelineSharedState
@@ -977,7 +981,11 @@ func (r *recorder) run(ctx context.Context) {
 		r.pipelineState.mu.Lock()
 		r.pipelineState.runExited = true
 		r.pipelineState.mu.Unlock()
-		r.sendAccumulatedSummary()
+		// 分段重启时跳过摘要：CloseForRestart 已设置此标记，
+		// TransferPipelineState 完成后由回调发送含完整 Pipeline 详情的摘要
+		if !r.closeForRestart.Load() {
+			r.sendAccumulatedSummary()
+		}
 	}()
 
 	const minRetryInterval = 5 * time.Second
@@ -1394,6 +1402,9 @@ func (r *recorder) Close() {
 }
 
 func (r *recorder) CloseForRestart() []notify.RecordingFileDetail {
+	// 先设置重启标记，使 run() 的 defer 跳过 sendAccumulatedSummary，
+	// 避免在 TransferPipelineState 之前发送不含 Pipeline 详情的摘要
+	r.closeForRestart.Store(true)
 	r.pipelineState.mu.Lock()
 	r.pipelineState.suppressSummary = true
 	r.pipelineState.mu.Unlock()

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -278,7 +278,7 @@ type pipelineSharedState struct {
 	sourceNames    map[string]bool              // 被 Pipeline 消费的原始文件名（用于合并时排除已删除的源文件）
 	onAllTasksDone func()                       // 所有任务完成时的回调（分段重启时设置）
 	suppressSummary bool                        // 为 true 时，run() 退出不推送摘要（分段重启场景），用 mu 保护
-	redirectedTo    *pipelineSharedState         // 分段重启时重定向到新 recorder 的共享状态
+	redirectedTo    atomic.Pointer[pipelineSharedState] // 分段重启时重定向到新 recorder 的共享状态
 }
 
 // resolveState 沿 redirect 链找到当前活跃的 pipelineSharedState。
@@ -286,14 +286,14 @@ type pipelineSharedState struct {
 // 返回时调用者持有 result.mu 锁。
 func resolveState(state *pipelineSharedState) *pipelineSharedState {
 	for {
-		// 无锁遍历找到链尾候选
+		// 无锁遍历找到链尾候选（通过 atomic.Load 避免与写入端的数据竞争）
 		final := state
-		for final.redirectedTo != nil {
-			final = final.redirectedTo
+		for next := final.redirectedTo.Load(); next != nil; next = final.redirectedTo.Load() {
+			final = next
 		}
 		// 锁住候选状态，验证没有被并发重定向
 		final.mu.Lock()
-		if final.redirectedTo == nil {
+		if final.redirectedTo.Load() == nil {
 			return final // 调用者持有 final.mu 锁
 		}
 		final.mu.Unlock()
@@ -319,6 +319,17 @@ type recorder struct {
 	// pipelineState 封装 Pipeline 相关的共享状态
 	// 使用指针，分段重启时新旧 recorder 共享同一份状态
 	pipelineState *pipelineSharedState
+
+	// transferWg 用于分段重启时的摘要屏障。
+	// RestartRecorder 在创建新 recorder 后 Add(1)，
+	// TransferPipelineState 完成后 Done()。
+	// sendAccumulatedSummary 在发送前 Wait()，确保旧分段状态已转入。
+	// 非分段重启场景为 nil，Wait 是 no-op。
+	transferWg *sync.WaitGroup
+
+	// notifyWg 跟踪异步通知 goroutine（go sendAccumulatedSummary）。
+	// 由 RecorderManager 持有，关闭流程中等待所有通知发送完成。
+	notifyWg *sync.WaitGroup
 
 	// 当前录制的流信息（来自平台 API）
 	currentStreamInfo *live.AvailableStreamInfo
@@ -1016,6 +1027,11 @@ func (r *recorder) accumulateRecordedFiles(files ...string) {
 // sendAccumulatedSummary 录制结束后统一推送录制文件摘要通知
 // 在 run() 退出时通过 defer 调用，确保所有分段文件汇总为一条通知
 func (r *recorder) sendAccumulatedSummary() {
+	// 分段重启屏障：等待 TransferPipelineState 完成，
+	// 确保旧分段的 pipelineDetails/pendingCount 已转入再发送摘要
+	if r.transferWg != nil {
+		r.transferWg.Wait()
+	}
 	r.pipelineState.mu.Lock()
 	pendingCount := r.pipelineState.pendingCount
 	// 幂等保护：防止 defer 和回调并发双发
@@ -1059,7 +1075,7 @@ func (r *recorder) sendAccumulatedSummary() {
 	// 使用 Pipeline 收集的最终文件详情（如有），否则用录制累积的原始文件
 	if len(pipelineDetails) > 0 {
 		// 合并未被 Pipeline 覆盖的录制文件（如某分段因 stages==0 未入队）
-		merged := pipelineDetails
+		merged := append([]notify.RecordingFileDetail(nil), pipelineDetails...)
 		if len(r.recordedFiles) > 0 {
 			inPipeline := map[string]bool{}
 			for _, d := range pipelineDetails {
@@ -1164,7 +1180,17 @@ func (r *recorder) onPipelineTaskComplete(task *pipeline.PipelineTask) {
 			onAllDone()
 		} else if runExited {
 			// 非分段重启场景：run() 已退出，异步发送摘要
-			go r.sendAccumulatedSummary()
+			if r.notifyWg != nil {
+				r.notifyWg.Add(1)
+			}
+			go func() {
+				defer func() {
+					if r.notifyWg != nil {
+						r.notifyWg.Done()
+					}
+				}()
+				r.sendAccumulatedSummary()
+			}()
 		}
 		// run() 仍在运行且无回调：等待 run() 退出时由 defer 中的 sendAccumulatedSummary 发送
 	}
@@ -1399,14 +1425,24 @@ func (r *recorder) TransferPipelineState(old *recorder) {
 		shouldSend := r.pipelineState.runExited
 		r.pipelineState.mu.Unlock()
 		if shouldSend {
-			go r.sendAccumulatedSummary()
+			if r.notifyWg != nil {
+				r.notifyWg.Add(1)
+			}
+			go func() {
+				defer func() {
+					if r.notifyWg != nil {
+						r.notifyWg.Done()
+					}
+				}()
+				r.sendAccumulatedSummary()
+			}()
 		}
 		// run() 未退出时不发送：新 recorder 的 defer 会在退出时检查并发送
 	}
 
 	// 关键：设置 redirect 链，使旧 recorder 及更早的 recorder 的回调
 	// 能通过 resolveState 找到当前活跃的共享状态
-	oldState.redirectedTo = r.pipelineState
+	oldState.redirectedTo.Store(r.pipelineState)
 	oldState.mu.Unlock()
 
 	r.getLogger().Infof("继承 Pipeline 状态：pending=%d, details=%d 个文件",

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -11,9 +11,14 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	"github.com/bililive-go/bililive-go/src/configs"
+	"github.com/bililive-go/bililive-go/src/instance"
 	"github.com/bililive-go/bililive-go/src/live"
 	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	"github.com/bililive-go/bililive-go/src/notify"
+	"github.com/bililive-go/bililive-go/src/pipeline"
+	"github.com/bililive-go/bililive-go/src/pkg/events"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
+	"github.com/bililive-go/bililive-go/src/types"
 )
 
 func TestTryRecordStopsWithoutPanicWhenFilenameRenderFails(t *testing.T) {
@@ -48,5 +53,333 @@ func TestTryRecordStopsWithoutPanicWhenFilenameRenderFails(t *testing.T) {
 	}
 	if !strings.Contains(logs, "render failed") {
 		t.Fatalf("日志未保留原始模板错误: %s", logs)
+	}
+}
+
+// newTestRecorder 创建用于测试的 recorder 实例（不启动 run goroutine）
+func newTestRecorder(t *testing.T, liveId types.LiveID) *recorder {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	l := livemock.NewMockLive(ctrl)
+	l.EXPECT().GetLiveId().Return(liveId).AnyTimes()
+	l.EXPECT().GetLogger().Return(livelogger.New(0, logrus.Fields{"test": t.Name()})).AnyTimes()
+
+	// 创建带 instance 的 context（NewRecorder 需要 instance.Cache 和 EventDispatcher）
+	inst := &instance.Instance{
+		Cache: gcache.New(1).LRU().Build(),
+	}
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	// NewDispatcher 会自动设置 inst.EventDispatcher
+	events.NewDispatcher(ctx)
+
+	r, err := NewRecorder(ctx, l)
+	if err != nil {
+		t.Fatalf("创建 recorder 失败: %v", err)
+	}
+	return r.(*recorder)
+}
+
+func TestResolveState_NoRedirect(t *testing.T) {
+	state := &pipelineSharedState{
+		sourceNames: make(map[string]bool),
+		pendingCount: 5,
+	}
+
+	resolved := resolveState(state)
+	if resolved != state {
+		t.Fatal("无 redirect 时 resolveState 应返回原始状态")
+	}
+	if resolved.pendingCount != 5 {
+		t.Fatalf("pendingCount 期望 5，实际 %d", resolved.pendingCount)
+	}
+	resolved.mu.Unlock()
+}
+
+func TestResolveState_SingleRedirect(t *testing.T) {
+	stateA := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 3}
+	stateB := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 0}
+
+	// 模拟 A→B 重定向
+	stateA.redirectedTo = stateB
+
+	resolved := resolveState(stateA)
+	if resolved != stateB {
+		t.Fatal("单跳 redirect 应解析到 stateB")
+	}
+	resolved.mu.Unlock()
+}
+
+func TestResolveState_MultiHopChain(t *testing.T) {
+	stateA := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 3}
+	stateB := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 2}
+	stateC := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 1}
+
+	// 模拟 A→B→C 链
+	stateA.redirectedTo = stateB
+	stateB.redirectedTo = stateC
+
+	resolved := resolveState(stateA)
+	if resolved != stateC {
+		t.Fatal("多跳 redirect 链应解析到 stateC")
+	}
+	resolved.mu.Unlock()
+}
+
+func TestTransferPipelineState_ChainRedirect(t *testing.T) {
+	// 模拟 A→B→C 连续分段重启
+	recA := newTestRecorder(t, "test-live")
+	recB := newTestRecorder(t, "test-live")
+	recC := newTestRecorder(t, "test-live")
+
+	// A 有 3 个待处理任务和一些文件详情
+	recA.pipelineState.pendingCount = 3
+	recA.pipelineState.enqueued = true
+	recA.pipelineState.details = []notify.RecordingFileDetail{
+		{Name: "a.flv", Size: 100},
+	}
+	recA.pipelineState.sourceNames["a_src.flv"] = true
+	// A 模拟已抑制（CloseForRestart 设置）
+	recA.pipelineState.suppressSummary = true
+
+	// A → B 重启
+	recB.TransferPipelineState(recA)
+
+	// 验证 B 继承了 A 的状态
+	if recB.pipelineState.pendingCount != 3 {
+		t.Fatalf("B pendingCount 期望 3，实际 %d", recB.pipelineState.pendingCount)
+	}
+	if len(recB.pipelineState.details) != 1 {
+		t.Fatalf("B details 期望 1，实际 %d", len(recB.pipelineState.details))
+	}
+
+	// B 有额外的 2 个任务
+	recB.pipelineState.pendingCount += 2 // 模拟 B 自己又入队了 2 个任务
+
+	// B → C 重启
+	recC.TransferPipelineState(recB)
+
+	// 验证 C 继承了所有状态
+	if recC.pipelineState.pendingCount != 5 {
+		t.Fatalf("C pendingCount 期望 5，实际 %d", recC.pipelineState.pendingCount)
+	}
+
+	// 关键验证：A 的 pipelineState 通过 redirect 链应解析到 C 的状态
+	resolvedA := resolveState(recA.pipelineState)
+	if resolvedA != recC.pipelineState {
+		t.Fatal("A 的状态应通过 redirect 链解析到 C 的状态")
+	}
+	resolvedA.mu.Unlock()
+
+	// B 的 pipelineState 应直接指向 C
+	resolvedB := resolveState(recB.pipelineState)
+	if resolvedB != recC.pipelineState {
+		t.Fatal("B 的状态应解析到 C 的状态")
+	}
+	resolvedB.mu.Unlock()
+}
+
+func TestOnPipelineTaskComplete_AfterChainRedirect(t *testing.T) {
+	// 模拟 A→B→C 后，A 的回调操作 C 的状态
+	recA := newTestRecorder(t, "test-live")
+	recB := newTestRecorder(t, "test-live")
+	recC := newTestRecorder(t, "test-live")
+
+	// A 有 1 个待处理任务
+	recA.pipelineState.pendingCount = 1
+	recA.pipelineState.enqueued = true
+	recA.pipelineState.suppressSummary = true
+	recA.pipelineState.runExited = true
+
+	// A → B → C
+	recB.TransferPipelineState(recA)
+	recC.TransferPipelineState(recB)
+
+	// 模拟 C 的 run() 已退出（C 是当前活跃 recorder，runExited 是 per-recorder 的）
+	recC.pipelineState.mu.Lock()
+	recC.pipelineState.runExited = true
+	recC.pipelineState.mu.Unlock()
+
+	// C 的 onAllTasksDone 回调应存在（TransferPipelineState 始终设置）
+	onAllDoneCalled := false
+	recC.pipelineState.onAllTasksDone = func() {
+		recC.pipelineState.mu.Lock()
+		shouldSend := recC.pipelineState.runExited
+		recC.pipelineState.mu.Unlock()
+		if shouldSend {
+			onAllDoneCalled = true
+		}
+	}
+
+	// 模拟 A 的 Pipeline 任务完成
+	task := &pipeline.PipelineTask{
+		Status:       pipeline.PipelineStatusCompleted,
+		CurrentFiles: []pipeline.FileInfo{},
+		InitialFiles: []pipeline.FileInfo{
+			{Path: "/data/a.flv", Size: 1024, Type: pipeline.FileTypeVideo},
+		},
+		LastStageFiles: []pipeline.FileInfo{
+			{Path: "/data/a.flv", Size: 1024, Type: pipeline.FileTypeVideo, Metadata: map[string]any{"uploaded": true}},
+		},
+	}
+
+	recA.onPipelineTaskComplete(task)
+
+	// 验证：C 的 pendingCount 应为 0（A 的回调正确递减了 C 的计数）
+	if recC.pipelineState.pendingCount != 0 {
+		t.Fatalf("C pendingCount 期望 0，实际 %d（A 的回调未正确操作 C 的状态）", recC.pipelineState.pendingCount)
+	}
+
+	// 验证：A 的回调收集的 details 应在 C 的状态中
+	if len(recC.pipelineState.details) == 0 {
+		t.Fatal("C 的 details 不应为空（A 的回调应将文件详情写入 C 的状态）")
+	}
+
+	// 验证：onAllTasksDone 应被触发（C 已退出）
+	if !onAllDoneCalled {
+		t.Fatal("onAllTasksDone 回调应被触发（C.runExited=true）")
+	}
+}
+
+func TestExtractUploadedDetails_ExcludesCover(t *testing.T) {
+	files := []pipeline.FileInfo{
+		{Path: "/data/video.flv", Size: 1024, Type: pipeline.FileTypeVideo, Metadata: map[string]any{"uploaded": true}},
+		{Path: "/data/cover.jpg", Size: 512, Type: pipeline.FileTypeCover, Metadata: map[string]any{"uploaded": true}},
+		{Path: "/data/other.txt", Size: 256, Type: pipeline.FileTypeOther, Metadata: map[string]any{"uploaded": true}},
+	}
+
+	details := extractUploadedDetails(files)
+
+	if len(details) != 2 {
+		t.Fatalf("期望 2 个文件（排除封面），实际 %d", len(details))
+	}
+
+	names := map[string]bool{}
+	for _, d := range details {
+		names[d.Name] = true
+	}
+	if names["cover.jpg"] {
+		t.Fatal("封面文件不应出现在上传详情中")
+	}
+	if !names["video.flv"] || !names["other.txt"] {
+		t.Fatal("视频和其他类型文件应出现在上传详情中")
+	}
+}
+
+func TestSuppressSummary_InSharedState(t *testing.T) {
+	// 验证 suppressSummary 在 pipelineSharedState 中，通过 mu 保护
+	rec := newTestRecorder(t, "test-live")
+
+	// 初始值应为 false
+	rec.pipelineState.mu.Lock()
+	if rec.pipelineState.suppressSummary {
+		t.Fatal("suppressSummary 初始值应为 false")
+	}
+	rec.pipelineState.mu.Unlock()
+
+	// CloseForRestart 设置 suppressSummary
+	rec.pipelineState.mu.Lock()
+	rec.pipelineState.suppressSummary = true
+	rec.pipelineState.mu.Unlock()
+
+	// 验证设置成功
+	rec.pipelineState.mu.Lock()
+	if !rec.pipelineState.suppressSummary {
+		t.Fatal("suppressSummary 应为 true")
+	}
+	rec.pipelineState.mu.Unlock()
+}
+
+func TestTransferPipelineState_SetRedirect(t *testing.T) {
+	// 验证 TransferPipelineState 设置了 redirect 链
+	recA := newTestRecorder(t, "test-live")
+	recB := newTestRecorder(t, "test-live")
+
+	recA.pipelineState.pendingCount = 1
+	recA.pipelineState.suppressSummary = true
+
+	recB.TransferPipelineState(recA)
+
+	// A 的状态应被重定向到 B
+	if recA.pipelineState.redirectedTo != recB.pipelineState {
+		t.Fatal("A 的 redirect 应指向 B 的状态")
+	}
+
+	// resolveState 应从 A 找到 B
+	resolved := resolveState(recA.pipelineState)
+	if resolved != recB.pipelineState {
+		t.Fatal("resolveState(A) 应返回 B 的状态")
+	}
+	resolved.mu.Unlock()
+}
+
+func TestOnAllTasksDone_NotSentWhileRecording(t *testing.T) {
+	// 验证 Bot 指出的场景：旧任务完成时新 recorder 仍在录制，摘要不应提前发送
+	recA := newTestRecorder(t, "test-live")
+	recB := newTestRecorder(t, "test-live")
+
+	recA.pipelineState.pendingCount = 1
+	recA.pipelineState.enqueued = true
+	recA.pipelineState.suppressSummary = true
+	recA.pipelineState.runExited = true
+
+	// A → B
+	recB.TransferPipelineState(recA)
+
+	// B 仍在录制（runExited=false）
+	// 记录 B 的 onAllTasksDone 是否被调用
+	callbackTriggered := false
+	originalCallback := recB.pipelineState.onAllTasksDone
+	recB.pipelineState.onAllTasksDone = func() {
+		callbackTriggered = true
+		originalCallback()
+	}
+
+	// 模拟 A 的任务完成
+	task := &pipeline.PipelineTask{
+		Status:       pipeline.PipelineStatusCompleted,
+		CurrentFiles: []pipeline.FileInfo{},
+		InitialFiles: []pipeline.FileInfo{
+			{Path: "/data/a.flv", Size: 1024, Type: pipeline.FileTypeVideo},
+		},
+		LastStageFiles: []pipeline.FileInfo{
+			{Path: "/data/a.flv", Size: 1024, Type: pipeline.FileTypeVideo},
+		},
+	}
+	recA.onPipelineTaskComplete(task)
+
+	// 回调应被触发（remaining=0, suppressSummary=true）
+	if !callbackTriggered {
+		t.Fatal("onAllTasksDone 应被触发")
+	}
+
+	// 但摘要不应被发送（B 仍在录制，runExited=false）
+	// 验证方式：summarySent 应仍为 false
+	recB.pipelineState.mu.Lock()
+	summarySent := recB.pipelineState.summarySent
+	recB.pipelineState.mu.Unlock()
+	if summarySent {
+		t.Fatal("摘要不应在新 recorder 仍在录制时发送（summarySent 应为 false）")
+	}
+}
+
+func TestFinalRecorder_SummaryNotSuppressed(t *testing.T) {
+	// 验证最终 recorder 的摘要不被 suppressSummary 抑制
+	// （suppressSummary 不应从旧 recorder 传播到新 recorder）
+	recA := newTestRecorder(t, "test-live")
+	recB := newTestRecorder(t, "test-live")
+
+	recA.pipelineState.pendingCount = 1
+	recA.pipelineState.enqueued = true
+	recA.pipelineState.suppressSummary = true
+
+	// A → B
+	recB.TransferPipelineState(recA)
+
+	// B 的 suppressSummary 应为 false（不从 A 继承）
+	recB.pipelineState.mu.Lock()
+	bSuppress := recB.pipelineState.suppressSummary
+	recB.pipelineState.mu.Unlock()
+	if bSuppress {
+		t.Fatal("最终 recorder 的 suppressSummary 应为 false（不应从旧 recorder 继承）")
 	}
 }

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -100,7 +100,7 @@ func TestResolveState_SingleRedirect(t *testing.T) {
 	stateB := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 0}
 
 	// 模拟 A→B 重定向
-	stateA.redirectedTo = stateB
+	stateA.redirectedTo.Store(stateB)
 
 	resolved := resolveState(stateA)
 	if resolved != stateB {
@@ -115,8 +115,8 @@ func TestResolveState_MultiHopChain(t *testing.T) {
 	stateC := &pipelineSharedState{sourceNames: make(map[string]bool), pendingCount: 1}
 
 	// 模拟 A→B→C 链
-	stateA.redirectedTo = stateB
-	stateB.redirectedTo = stateC
+	stateA.redirectedTo.Store(stateB)
+	stateB.redirectedTo.Store(stateC)
 
 	resolved := resolveState(stateA)
 	if resolved != stateC {
@@ -300,7 +300,7 @@ func TestTransferPipelineState_SetRedirect(t *testing.T) {
 	recB.TransferPipelineState(recA)
 
 	// A 的状态应被重定向到 B
-	if recA.pipelineState.redirectedTo != recB.pipelineState {
+	if recA.pipelineState.redirectedTo.Load() != recB.pipelineState {
 		t.Fatal("A 的 redirect 应指向 B 的状态")
 	}
 

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -1727,6 +1727,9 @@ func applyConfigUpdates(c *configs.Config, updates map[string]interface{}) error
 			if deleteAllAfter, ok := cloudUpload["delete_all_after_upload"].(bool); ok {
 				c.OnRecordFinished.CloudUpload.DeleteAllAfterUpload = deleteAllAfter
 			}
+			if uploadSubtitles, ok := cloudUpload["upload_subtitles"].(bool); ok {
+				c.OnRecordFinished.CloudUpload.UploadSubtitles = uploadSubtitles
+			}
 		}
 		// 处理上传时机
 		if uploadTiming, ok := orf["upload_timing"].(string); ok {

--- a/src/servers/pipeline_handler.go
+++ b/src/servers/pipeline_handler.go
@@ -347,7 +347,7 @@ func makeBatchBurnHandler(pm *pipeline.Manager) http.HandlerFunc {
 			}
 			task := pipeline.NewPipelineTask(recordInfo, burnConfig, files)
 
-			if err := pm.EnqueueTask(task); err != nil {
+			if err := pm.EnqueueTask(task, nil); err != nil {
 				result.Skipped = append(result.Skipped, filepath.Base(p)+" - 入队失败: "+err.Error())
 				continue
 			}

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -145,10 +145,13 @@ const analyzeConfig = (config: any) => {
   if (convert) {
     files['video.mp4'] = { ext: '.mp4', desc: '转码后视频', status: 'kept' };
     if (deleteFlv) {
-      // 源文件被转码替代，标记为中间产物（不上传，最终由 executor 删除）
-      if (files['video.flv'].status === 'uploaded') {
+      if (isImmediate && upload) {
+        // immediate 模式：.flv 已在 pipeline 开头被上传，转换后被标记为 Deletable 并删除
+        files['video.flv'].status = 'uploaded_deleted';
+      } else if (files['video.flv'].status === 'uploaded') {
         files['video.flv'].status = 'uploaded_deleted';
       } else {
+        // after_process 模式：源文件是中间产物，不参与上传
         files['video.flv'].status = 'intermediate';
       }
     } else {
@@ -163,21 +166,35 @@ const analyzeConfig = (config: any) => {
     files['video.mkv'] = { ext: '.mkv', desc: '烧录后视频', status: 'kept' };
     if (burnDelSource) {
       const target = convert ? 'video.mp4' : 'video.flv';
-      if (files[target].status === 'uploaded') {
+      if (isImmediate && upload && !convert) {
+        // immediate 模式（无转码）：.flv 已在 pipeline 开头被上传，烧录后被标记为 Deletable 并删除
+        files[target].status = 'uploaded_deleted';
+      } else if (files[target].status === 'uploaded') {
         files[target].status = 'uploaded_deleted';
       } else {
+        // after_process 模式或 immediate+convert（.mp4 未被上传）：中间产物
         files[target].status = 'intermediate';
       }
     } else {
       const src = convert ? 'video.mp4' : 'video.flv';
-      if (files[src] && files[src].status === 'kept') {
+      // after_process 模式：源视频保留在 BurnSubtitlesStage output 中，会被 cloud_upload 上传
+      // immediate 模式：源视频在 cloud_upload 之后才创建/保留，不会被上传
+      if (!isImmediate && files[src] && files[src].status === 'kept') {
         files[src].status = 'uploaded';
       }
     }
     if (burnDelAss) {
-      files['video.ass'].status = 'deleted';
+      if (isImmediate && upload) {
+        // immediate 模式：.ass 已在 pipeline 开头被上传，烧录后被标记为 Deletable 并删除
+        files['video.ass'].status = 'uploaded_deleted';
+      } else {
+        files['video.ass'].status = 'deleted';
+      }
     }
   }
+
+  // immediate 模式下，convert 和 burn 产出的文件（.mp4, .mkv）不会被上传
+  // 它们在 cloud_upload 之后才创建，应保持 'kept' 状态
 
   // 封面
   if (cover) {

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -123,6 +123,7 @@ const analyzeConfig = (config: any) => {
   const upload = cu.enable ?? false;
   const delAfter = cu.delete_after_upload ?? false;
   const delAllAfter = cu.delete_all_after_upload ?? false;
+  const uploadAss = cu.upload_subtitles ?? false;
 
   // 文件状态：uploaded(上传), deleted(删除), kept(保留)
   const files: Record<string, { ext: string; desc: string; status: string }> = {};
@@ -131,9 +132,12 @@ const analyzeConfig = (config: any) => {
   files['video.flv'] = { ext: '.flv', desc: '原始录制视频', status: 'kept' };
   files['video.ass'] = { ext: '.ass', desc: '弹幕字幕', status: 'kept' };
 
-  // immediate 模式：先上传原始文件
+  // immediate 模式：先上传原始文件（.ass 在录制结束时已存在，可一并上传）
   if (isImmediate && upload) {
     files['video.flv'].status = 'uploaded';
+    if (uploadAss) {
+      files['video.ass'].status = 'uploaded';
+    }
   }
 
   // 转码
@@ -197,6 +201,10 @@ const analyzeConfig = (config: any) => {
     }
     if (cover) {
       files['cover.jpg'].status = 'uploaded';
+    }
+    // 上传弹幕字幕（需 after_process 模式，immediate 模式下 .ass 尚未生成）
+    if (uploadAss) {
+      files['video.ass'].status = 'uploaded';
     }
 
     // 删除逻辑
@@ -442,6 +450,11 @@ const CloudUploadSettings: React.FC<CloudUploadSettingsProps> = ({ config, form 
       <ConfigField label="上传后删除全部文件" description="选「处理完再上传」时，上传成功后删除所有本地文件（含中间产物）。选「先上传再处理」时此开关无效">
         <Form.Item name={['on_record_finished', 'cloud_upload', 'delete_all_after_upload']} valuePropName="checked" noStyle>
           <Switch onChange={handleDeleteAllAfterChange} />
+        </Form.Item>
+      </ConfigField>
+      <ConfigField label="上传弹幕字幕" description="同时上传与视频同名的 .ass 弹幕字幕文件到云存储。需开启弹幕录制">
+        <Form.Item name={['on_record_finished', 'cloud_upload', 'upload_subtitles']} valuePropName="checked" noStyle>
+          <Switch />
         </Form.Item>
       </ConfigField>
 

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -232,7 +232,9 @@ const analyzeConfig = (config: any) => {
     const hasVideo = Object.entries(files).some(([name, f]) => {
       if (name === 'video.ass') return false;
       const ext = f.ext.toLowerCase();
-      return (ext === '.flv' || ext === '.mp4' || ext === '.mkv') && f.status !== 'deleted' && f.status !== 'uploaded_deleted';
+      if (ext !== '.flv' && ext !== '.mp4' && ext !== '.mkv') return false;
+      // 只有 kept 或 uploaded（本地保留）的视频才算"存在"
+      return f.status === 'kept' || f.status === 'uploaded';
     });
     if (!hasVideo) {
       files['video.ass'].status = 'deleted';

--- a/src/webapp/src/component/config-info/CloudUploadSettings.tsx
+++ b/src/webapp/src/component/config-info/CloudUploadSettings.tsx
@@ -125,7 +125,8 @@ const analyzeConfig = (config: any) => {
   const delAllAfter = cu.delete_all_after_upload ?? false;
   const uploadAss = cu.upload_subtitles ?? false;
 
-  // 文件状态：uploaded(上传), deleted(删除), kept(保留)
+  // 文件状态：uploaded(上传保留), uploaded_deleted(上传后删除), intermediate(中间产物,不上传),
+  // deleted(删除), kept(本地保留)
   const files: Record<string, { ext: string; desc: string; status: string }> = {};
 
   // 初始文件
@@ -144,15 +145,13 @@ const analyzeConfig = (config: any) => {
   if (convert) {
     files['video.mp4'] = { ext: '.mp4', desc: '转码后视频', status: 'kept' };
     if (deleteFlv) {
-      // 如果已经被标记为 uploaded，改为 uploaded_deleted
+      // 源文件被转码替代，标记为中间产物（不上传，最终由 executor 删除）
       if (files['video.flv'].status === 'uploaded') {
         files['video.flv'].status = 'uploaded_deleted';
       } else {
-        files['video.flv'].status = 'deleted';
+        files['video.flv'].status = 'intermediate';
       }
     } else {
-      // delete_flv_after_convert=false：源视频保留在 ConvertMp4Stage output 中
-      // immediate 模式下已在 pipeline 开头被上传，after_process 模式下也会被上传
       if (files['video.flv'].status === 'kept') {
         files['video.flv'].status = 'uploaded';
       }
@@ -163,16 +162,13 @@ const analyzeConfig = (config: any) => {
   if (burn) {
     files['video.mkv'] = { ext: '.mkv', desc: '烧录后视频', status: 'kept' };
     if (burnDelSource) {
-      // 删除转码后的 mp4 或原始 flv
       const target = convert ? 'video.mp4' : 'video.flv';
       if (files[target].status === 'uploaded') {
         files[target].status = 'uploaded_deleted';
       } else {
-        files[target].status = 'deleted';
+        files[target].status = 'intermediate';
       }
     } else {
-      // burn_delete_source=false：源视频保留在 BurnSubtitlesStage output 中
-      // immediate 模式下已在 pipeline 开头被上传，after_process 模式下也会被上传
       const src = convert ? 'video.mp4' : 'video.flv';
       if (files[src] && files[src].status === 'kept') {
         files[src].status = 'uploaded';
@@ -234,6 +230,7 @@ const analyzeConfig = (config: any) => {
       const ext = f.ext.toLowerCase();
       if (ext !== '.flv' && ext !== '.mp4' && ext !== '.mkv') return false;
       // 只有 kept 或 uploaded（本地保留）的视频才算"存在"
+      // intermediate（中间产物）和 deleted/uploaded_deleted（已删除）不算
       return f.status === 'kept' || f.status === 'uploaded';
     });
     if (!hasVideo) {
@@ -254,8 +251,8 @@ const analyzeConfig = (config: any) => {
     } else if (f.status === 'uploaded_deleted') {
       uploaded.push(name);
       deleted.push(name);
-    } else if (f.status === 'deleted') {
-      deleted.push(name);
+    } else if (f.status === 'deleted' || f.status === 'intermediate') {
+      deleted.push(name); // intermediate 是中间产物，显示为删除
     } else {
       kept.push(name);
     }

--- a/src/webapp/src/component/config-info/index.tsx
+++ b/src/webapp/src/component/config-info/index.tsx
@@ -85,6 +85,7 @@ interface EffectiveConfig {
       upload_path_tmpl: string;
       delete_after_upload: boolean;
       delete_all_after_upload: boolean;
+      upload_subtitles: boolean;
     };
     upload_timing: string;
     burn_subtitles: boolean;


### PR DESCRIPTION
录制摘要通知原来在 recorder.run() 退出时立即发送，此时 Pipeline（转码、修复、上传等） 尚未执行。开启「上传后删除」时，通知中的文件实际已被删除，消息严重失真。

修复方案：
- recorder 中添加 pipelineEnqueued 标志，Pipeline 任务入队后跳过摘要推送
- Pipeline Manager 在任务完成/失败后发送摘要，反映最终文件状态
- FileInfo 添加 Size 字段，创建时预存文件大小，确保文件删除后仍可构建摘要
- 提取 sendToAllChannels 消除通道推送重复代码
- 新增 buildUploadedSummaryBody 构造「已上传到云端」场景的消息体