### PR TITLE
fix: 主动停止录制后继续处理已写入的 FLV 文件

### DIFF
--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -693,11 +693,21 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		if elapsed := time.Since(r.startTime); elapsed < 5*time.Second {
 			cleanupOrphanedDanmakuFiles(dmFile)
 		}
-		return
-	}
-
-	// 录制成功，累积弹幕文件
-	if dmFile != "" {
+		// LiveEnd/Close 会先关闭 r.stop 再调用 parser.Stop()：FFmpeg 若未能在 3 秒内
+		// 响应 stdin 的 "q" 退出请求（例如直播存在延迟缓冲、仍在阻塞读取网络数据），
+		// 会被强制 SIGKILL，此处的 err 即为该次强制终止（如 "signal: killed"）。
+		// 这种情况下已经写入的部分数据仍然有效，若直接 return 会把它们遗弃为
+		// 一个未经过 fix_flv/convert_mp4 修复、往往无法直接播放的 FLV。
+		// 因此只要是主动停止且输出文件非空，就继续走下面的后处理流程，尽量保留已录制内容。
+		if !r.isUserStopped() {
+			return
+		}
+		if fi, statErr := os.Stat(fileName); statErr != nil || fi.Size() == 0 {
+			return
+		}
+		r.getLogger().Warn("录制被主动停止中断（可能是直播延迟导致 FFmpeg 被强制终止），尝试对已写入的部分文件进行后处理")
+	} else if dmFile != "" {
+		// 录制成功，累积弹幕文件
 		if fi, dmErr := os.Stat(dmFile); dmErr == nil && fi.Size() > 0 {
 			r.accumulateRecordedFiles(dmFile)
 		}
@@ -1392,6 +1402,18 @@ func (r *recorder) IsRecording() bool {
 		return fileInfo.Size() > 0
 	}
 	return false
+}
+
+// isUserStopped 返回 recorder 是否已被主动停止（LiveEnd/Close/CloseForRestart）。
+// r.stop 在 Close() 中先于 parser.Stop() 被关闭，因此 tryRecord 里 ParseLiveStream
+// 返回后据此可判断这次错误是否源自主动停止触发的强制终止，而非真正的录制异常。
+func (r *recorder) isUserStopped() bool {
+	select {
+	case <-r.stop:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *recorder) Close() {


### PR DESCRIPTION
## 背景

在收到 `LiveEnd` 后，recorder 会主动停止 FFmpeg。如果 FFmpeg 未能在超时时间内正常退出并被强制终止，`ParseLiveStream` 会返回错误，原有逻辑会直接结束录制流程，导致已经写入的 FLV 文件无法进入后处理流水线。

## 变更内容

- 增加主动停止状态判断，区分录制异常与 `LiveEnd` / `Close` / `CloseForRestart` 触发的停止。
- 当录制由主动停止中断，且输出文件存在并且非空时，不再直接丢弃文件，而是继续执行 `fix_flv`、`convert_mp4` 等后处理。
- 保留真正录制异常和空文件场景下的原有退出行为。
- 增加相应的告警日志，便于定位部分文件恢复场景。

## 说明

本 PR 先实现低风险的文件挽救与后处理容错；Issue 中提出的可配置“下播宽限期”未包含在本次改动中，可另行讨论和实现。

## 验证

- [x] `make dev`

关联 #1182
