### PR TITLE
修复 ASS 弹幕排队延迟导致时间轴过长的问题

### DIFF
--- a/src/recorders/danmaku/ass.go
+++ b/src/recorders/danmaku/ass.go
@@ -29,6 +29,8 @@ type AssWriter struct {
 	laneNum      int // total lanes in the usable range
 	nextLane     int
 	laneLast     []int64 // last tail-clear time (centiseconds) per lane
+
+	maxLaneDelayCS int64 // 弹幕排队等待 lane 的最大延迟（厘秒）
 }
 
 func parseResolution(res string) (int, int) {
@@ -96,6 +98,9 @@ func NewAssWriter(filePath string, startAt time.Time, cfg configs.DanmakuConfig,
 		laneNum:      laneNum,
 		nextLane:     0,
 		laneLast:     make([]int64, laneNum),
+		// 排队延迟最多不超过一个完整滚动周期，避免弹幕高峰期间延迟无限累积，
+		// 导致 ass 文件末尾的时间戳远超实际录制时长 (#1178)。
+		maxLaneDelayCS: int64(scrollTimeMs) / 10,
 	}
 
 	if err := w.writeHeader(); err != nil {
@@ -412,6 +417,11 @@ func (w *AssWriter) assignLane(startCS int64, textWidth int) (int, int64) {
 		}
 	}
 	newStartCS := w.laneLast[earliest]
+	// 弹幕高峰持续超过屏幕容量时，排队延迟会不断累积。一旦超过上限就放弃排队，
+	// 直接按实际到达时间显示（允许短暂重叠），防止延迟随录制时长无限增长。
+	if newStartCS-startCS > w.maxLaneDelayCS {
+		newStartCS = startCS
+	}
 	// 存储新弹幕尾部离开右侧的时间点
 	tailClearCS := newStartCS + int64(w.scrollTimeMs)*int64(safeTextWidth)/int64(w.resX)/10
 	w.laneLast[earliest] = tailClearCS

--- a/src/recorders/danmaku/ass_test.go
+++ b/src/recorders/danmaku/ass_test.go
@@ -1,0 +1,33 @@
+package danmaku
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bililive-go/bililive-go/src/configs"
+)
+
+// TestAssignLaneDelayIsBounded 验证弹幕高峰期间排队延迟不会无限累积
+// (issue #1178：录制时长 1 分钟但弹幕过多时，生成的 ass 文件时间轴长达 5 分钟)。
+func TestAssignLaneDelayIsBounded(t *testing.T) {
+	cfg := configs.DanmakuConfig{}
+	cfg.SetDefaults()
+	cfg.ScrollArea = "quarter" // 缩小可用 lane 数量，更容易触发排队
+
+	path := filepath.Join(t.TempDir(), "test.ass")
+	w, err := NewAssWriter(path, time.Now(), cfg, "test")
+	if err != nil {
+		t.Fatalf("NewAssWriter failed: %v", err)
+	}
+	defer w.Close()
+
+	// 模拟弹幕高峰：到达速度远快于屏幕可承载速度（startCS 每条只增加 1 厘秒）
+	for i := 0; i < 2000; i++ {
+		startCS := int64(i)
+		_, adjustedStart := w.assignLane(startCS, 200)
+		if delay := adjustedStart - startCS; delay > w.maxLaneDelayCS {
+			t.Fatalf("danmaku #%d: lane queueing delay exceeded cap: got %d cs, want <= %d cs", i, delay, w.maxLaneDelayCS)
+		}
+	}
+}


### PR DESCRIPTION
## 问题

关联并修复 #1178。

当直播间弹幕密度持续超过可用轨道的承载能力时，ASS 弹幕会不断排队，导致生成文件末尾的时间戳远超实际录制时长。

## 原因

`AssWriter.assignLane` 在所有轨道被占用时，会把新弹幕延迟到最早空闲轨道的时间点，但原有逻辑没有限制排队延迟。弹幕持续高峰时，延迟因此不断累积。

## 修改内容

- 为轨道排队延迟增加上限，上限为一个完整的弹幕滚动周期
- 超过上限时按弹幕实际到达时间显示，允许高峰期出现短暂重叠，避免时间轴无限延长
- 新增单元测试，模拟高密度弹幕并验证排队延迟始终不超过上限

## 验证

- `make build-web dev`
- `make lint`
- `make test`
