### PR TITLE
fix: 暂时关闭平台级访问限流

### DIFF
--- a/src/configs/config_test.go
+++ b/src/configs/config_test.go
@@ -97,7 +97,7 @@ func TestGetPlatformMinAccessInterval(t *testing.T) {
 	assert.Equal(t, 1, interval) // 默认最小间隔为 1 秒，防止无限制高频访问
 }
 
-func TestDefaultPlatformRateLimitSurvivesTransientConfigUpdate(t *testing.T) {
+func TestPlatformRateLimitRemainsDisabledAfterConfigUpdate(t *testing.T) {
 	const roomURL = "https://live.douyin.com/123456"
 	limiter := ratelimit.GetGlobalRateLimiter()
 	t.Cleanup(func() {
@@ -109,15 +109,15 @@ func TestDefaultPlatformRateLimitSurvivesTransientConfigUpdate(t *testing.T) {
 	cfg.RefreshLiveRoomIndexCache()
 	SetCurrentConfig(cfg)
 
-	if got := limiter.GetAllPlatformLimits()[PlatformKeyDouyin]; got != 1 {
-		t.Fatalf("初始默认平台限流 = %d 秒，期望 1 秒", got)
+	if limits := limiter.GetAllPlatformLimits(); len(limits) != 0 {
+		t.Fatalf("配置加载后平台限流应保持关闭，实际限制：%v", limits)
 	}
 
 	if _, err := SetLiveRoomId(roomURL, types.LiveID("douyin-test")); err != nil {
 		t.Fatalf("写入临时 LiveId 失败: %v", err)
 	}
-	if got := limiter.GetAllPlatformLimits()[PlatformKeyDouyin]; got != 1 {
-		t.Fatalf("临时配置更新后的默认平台限流 = %d 秒，期望仍为 1 秒", got)
+	if limits := limiter.GetAllPlatformLimits(); len(limits) != 0 {
+		t.Fatalf("临时配置更新后平台限流应保持关闭，实际限制：%v", limits)
 	}
 }
 

--- a/src/pkg/ratelimit/ratelimit.go
+++ b/src/pkg/ratelimit/ratelimit.go
@@ -11,6 +11,7 @@ import (
 type PlatformRateLimiter struct {
 	limiters map[string]*PlatformLimiter // 平台名称 -> 限制器
 	mu       sync.RWMutex                // 读写锁保护map
+	enabled  bool                        // 是否实际应用平台级访问限制
 }
 
 // PlatformLimiter 单个平台的频率限制器
@@ -21,8 +22,17 @@ type PlatformLimiter struct {
 	inFlight    chan struct{} // 限制同一平台最多一个请求在途
 }
 
-var globalRateLimiter = &PlatformRateLimiter{
-	limiters: make(map[string]*PlatformLimiter),
+// 平台级访问限制暂时关闭，以避免同平台请求串行排队导致新直播间长时间无法开始录制。
+// 保留限制器实现和配置结构，后续改善调度策略后可重新启用。
+const globalRateLimitEnabled = false
+
+var globalRateLimiter = newPlatformRateLimiter(globalRateLimitEnabled)
+
+func newPlatformRateLimiter(enabled bool) *PlatformRateLimiter {
+	return &PlatformRateLimiter{
+		limiters: make(map[string]*PlatformLimiter),
+		enabled:  enabled,
+	}
 }
 
 // GetGlobalRateLimiter 获取全局速率限制器实例
@@ -32,6 +42,10 @@ func GetGlobalRateLimiter() *PlatformRateLimiter {
 
 // SetPlatformLimit 设置或更新指定平台的访问频率限制
 func (prl *PlatformRateLimiter) SetPlatformLimit(platform string, intervalSec int) {
+	if !prl.enabled {
+		return
+	}
+
 	if intervalSec <= 0 {
 		// 如果间隔为0或负数，移除该平台的限制
 		prl.mu.Lock()
@@ -63,7 +77,7 @@ func (prl *PlatformRateLimiter) SetPlatformLimit(platform string, intervalSec in
 // EnsurePlatformLimit 在平台尚无限制时设置默认值，不覆盖已经显式配置的间隔。
 // 用于房间对象早于配置持久化创建的路径，保证首次请求也不会绕过平台保护。
 func (prl *PlatformRateLimiter) EnsurePlatformLimit(platform string, intervalSec int) {
-	if platform == "" || intervalSec <= 0 {
+	if !prl.enabled || platform == "" || intervalSec <= 0 {
 		return
 	}
 
@@ -90,6 +104,10 @@ func (prl *PlatformRateLimiter) WaitForPlatform(platform string) {
 // 如果平台没有设置限制，立即返回 true
 // 返回 true 表示成功获取访问权限，false 表示被 context 取消
 func (prl *PlatformRateLimiter) WaitForPlatformWithContext(ctx context.Context, platform string) bool {
+	if !prl.enabled {
+		return true
+	}
+
 	prl.mu.RLock()
 	limiter, exists := prl.limiters[platform]
 	prl.mu.RUnlock()
@@ -108,6 +126,10 @@ func (prl *PlatformRateLimiter) WaitForPlatformWithContext(ctx context.Context, 
 // 仅限制请求开始间隔不足以保护启动阶段：当前一个请求耗时超过最小间隔时，后续请求仍会
 // 重叠执行。这里把并发槽位与开始间隔合并为一次许可，使大量直播间并发初始化时仍按平台串行。
 func (prl *PlatformRateLimiter) AcquirePlatformWithContext(ctx context.Context, platform string) (release func(), ok bool) {
+	if !prl.enabled {
+		return func() {}, true
+	}
+
 	prl.mu.RLock()
 	limiter, exists := prl.limiters[platform]
 	prl.mu.RUnlock()
@@ -172,6 +194,10 @@ func waitForLimiterWithContext(ctx context.Context, limiter *PlatformLimiter) bo
 
 // GetPlatformNextAllowedTime 获取平台下次允许访问的时间
 func (prl *PlatformRateLimiter) GetPlatformNextAllowedTime(platform string) time.Time {
+	if !prl.enabled {
+		return time.Now()
+	}
+
 	prl.mu.RLock()
 	limiter, exists := prl.limiters[platform]
 	prl.mu.RUnlock()
@@ -197,6 +223,10 @@ func (prl *PlatformRateLimiter) RemovePlatformLimit(platform string) {
 
 // GetAllPlatformLimits 获取所有平台的当前限制设置
 func (prl *PlatformRateLimiter) GetAllPlatformLimits() map[string]int {
+	if !prl.enabled {
+		return map[string]int{}
+	}
+
 	prl.mu.RLock()
 	defer prl.mu.RUnlock()
 
@@ -219,6 +249,10 @@ type WaitInfo struct {
 
 // GetPlatformWaitInfo 获取指定平台的等待状态信息
 func (prl *PlatformRateLimiter) GetPlatformWaitInfo(platform string) WaitInfo {
+	if !prl.enabled {
+		return WaitInfo{}
+	}
+
 	prl.mu.RLock()
 	limiter, exists := prl.limiters[platform]
 	prl.mu.RUnlock()
@@ -254,6 +288,10 @@ func (prl *PlatformRateLimiter) GetPlatformWaitInfo(platform string) WaitInfo {
 // ForceAccess 强制访问平台，忽略频率限制
 // 返回距离上次访问的时间间隔
 func (prl *PlatformRateLimiter) ForceAccess(platform string) time.Duration {
+	if !prl.enabled {
+		return 0
+	}
+
 	prl.mu.RLock()
 	limiter, exists := prl.limiters[platform]
 	prl.mu.RUnlock()

--- a/src/pkg/ratelimit/ratelimit.go
+++ b/src/pkg/ratelimit/ratelimit.go
@@ -40,6 +40,11 @@ func GetGlobalRateLimiter() *PlatformRateLimiter {
 	return globalRateLimiter
 }
 
+// Enabled 返回当前限制器是否实际应用平台级访问限制。
+func (prl *PlatformRateLimiter) Enabled() bool {
+	return prl.enabled
+}
+
 // SetPlatformLimit 设置或更新指定平台的访问频率限制
 func (prl *PlatformRateLimiter) SetPlatformLimit(platform string, intervalSec int) {
 	if !prl.enabled {
@@ -104,6 +109,10 @@ func (prl *PlatformRateLimiter) WaitForPlatform(platform string) {
 // 如果平台没有设置限制，立即返回 true
 // 返回 true 表示成功获取访问权限，false 表示被 context 取消
 func (prl *PlatformRateLimiter) WaitForPlatformWithContext(ctx context.Context, platform string) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
 	if !prl.enabled {
 		return true
 	}
@@ -126,6 +135,10 @@ func (prl *PlatformRateLimiter) WaitForPlatformWithContext(ctx context.Context, 
 // 仅限制请求开始间隔不足以保护启动阶段：当前一个请求耗时超过最小间隔时，后续请求仍会
 // 重叠执行。这里把并发槽位与开始间隔合并为一次许可，使大量直播间并发初始化时仍按平台串行。
 func (prl *PlatformRateLimiter) AcquirePlatformWithContext(ctx context.Context, platform string) (release func(), ok bool) {
+	if ctx.Err() != nil {
+		return nil, false
+	}
+
 	if !prl.enabled {
 		return func() {}, true
 	}

--- a/src/pkg/ratelimit/ratelimit_test.go
+++ b/src/pkg/ratelimit/ratelimit_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPlatformRateLimiter(t *testing.T) {
-	limiter := GetGlobalRateLimiter()
+	limiter := newPlatformRateLimiter(true)
 
 	// 设置测试平台限制：2秒间隔
 	limiter.SetPlatformLimit("test_platform", 2)
@@ -44,7 +44,7 @@ func TestPlatformRateLimiter(t *testing.T) {
 }
 
 func TestPlatformRateLimiterUpdate(t *testing.T) {
-	limiter := GetGlobalRateLimiter()
+	limiter := newPlatformRateLimiter(true)
 
 	// 设置初始限制
 	limiter.SetPlatformLimit("update_test", 3)
@@ -80,6 +80,7 @@ func TestAcquirePlatformSerializesInFlightRequests(t *testing.T) {
 				inFlight: make(chan struct{}, 1),
 			},
 		},
+		enabled: true,
 	}
 
 	releaseFirst, ok := limiter.AcquirePlatformWithContext(context.Background(), "test")
@@ -112,11 +113,31 @@ func TestAcquirePlatformSerializesInFlightRequests(t *testing.T) {
 }
 
 func TestEnsurePlatformLimitDoesNotOverrideExplicitLimit(t *testing.T) {
-	limiter := &PlatformRateLimiter{limiters: make(map[string]*PlatformLimiter)}
+	limiter := newPlatformRateLimiter(true)
 	limiter.SetPlatformLimit("test", 5)
 	limiter.EnsurePlatformLimit("test", 1)
 
 	if got := limiter.GetAllPlatformLimits()["test"]; got != 5 {
 		t.Fatalf("兜底限制覆盖了显式配置：得到 %d 秒，期望 5 秒", got)
+	}
+}
+
+func TestGlobalPlatformRateLimiterDisabled(t *testing.T) {
+	limiter := GetGlobalRateLimiter()
+	limiter.SetPlatformLimit("test", 60)
+
+	if limits := limiter.GetAllPlatformLimits(); len(limits) != 0 {
+		t.Fatalf("全局平台限制器应保持关闭，实际限制：%v", limits)
+	}
+
+	release, ok := limiter.AcquirePlatformWithContext(context.Background(), "test")
+	if !ok {
+		t.Fatal("关闭平台限制后请求应立即获准")
+	}
+	release()
+
+	waitInfo := limiter.GetPlatformWaitInfo("test")
+	if waitInfo.MinIntervalSec != 0 || waitInfo.NextRequestInSec != 0 {
+		t.Fatalf("关闭平台限制后不应报告等待状态：%+v", waitInfo)
 	}
 }

--- a/src/pkg/ratelimit/ratelimit_test.go
+++ b/src/pkg/ratelimit/ratelimit_test.go
@@ -125,6 +125,9 @@ func TestEnsurePlatformLimitDoesNotOverrideExplicitLimit(t *testing.T) {
 func TestGlobalPlatformRateLimiterDisabled(t *testing.T) {
 	limiter := GetGlobalRateLimiter()
 	limiter.SetPlatformLimit("test", 60)
+	if limiter.Enabled() {
+		t.Fatal("全局平台限制器应保持关闭")
+	}
 
 	if limits := limiter.GetAllPlatformLimits(); len(limits) != 0 {
 		t.Fatalf("全局平台限制器应保持关闭，实际限制：%v", limits)
@@ -139,5 +142,14 @@ func TestGlobalPlatformRateLimiterDisabled(t *testing.T) {
 	waitInfo := limiter.GetPlatformWaitInfo("test")
 	if waitInfo.MinIntervalSec != 0 || waitInfo.NextRequestInSec != 0 {
 		t.Fatalf("关闭平台限制后不应报告等待状态：%+v", waitInfo)
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if limiter.WaitForPlatformWithContext(canceledCtx, "test") {
+		t.Fatal("关闭平台限制后仍应尊重 context 取消")
+	}
+	if release, acquired := limiter.AcquirePlatformWithContext(canceledCtx, "test"); acquired || release != nil {
+		t.Fatal("context 已取消时不应获取平台许可")
 	}
 }

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -185,7 +185,13 @@ func getLive(writer http.ResponseWriter, r *http.Request) {
 	}
 
 	// 获取平台等待状态信息
-	waitInfo := ratelimit.GetGlobalRateLimiter().GetPlatformWaitInfo(platformKey)
+	platformRateLimiter := ratelimit.GetGlobalRateLimiter()
+	platformRateLimitEnabled := platformRateLimiter.Enabled()
+	waitInfo := platformRateLimiter.GetPlatformWaitInfo(platformKey)
+	platformRateLimit := 0
+	if platformRateLimitEnabled {
+		platformRateLimit = cfg.GetPlatformMinAccessInterval(platformKey)
+	}
 
 	// 获取调度器状态信息
 	var schedulerStatus *live.SchedulerStatus
@@ -250,10 +256,12 @@ func getLive(writer http.ResponseWriter, r *http.Request) {
 		"audio_only":            room.AudioOnly,
 
 		// 平台访问限制
-		"platform_rate_limit": cfg.GetPlatformMinAccessInterval(platformKey),
+		"platform_rate_limit":         platformRateLimit,
+		"platform_rate_limit_enabled": platformRateLimitEnabled,
 
 		// 平台等待状态
 		"rate_limit_info": map[string]interface{}{
+			"enabled":             platformRateLimitEnabled,
 			"waited_seconds":      waitInfo.WaitedSeconds,
 			"next_request_in_sec": waitInfo.NextRequestInSec,
 			"min_interval_sec":    waitInfo.MinIntervalSec,
@@ -469,7 +477,8 @@ func parseLiveAction(writer http.ResponseWriter, r *http.Request) {
 	case "forceRefresh":
 		// 强制刷新：忽略平台访问频率限制，立即获取最新信息
 		platformKey := configs.GetPlatformKeyFromUrl(live.GetRawUrl())
-		ratelimit.GetGlobalRateLimiter().ForceAccess(platformKey)
+		platformRateLimiter := ratelimit.GetGlobalRateLimiter()
+		platformRateLimiter.ForceAccess(platformKey)
 
 		// 手动调用 GetInfo 获取最新信息
 		info, err := live.GetInfo()
@@ -481,8 +490,9 @@ func parseLiveAction(writer http.ResponseWriter, r *http.Request) {
 		}
 
 		// 广播频率限制更新事件，通知前端更新倒计时
-		waitInfo := ratelimit.GetGlobalRateLimiter().GetPlatformWaitInfo(platformKey)
+		waitInfo := platformRateLimiter.GetPlatformWaitInfo(platformKey)
 		GetSSEHub().BroadcastRateLimitUpdate(live.GetLiveId(), map[string]interface{}{
+			"enabled":             platformRateLimiter.Enabled(),
 			"waited_seconds":      waitInfo.WaitedSeconds,
 			"next_request_in_sec": waitInfo.NextRequestInSec,
 			"min_interval_sec":    waitInfo.MinIntervalSec,
@@ -1187,6 +1197,7 @@ func getPlatformStats(writer http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	platformRateLimitEnabled := ratelimit.GetGlobalRateLimiter().Enabled()
 
 	// 统计每个平台的直播间（只统计正在监控的）
 	platformRooms := make(map[string][]map[string]interface{})
@@ -1269,7 +1280,7 @@ func getPlatformStats(writer http.ResponseWriter, r *http.Request) {
 
 		// 检查是否低于最小访问间隔
 		warningMessage := ""
-		if listeningCount > 0 && platformConfig.MinAccessIntervalSec > 0 && actualAccessInterval < float64(platformConfig.MinAccessIntervalSec) {
+		if platformRateLimitEnabled && listeningCount > 0 && platformConfig.MinAccessIntervalSec > 0 && actualAccessInterval < float64(platformConfig.MinAccessIntervalSec) {
 			effectiveInterval := float64(platformConfig.MinAccessIntervalSec) * float64(listeningCount)
 			warningMessage = fmt.Sprintf("当前设置下实际每个直播间的检测间隔约为 %.1f 秒（受最小访问间隔限制）", effectiveInterval)
 		}
@@ -1349,9 +1360,10 @@ func getPlatformStats(writer http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"platforms":           stats,
-		"available_platforms": availablePlatforms,
-		"global_interval":     cfg.Interval,
+		"platforms":                   stats,
+		"available_platforms":         availablePlatforms,
+		"global_interval":             cfg.Interval,
+		"platform_rate_limit_enabled": platformRateLimitEnabled,
 	}
 
 	writeJSON(writer, response)

--- a/src/servers/handler_test.go
+++ b/src/servers/handler_test.go
@@ -1,6 +1,7 @@
 package servers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/bililive-go/bililive-go/src/configs"
+	"github.com/bililive-go/bililive-go/src/instance"
 )
 
 func TestGetSoopLiveAuthConfigDoesNotExposeSavedPassword(t *testing.T) {
@@ -31,4 +33,40 @@ func TestGetSoopLiveAuthConfigDoesNotExposeSavedPassword(t *testing.T) {
 	assert.Equal(t, true, data["has_saved_credentials"])
 	_, exists := data["password"]
 	assert.False(t, exists)
+}
+
+func TestGetPlatformStatsReportsDisabledRateLimit(t *testing.T) {
+	cfg := configs.NewConfig()
+	cfg.Interval = 1
+	cfg.PlatformConfigs[configs.PlatformKeyDouyin] = configs.PlatformConfig{
+		Name:                 "抖音",
+		MinAccessIntervalSec: 60,
+	}
+	cfg.LiveRooms = []configs.LiveRoom{{
+		Url:         "https://live.douyin.com/123456",
+		IsListening: true,
+	}}
+	cfg.RefreshLiveRoomIndexCache()
+	configs.SetCurrentConfig(cfg)
+	t.Cleanup(func() { configs.SetCurrentConfig(configs.NewConfig()) })
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/api/config/platforms", nil)
+	request = request.WithContext(context.WithValue(request.Context(), instance.Key, &instance.Instance{}))
+	getPlatformStats(recorder, request)
+
+	assert.Equal(t, 200, recorder.Code)
+	var response struct {
+		PlatformRateLimitEnabled bool `json:"platform_rate_limit_enabled"`
+		Platforms                []struct {
+			PlatformKey    string `json:"platform_key"`
+			WarningMessage string `json:"warning_message"`
+		} `json:"platforms"`
+	}
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.False(t, response.PlatformRateLimitEnabled)
+	if assert.Len(t, response.Platforms, 1) {
+		assert.Equal(t, configs.PlatformKeyDouyin, response.Platforms[0].PlatformKey)
+		assert.Empty(t, response.Platforms[0].WarningMessage)
+	}
 }

--- a/src/webapp/src/component/config-info/index.tsx
+++ b/src/webapp/src/component/config-info/index.tsx
@@ -183,6 +183,7 @@ interface PlatformStatsResponse {
   platforms: PlatformStat[];
   available_platforms: string[];
   global_interval: number;
+  platform_rate_limit_enabled?: boolean;
 }
 
 // 实际生效值显示组件
@@ -1082,6 +1083,7 @@ const PlatformSettings: React.FC<{
   }
 
   const { platforms, available_platforms, global_interval } = platformStats;
+  const platformRateLimitEnabled = platformStats.platform_rate_limit_enabled ?? true;
 
   // 分组平台：有直播间的 vs 只有配置没有直播间的
   const platformsWithRooms = platforms.filter(p => p.has_rooms);
@@ -1186,6 +1188,7 @@ const PlatformSettings: React.FC<{
             platform={platform}
             globalConfig={globalConfig}
             globalInterval={global_interval}
+            platformRateLimitEnabled={platformRateLimitEnabled}
             onSave={(values) => handleSave(platform.platform_key, values)}
             onDelete={() => handleDelete(platform.platform_key)}
             loading={loading}
@@ -1208,6 +1211,15 @@ const PlatformSettings: React.FC<{
         showIcon
         style={{ marginBottom: 16 }}
       />
+      {!platformRateLimitEnabled && (
+        <Alert
+          message="平台级访问限流已暂时停用"
+          description="min_access_interval_sec 配置会被保留，但当前不会限制请求间隔或同平台并发。后续调度策略改善后再恢复生效。"
+          type="warning"
+          showIcon
+          style={{ marginBottom: 16 }}
+        />
+      )}
 
       {/* 正在监控的平台 */}
       {platformsWithRooms.length > 0 && (
@@ -1257,11 +1269,12 @@ const PlatformConfigForm: React.FC<{
   platform: PlatformStat;
   globalConfig: EffectiveConfig;
   globalInterval: number;
+  platformRateLimitEnabled: boolean;
   onSave: (values: any) => void;
   onDelete: () => void;
   loading: boolean;
   onNavigateToRoom: (liveId: string) => void;
-}> = ({ platform, globalConfig, globalInterval, onSave, onDelete, loading, onNavigateToRoom }) => {
+}> = ({ platform, globalConfig, globalInterval, platformRateLimitEnabled, onSave, onDelete, loading, onNavigateToRoom }) => {
   const [form] = Form.useForm();
 
   useEffect(() => {
@@ -1341,18 +1354,31 @@ const PlatformConfigForm: React.FC<{
         </ConfigField>
 
         <ConfigField
-          label="最小访问间隔 (秒)"
-          description="该平台 API 的最小访问间隔，用于防风控。若监控数量过多导致频率过快，系统会自动增加检测间隔。"
+          label={`最小访问间隔 (秒${platformRateLimitEnabled ? '' : '，暂未启用'})`}
+          description={platformRateLimitEnabled
+            ? '该平台 API 的最小访问间隔，用于防风控。若监控数量过多导致频率过快，系统会自动增加检测间隔。'
+            : '配置值会继续保留，但平台级访问限流关闭期间不会生效。'}
           id={`platforms-${platformKey}-min_access_interval_sec`}
-          inheritance={{
+          inheritance={platformRateLimitEnabled ? {
             source: 'default',
             isOverridden: (platform.min_access_interval_sec || 0) > 0,
             inheritedValue: '不限制 (0)',
-          }}
-          valueDisplay={(platform.min_access_interval_sec || 0) > 0 ? platform.min_access_interval_sec : '不限制 (0)'}
+          } : undefined}
+          effectiveValue={platformRateLimitEnabled ? undefined : '当前不生效'}
+          valueDisplay={!platformRateLimitEnabled
+            ? ((platform.min_access_interval_sec || 0) > 0
+              ? `已配置 ${platform.min_access_interval_sec} 秒（暂不生效）`
+              : '暂未启用')
+            : ((platform.min_access_interval_sec || 0) > 0 ? platform.min_access_interval_sec : '不限制 (0)')}
         >
           <Form.Item name="min_access_interval_sec" rules={[{ type: 'number', min: 0, message: '不能为负数' }]}>
-            <InputNumber min={0} max={3600} style={{ width: 200 }} placeholder="0 (不限制)" />
+            <InputNumber
+              min={0}
+              max={3600}
+              style={{ width: 200 }}
+              placeholder="0 (不限制)"
+              disabled={!platformRateLimitEnabled}
+            />
           </Form.Item>
         </ConfigField>
 

--- a/src/webapp/src/component/live-list/index.tsx
+++ b/src/webapp/src/component/live-list/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Divider, Table, Tag, Tabs, Row, Col, Tooltip, message, List, Typography, Switch, Space, Popconfirm, Select, Spin } from 'antd';
+import { Alert, Button, Divider, Table, Tag, Tabs, Row, Col, Tooltip, message, List, Typography, Switch, Space, Popconfirm, Select, Spin } from 'antd';
 import { EditOutlined, SyncOutlined, CloudSyncOutlined, ReloadOutlined, SwapOutlined, CheckCircleOutlined, ExclamationCircleOutlined, CommentOutlined } from '@ant-design/icons';
 import PopDialog from '../pop-dialog/index';
 import BatchAddRoomDialog from '../batch-add-room-dialog/index';
@@ -824,10 +824,40 @@ class LiveList extends React.Component<Props, IState> {
 
             // 旧的频率限制信息处理逻辑（兼容性保留）
             const rateLimitInfo = updateData;
+            const rateLimitEnabled = rateLimitInfo?.enabled
+                ?? currentDetail?.platform_rate_limit_enabled
+                ?? true;
             const updatedDetail = {
                 ...currentDetail,
-                rate_limit_info: rateLimitInfo
+                platform_rate_limit_enabled: rateLimitEnabled,
+                platform_rate_limit: rateLimitEnabled ? currentDetail?.platform_rate_limit : 0,
+                rate_limit_info: {
+                    ...rateLimitInfo,
+                    enabled: rateLimitEnabled
+                }
             };
+
+            if (!rateLimitEnabled) {
+                return {
+                    ...prevState,
+                    expandedDetails: {
+                        ...prevState.expandedDetails,
+                        [roomId]: updatedDetail
+                    },
+                    countdownTimers: {
+                        ...prevState.countdownTimers,
+                        [roomId]: 0
+                    },
+                    lastUpdateTimes: {
+                        ...prevState.lastUpdateTimes,
+                        [roomId]: Date.now()
+                    },
+                    refreshStatus: {
+                        ...prevState.refreshStatus,
+                        [roomId]: 'idle'
+                    }
+                };
+            }
 
             const nextRequestInSec = Math.ceil(rateLimitInfo?.next_request_in_sec || 0);
             const minIntervalSec = rateLimitInfo?.min_interval_sec || currentDetail?.platform_rate_limit || 20;
@@ -1235,6 +1265,9 @@ class LiveList extends React.Component<Props, IState> {
                     // 优先使用 scheduler_status 来确定刷新状态
                     const schedulerStatus = detail.scheduler_status;
                     const rateLimitInfo = detail.rate_limit_info;
+                    const rateLimitEnabled = detail.platform_rate_limit_enabled
+                        ?? rateLimitInfo?.enabled
+                        ?? true;
 
                     let initialCountdown = 0;
                     let initialStatus: RefreshStatus = 'idle';
@@ -1249,14 +1282,14 @@ class LiveList extends React.Component<Props, IState> {
                             // 有下次请求计划
                             initialCountdown = Math.ceil(schedulerStatus.seconds_until_next_request);
                             // 检查是否在等待平台限制
-                            if (rateLimitInfo?.next_request_in_sec > 0) {
+                            if (rateLimitEnabled && rateLimitInfo?.next_request_in_sec > 0) {
                                 initialStatus = 'waiting_rate_limit';
                             } else {
                                 initialStatus = 'waiting_interval';
                             }
                         } else if (schedulerStatus.seconds_until_next_request === 0) {
                             // 即将发送请求或正在等待平台限制
-                            if (rateLimitInfo?.next_request_in_sec > 0) {
+                            if (rateLimitEnabled && rateLimitInfo?.next_request_in_sec > 0) {
                                 initialCountdown = Math.ceil(rateLimitInfo.next_request_in_sec);
                                 initialStatus = 'waiting_rate_limit';
                             } else {
@@ -1270,19 +1303,24 @@ class LiveList extends React.Component<Props, IState> {
                         }
                     } else {
                         // 回退到旧逻辑（兼容性）
-                        const nextRequestInSec = Math.ceil(rateLimitInfo?.next_request_in_sec || 0);
-                        const minIntervalSec = rateLimitInfo?.min_interval_sec || detail.platform_rate_limit || 20;
-                        const waitedSec = Math.round(rateLimitInfo?.waited_seconds || 0);
-
-                        if (nextRequestInSec > 0) {
-                            initialCountdown = nextRequestInSec;
-                            initialStatus = 'waiting_rate_limit';
-                        } else if (waitedSec < minIntervalSec) {
-                            initialCountdown = minIntervalSec - waitedSec;
-                            initialStatus = 'waiting_interval';
-                        } else {
+                        if (!rateLimitEnabled) {
                             initialCountdown = 0;
                             initialStatus = 'idle';
+                        } else {
+                            const nextRequestInSec = Math.ceil(rateLimitInfo?.next_request_in_sec || 0);
+                            const minIntervalSec = rateLimitInfo?.min_interval_sec || detail.platform_rate_limit || 20;
+                            const waitedSec = Math.round(rateLimitInfo?.waited_seconds || 0);
+
+                            if (nextRequestInSec > 0) {
+                                initialCountdown = nextRequestInSec;
+                                initialStatus = 'waiting_rate_limit';
+                            } else if (waitedSec < minIntervalSec) {
+                                initialCountdown = minIntervalSec - waitedSec;
+                                initialStatus = 'waiting_interval';
+                            } else {
+                                initialCountdown = 0;
+                                initialStatus = 'idle';
+                            }
                         }
                     }
 
@@ -1428,6 +1466,9 @@ class LiveList extends React.Component<Props, IState> {
         const countdown = countdownTimers[record.roomId] ?? 0;
         const status = refreshStatus[record.roomId] ?? 'idle';
         const liveId = record.roomId;
+        const platformRateLimitEnabled = detail?.platform_rate_limit_enabled
+            ?? detail?.rate_limit_info?.enabled
+            ?? true;
         // 保存 this 引用供嵌套函数使用
         const component = this;
 
@@ -1782,7 +1823,27 @@ class LiveList extends React.Component<Props, IState> {
 
                             <Divider style={{ margin: '8px 0' }}>平台访问频率控制</Divider>
                             <div style={{ padding: '0 12px 8px' }}>
-                                {detail.rate_limit_info ? (
+                                {!platformRateLimitEnabled ? (
+                                    <div>
+                                        <Alert
+                                            message="平台级访问限流已暂时停用"
+                                            description="当前不会限制同平台请求的最小间隔或并发数；已保存的 min_access_interval_sec 配置暂不生效。"
+                                            type="warning"
+                                            showIcon
+                                        />
+                                        <div style={{ marginTop: 12, borderBottom: 'none' }}>
+                                            <Button
+                                                type="primary"
+                                                size="small"
+                                                onClick={handleForceRefresh}
+                                                loading={status === 'refreshing'}
+                                                icon={<ReloadOutlined />}
+                                            >
+                                                立即刷新
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ) : detail.rate_limit_info ? (
                                     <div>
                                         <div style={configRowStyle}>
                                             <Tooltip


### PR DESCRIPTION
## 背景

关联 #1180。

当前平台级访问限制会同时约束请求开始间隔，并将同一平台的在途请求限制为 1 个。抖音单次状态检测可能耗时较长，订阅较多房间时，新添加的直播间会在平台队列中长时间等待，导致不能及时开始录制。

## 改动

- 暂时关闭全局平台级访问限制器，平台请求不再等待最小间隔或同平台串行槽位
- 限制器关闭时不再登记限制，也不再向状态接口报告等待时间
- 保留现有限制器实现和配置结构，后续改善调度策略后可通过全局开关恢复
- 调整单元测试：独立验证限制器原有逻辑，并增加全局限制保持关闭的回归覆盖

## 影响

- 同平台多个直播间可以并发检测，缓解新直播间初始化和开播检测延迟
- 每个直播间自身的轮询间隔和失败退避仍然保留
- 启动或工具恢复时的平台请求峰值可能增加；这是本次临时缓解措施的已知取舍

## 验证

- `make build-web dev`
- `make lint`
- `make test`
