### PR TITLE
fix: 修复 Docker 中 bililive-tools 无法获取 HOME

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-HOME=/srv/bililive
+export HOME=/srv/bililive
 
 chown -R ${PUID}:${PGID} ${HOME}
 chown -R ${PUID}:${PGID} /etc/bililive-go

--- a/src/tools/tools.go
+++ b/src/tools/tools.go
@@ -701,9 +701,7 @@ func startBTools() error {
 
 	nodeFolder := filepath.Dir(node.GetToolPath())
 	btoolsFolder := filepath.Dir(btools.GetToolPath())
-	env := []string{
-		"PATH=" + nodeFolder + string(os.PathListSeparator) + os.Getenv("PATH"),
-	}
+	env := btoolsCommandEnv(nodeFolder)
 	nodePath, err := filepath.Abs(node.GetToolPath())
 	if err != nil {
 		currentBToolsStatus.Store(int32(BToolsStatusFailed))
@@ -748,6 +746,14 @@ func startBTools() error {
 		blog.GetLogger().WithError(err).Warnln("bililive-tools 进程已退出，依赖它的平台（如抖音）将暂停请求")
 	}
 	return err
+}
+
+func btoolsCommandEnv(nodeFolder string) []string {
+	// 必须继承父进程环境。只传 PATH 会丢失 HOME；当容器使用的 PUID
+	// 不存在于 /etc/passwd 时，Node.js 无法推导主目录并报 uv_os_homedir ENOENT。
+	return append(os.Environ(),
+		"PATH="+nodeFolder+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
 }
 
 func AsyncDownloadIfNecessary(toolName string) {

--- a/src/tools/tools.go
+++ b/src/tools/tools.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -751,9 +752,27 @@ func startBTools() error {
 func btoolsCommandEnv(nodeFolder string) []string {
 	// 必须继承父进程环境。只传 PATH 会丢失 HOME；当容器使用的 PUID
 	// 不存在于 /etc/passwd 时，Node.js 无法推导主目录并报 uv_os_homedir ENOENT。
-	return append(os.Environ(),
-		"PATH="+nodeFolder+string(os.PathListSeparator)+os.Getenv("PATH"),
-	)
+	parentEnv := os.Environ()
+	env := make([]string, 1, len(parentEnv)+1)
+	env[0] = "PATH=" + nodeFolder + string(os.PathListSeparator) + os.Getenv("PATH")
+	for _, entry := range parentEnv {
+		if environmentEntryHasKey(entry, "PATH") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
+func environmentEntryHasKey(entry, key string) bool {
+	name, _, ok := strings.Cut(entry, "=")
+	if !ok {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(name, key)
+	}
+	return name == key
 }
 
 func AsyncDownloadIfNecessary(toolName string) {

--- a/src/tools/tools_test.go
+++ b/src/tools/tools_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,10 +31,30 @@ func TestBToolsCommandEnvInheritsParentEnvironment(t *testing.T) {
 	}
 }
 
+func TestEnvironmentHelpersUsePlatformKeyCaseSensitivity(t *testing.T) {
+	env := []string{
+		"https_proxy=http://lowercase-proxy.invalid",
+		"HTTPS_PROXY=http://uppercase-proxy.invalid",
+	}
+	wantValue := "http://uppercase-proxy.invalid"
+	wantCount := 1
+	if runtime.GOOS == "windows" {
+		wantValue = "http://lowercase-proxy.invalid"
+		wantCount = 2
+	}
+
+	if got := firstEnvironmentValue(env, "HTTPS_PROXY"); got != wantValue {
+		t.Fatalf("HTTPS_PROXY = %q，期望 %q", got, wantValue)
+	}
+	if got := environmentKeyCount(env, "HTTPS_PROXY"); got != wantCount {
+		t.Fatalf("HTTPS_PROXY 计数为 %d，期望 %d", got, wantCount)
+	}
+}
+
 func firstEnvironmentValue(env []string, key string) string {
 	for _, entry := range env {
-		name, current, ok := strings.Cut(entry, "=")
-		if ok && strings.EqualFold(name, key) {
+		_, current, ok := strings.Cut(entry, "=")
+		if ok && environmentEntryHasKey(entry, key) {
 			return current
 		}
 	}
@@ -43,8 +64,7 @@ func firstEnvironmentValue(env []string, key string) string {
 func environmentKeyCount(env []string, key string) int {
 	count := 0
 	for _, entry := range env {
-		name, _, ok := strings.Cut(entry, "=")
-		if ok && strings.EqualFold(name, key) {
+		if environmentEntryHasKey(entry, key) {
 			count++
 		}
 	}

--- a/src/tools/tools_test.go
+++ b/src/tools/tools_test.go
@@ -15,25 +15,38 @@ func TestBToolsCommandEnvInheritsParentEnvironment(t *testing.T) {
 	nodeFolder := filepath.Join("opt", "bililive", "tools", "node")
 	env := btoolsCommandEnv(nodeFolder)
 
-	if got := lastEnvironmentValue(env, "HOME"); got != "/tmp/bililive-home" {
+	if got := firstEnvironmentValue(env, "HOME"); got != "/tmp/bililive-home" {
 		t.Fatalf("HOME 未被继承，实际值为 %q", got)
 	}
-	if got := lastEnvironmentValue(env, "HTTPS_PROXY"); got != "http://proxy.example.com" {
+	if got := firstEnvironmentValue(env, "HTTPS_PROXY"); got != "http://proxy.example.com" {
 		t.Fatalf("HTTPS_PROXY 未被继承，实际值为 %q", got)
 	}
 	wantPath := nodeFolder + string(os.PathListSeparator) + "/usr/bin"
-	if got := lastEnvironmentValue(env, "PATH"); got != wantPath {
+	if got := firstEnvironmentValue(env, "PATH"); got != wantPath {
 		t.Fatalf("PATH = %q，期望 %q", got, wantPath)
+	}
+	if count := environmentKeyCount(env, "PATH"); count != 1 {
+		t.Fatalf("PATH 出现了 %d 次，期望仅出现一次", count)
 	}
 }
 
-func lastEnvironmentValue(env []string, key string) string {
-	var value string
+func firstEnvironmentValue(env []string, key string) string {
 	for _, entry := range env {
 		name, current, ok := strings.Cut(entry, "=")
 		if ok && strings.EqualFold(name, key) {
-			value = current
+			return current
 		}
 	}
-	return value
+	return ""
+}
+
+func environmentKeyCount(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(name, key) {
+			count++
+		}
+	}
+	return count
 }

--- a/src/tools/tools_test.go
+++ b/src/tools/tools_test.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBToolsCommandEnvInheritsParentEnvironment(t *testing.T) {
+	t.Setenv("HOME", "/tmp/bililive-home")
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com")
+	t.Setenv("PATH", "/usr/bin")
+
+	nodeFolder := filepath.Join("opt", "bililive", "tools", "node")
+	env := btoolsCommandEnv(nodeFolder)
+
+	if got := lastEnvironmentValue(env, "HOME"); got != "/tmp/bililive-home" {
+		t.Fatalf("HOME 未被继承，实际值为 %q", got)
+	}
+	if got := lastEnvironmentValue(env, "HTTPS_PROXY"); got != "http://proxy.example.com" {
+		t.Fatalf("HTTPS_PROXY 未被继承，实际值为 %q", got)
+	}
+	wantPath := nodeFolder + string(os.PathListSeparator) + "/usr/bin"
+	if got := lastEnvironmentValue(env, "PATH"); got != wantPath {
+		t.Fatalf("PATH = %q，期望 %q", got, wantPath)
+	}
+}
+
+func lastEnvironmentValue(env []string, key string) string {
+	var value string
+	for _, entry := range env {
+		name, current, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(name, key) {
+			value = current
+		}
+	}
+	return value
+}


### PR DESCRIPTION
## 问题

Docker 使用自定义 `PUID/PGID` 时，该 UID 可能不存在于容器的 `/etc/passwd` 中。当前启动 `bililive-tools` 的 Node.js 子进程只传递了 `PATH`，导致 `HOME` 等父进程环境变量丢失。Node.js 无法从环境或用户数据库取得主目录，因此报错：

```text
uv_os_homedir returned ENOENT (no such file or directory)
```

## 修复

- 启动 `bililive-tools` 时继承父进程环境变量，并在此基础上覆盖 `PATH`
- 在 Docker entrypoint 中显式导出 `HOME=/srv/bililive`
- 增加回归测试，验证 `HOME`、代理变量等能够传递，同时 Node.js 工具目录仍位于 `PATH` 首位

## 验证

- `make dev`
- `make build-web dev`
- `make lint`
- `make test`
