### PR TITLE
fix: 修复 Sentry 发现的生产环境问题

### DIFF
--- a/src/instance/live_map.go
+++ b/src/instance/live_map.go
@@ -105,12 +105,49 @@ func (lm *LiveMap) SetIfAbsent(id types.LiveID, l live.Live) bool {
 	return true
 }
 
-// ReplaceKey 原子地删除旧 key 并设置新 key。
-// 用于 InitializingLive 完成初始化后替换 LiveID 的场景。
-func (lm *LiveMap) ReplaceKey(oldID types.LiveID, newID types.LiveID, l live.Live) {
+// ReplaceKeyIfCurrent 仅当 oldID 仍指向 expected 时，才原子地删除旧 key 并设置新 key。
+// 用于 InitializingLive 完成初始化后替换 LiveID 的场景，避免已删除房间的迟到回调
+// 把房间重新插回 map。若 newID 已被其他 Live 占用，也会拒绝覆盖。
+func (lm *LiveMap) ReplaceKeyIfCurrent(oldID, newID types.LiveID, expected, replacement live.Live) bool {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
-	lm.initLocked()
+	current, ok := lm.m[oldID]
+	if !ok || current != expected {
+		return false
+	}
+	if newID != oldID {
+		if _, exists := lm.m[newID]; exists {
+			return false
+		}
+	}
 	delete(lm.m, oldID)
-	lm.m[newID] = l
+	lm.m[newID] = replacement
+	return true
+}
+
+// DeleteIfCurrent 仅当 id 仍指向 expected 时才删除，避免删除并发替换后的新对象。
+func (lm *LiveMap) DeleteIfCurrent(id types.LiveID, expected live.Live) bool {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	current, ok := lm.m[id]
+	if !ok || current != expected {
+		return false
+	}
+	delete(lm.m, id)
+	return true
+}
+
+// DeleteByRawURL 原子删除所有匹配原始 URL 的 Live，并返回被删除对象供调用方在锁外关闭。
+// 删除房间时 LiveID 可能正从初始化 ID 切换为平台 ID，因此不能只删除调用方最初看到的 key。
+func (lm *LiveMap) DeleteByRawURL(rawURL string) []live.Live {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	removed := make([]live.Live, 0, 1)
+	for id, current := range lm.m {
+		if current != nil && current.GetRawUrl() == rawURL {
+			delete(lm.m, id)
+			removed = append(removed, current)
+		}
+	}
+	return removed
 }

--- a/src/instance/live_map_test.go
+++ b/src/instance/live_map_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/bililive-go/bililive-go/src/live"
+	livemock "github.com/bililive-go/bililive-go/src/live/mock"
 	"github.com/bililive-go/bililive-go/src/types"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // TestLiveMap_ZeroValue 验证 LiveMap 的零值可以安全使用。
@@ -111,25 +113,63 @@ func TestLiveMap_BasicOperations(t *testing.T) {
 	}
 }
 
-// TestLiveMap_ReplaceKey 验证原子替换操作。
-func TestLiveMap_ReplaceKey(t *testing.T) {
+// TestLiveMap_ReplaceKeyIfCurrent 验证带对象身份检查的原子替换操作。
+func TestLiveMap_ReplaceKeyIfCurrent(t *testing.T) {
 	var lm LiveMap
+	ctrl := gomock.NewController(t)
+	current := livemock.NewMockLive(ctrl)
+	unexpected := livemock.NewMockLive(ctrl)
+	replacement := livemock.NewMockLive(ctrl)
+	occupied := livemock.NewMockLive(ctrl)
 
-	lm.Set("old", nil)
+	lm.Set("old", current)
 	if !lm.Has("old") {
 		t.Fatal("old key should exist")
 	}
 
-	lm.ReplaceKey("old", "new", nil)
+	if lm.ReplaceKeyIfCurrent("old", "new", unexpected, replacement) {
+		t.Fatal("expected 不匹配时不应替换")
+	}
+	lm.Set("new", occupied)
+	if lm.ReplaceKeyIfCurrent("old", "new", current, replacement) {
+		t.Fatal("new key 已占用时不应替换")
+	}
+	lm.Delete("new")
+	if !lm.ReplaceKeyIfCurrent("old", "new", current, replacement) {
+		t.Fatal("expected 匹配且 new key 空闲时应替换")
+	}
 
 	if lm.Has("old") {
-		t.Error("old key should be removed after ReplaceKey")
+		t.Error("old key should be removed after ReplaceKeyIfCurrent")
 	}
-	if !lm.Has("new") {
-		t.Error("new key should exist after ReplaceKey")
+	got, ok := lm.Get("new")
+	if !ok || got != replacement {
+		t.Error("new key should point to replacement after ReplaceKeyIfCurrent")
 	}
 	if lm.Len() != 1 {
-		t.Errorf("Len should be 1 after ReplaceKey, got %d", lm.Len())
+		t.Errorf("Len should be 1 after ReplaceKeyIfCurrent, got %d", lm.Len())
+	}
+}
+
+func TestLiveMap_DeleteByRawURL(t *testing.T) {
+	var lm LiveMap
+	ctrl := gomock.NewController(t)
+	first := livemock.NewMockLive(ctrl)
+	second := livemock.NewMockLive(ctrl)
+	other := livemock.NewMockLive(ctrl)
+	first.EXPECT().GetRawUrl().Return("https://example.com/room")
+	second.EXPECT().GetRawUrl().Return("https://example.com/room")
+	other.EXPECT().GetRawUrl().Return("https://example.com/other")
+	lm.Set("initializing", first)
+	lm.Set("platform-id", second)
+	lm.Set("other", other)
+
+	removed := lm.DeleteByRawURL("https://example.com/room")
+	if len(removed) != 2 {
+		t.Fatalf("应删除同 URL 的两个对象，实际删除 %d 个", len(removed))
+	}
+	if lm.Has("initializing") || lm.Has("platform-id") || !lm.Has("other") {
+		t.Fatal("DeleteByRawURL 删除了错误的 map 条目")
 	}
 }
 
@@ -203,7 +243,7 @@ func TestLiveMap_Concurrent(t *testing.T) {
 	// 如果没有 panic 或 race condition，测试通过
 }
 
-// TestLiveMap_ConcurrentReplaceKey 验证 ReplaceKey 在并发场景下的原子性。
+// TestLiveMap_ConcurrentReplaceKey 验证 ReplaceKeyIfCurrent 在并发场景下的原子性。
 func TestLiveMap_ConcurrentReplaceKey(t *testing.T) {
 	var lm LiveMap
 	const goroutines = 10
@@ -217,7 +257,7 @@ func TestLiveMap_ConcurrentReplaceKey(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goroutines * 2) // ReplaceKey + 并发读
 
-	// 并发 ReplaceKey
+	// 并发 ReplaceKeyIfCurrent
 	for g := 0; g < goroutines; g++ {
 		go func(g int) {
 			defer wg.Done()
@@ -225,7 +265,7 @@ func TestLiveMap_ConcurrentReplaceKey(t *testing.T) {
 				idx := g*iterations + i
 				oldID := types.LiveID(fmt.Sprintf("old-%d", idx))
 				newID := types.LiveID(fmt.Sprintf("new-%d", idx))
-				lm.ReplaceKey(oldID, newID, nil)
+				lm.ReplaceKeyIfCurrent(oldID, newID, nil, nil)
 			}
 		}(g)
 	}

--- a/src/listeners/error.go
+++ b/src/listeners/error.go
@@ -3,6 +3,7 @@ package listeners
 import "errors"
 
 var (
-	ErrListenerExist    = errors.New("this live has a listener")
-	ErrListenerNotExist = errors.New("this live has not a listener")
+	ErrListenerExist             = errors.New("this live has a listener")
+	ErrListenerNotExist          = errors.New("this live has not a listener")
+	ErrInitializingResultExpired = errors.New("the initializing result is no longer current")
 )

--- a/src/listeners/manager.go
+++ b/src/listeners/manager.go
@@ -2,6 +2,7 @@ package listeners
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/bililive-go/bililive-go/src/configs"
@@ -42,19 +43,27 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 		initializingLive := param.InitializingLive
 		originalLive := param.Live
 		info := param.Info
+		inst := instance.GetInstance(ctx)
+		logger := originalLive.GetLogger()
+		rawURL := originalLive.GetRawUrl()
+		oldLiveID := initializingLive.GetLiveId()
+
+		// GetInfo 可能在用户删除房间后才返回。先确认配置仍存在，避免迟到的初始化
+		// 回调重新插入已删除的房间，更不能把这种正常竞态升级成 panic。
+		cfg := configs.GetCurrentConfig()
+		if _, err := getConfiguredRoom(cfg, rawURL); err != nil {
+			logger.Debug("直播间初始化完成时配置已不存在，忽略迟到结果")
+			m.discardInitializingLive(ctx, inst, oldLiveID, initializingLive)
+			return
+		}
+
 		if info.CustomLiveId != "" {
 			originalLive.SetLiveIdByString(info.CustomLiveId)
 		}
-		inst := instance.GetInstance(ctx)
-		logger := originalLive.GetLogger()
 
 		// 将原始 Live 包装为 WrappedLive（使用全局缓存）
 		// 传入 ctx 以便调度器可以被统一取消
-		oldLiveId := initializingLive.GetLiveId()
 		wrappedLive := live.NewWrappedLive(ctx, originalLive, inst.Cache)
-
-		// 原子地替换 Lives map 中的条目（删除旧 InitializingLive，添加新 wrappedLive）
-		inst.Lives.ReplaceKey(oldLiveId, wrappedLive.GetLiveId(), wrappedLive)
 
 		// 将已有的 info 注入新的 WrappedLive，避免 listener 交接后立即重复请求平台，
 		// 同时让新调度器从本次成功请求开始计算下一轮间隔。
@@ -63,23 +72,52 @@ func (m *manager) registryListener(ctx context.Context, ed events.Dispatcher) {
 			logger.WithError(err).Warn("failed to cache info for new live")
 		}
 
-		cfg := configs.GetCurrentConfig()
-		room, err := cfg.GetLiveRoomByUrl(wrappedLive.GetRawUrl())
-		if err != nil {
-			logger.WithFields(map[string]any{
-				"room": wrappedLive.GetRawUrl(),
-			}).Error(err)
-			panic(err)
+		// 只有 map 中仍是本次初始化对象时才允许交接。删除流程会先移除旧对象，
+		// 因此迟到回调无法再把房间复活；同时避免覆盖已占用的新 LiveID。
+		newLiveID := wrappedLive.GetLiveId()
+		if !inst.Lives.ReplaceKeyIfCurrent(oldLiveID, newLiveID, initializingLive, wrappedLive) {
+			logger.Debug("直播间初始化结果已过期，放弃状态交接")
+			wrappedLive.Close()
+			return
 		}
-		configs.SetLiveRoomId(wrappedLive.GetRawUrl(), wrappedLive.GetLiveId())
+
+		// 配置可能在第一次检查与 map 交接之间被删除，再检查一次并回滚新对象。
+		cfg = configs.GetCurrentConfig()
+		room, err := getConfiguredRoom(cfg, rawURL)
+		if err != nil {
+			logger.Debug("直播间在初始化交接期间被删除，回滚迟到结果")
+			inst.Lives.DeleteIfCurrent(newLiveID, wrappedLive)
+			wrappedLive.Close()
+			initializingLive.Close()
+			return
+		}
+		configs.SetLiveRoomId(rawURL, newLiveID)
 		if room.IsListening {
 			if err := m.replaceListener(ctx, initializingLive, wrappedLive, info); err != nil {
-				logger.WithFields(map[string]any{
-					"url": wrappedLive.GetRawUrl(),
-				}).Error(err)
+				logger.WithError(err).Error("直播间初始化完成，但 listener 交接失败")
+				inst.Lives.DeleteIfCurrent(newLiveID, wrappedLive)
+				wrappedLive.Close()
+				m.discardInitializingLive(ctx, inst, oldLiveID, initializingLive)
+				return
 			}
 		}
+		initializingLive.Close()
 	}))
+}
+
+func getConfiguredRoom(cfg *configs.Config, rawURL string) (*configs.LiveRoom, error) {
+	if cfg == nil {
+		return nil, errors.New("配置尚未初始化")
+	}
+	return cfg.GetLiveRoomByUrl(rawURL)
+}
+
+func (m *manager) discardInitializingLive(ctx context.Context, inst *instance.Instance, id types.LiveID, initializingLive live.Live) {
+	if m.HasListener(ctx, id) {
+		_ = m.RemoveListener(ctx, id)
+	}
+	inst.Lives.DeleteIfCurrent(id, initializingLive)
+	initializingLive.Close()
 }
 
 func (m *manager) Start(ctx context.Context) error {
@@ -129,6 +167,11 @@ func (m *manager) RemoveListener(ctx context.Context, liveId types.LiveID) error
 func (m *manager) replaceListener(ctx context.Context, oldLive live.Live, newLive live.Live, info *live.Info) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+	newLiveID := newLive.GetLiveId()
+	current, ok := instance.GetInstance(ctx).Lives.Get(newLiveID)
+	if !ok || current != newLive {
+		return ErrInitializingResultExpired
+	}
 	oldLiveId := oldLive.GetLiveId()
 	oldListener, ok := m.savers[oldLiveId]
 	if !ok {
@@ -137,13 +180,18 @@ func (m *manager) replaceListener(ctx context.Context, oldLive live.Live, newLiv
 	// 必须等旧 ListenStop 的录制器清理完成后，才能让新 listener 发布 LiveStart。
 	oldListener.CloseSync()
 	newListener := newListener(ctx, newLive)
-	if oldLiveId == newLive.GetLiveId() {
+	if oldLiveId == newLiveID {
 		m.savers[oldLiveId] = newListener
 	} else {
 		delete(m.savers, oldLiveId)
-		m.savers[newLive.GetLiveId()] = newListener
+		m.savers[newLiveID] = newListener
 	}
-	return newListener.StartWithInfo(info)
+	if err := newListener.StartWithInfo(info); err != nil {
+		newListener.Close()
+		delete(m.savers, newLiveID)
+		return err
+	}
+	return nil
 }
 
 func (m *manager) GetListener(ctx context.Context, liveId types.LiveID) (Listener, error) {

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/bililive-go/bililive-go/src/instance"
 	"github.com/bililive-go/bililive-go/src/live"
 	livemock "github.com/bililive-go/bililive-go/src/live/mock"
+	"github.com/bililive-go/bililive-go/src/pkg/events"
 	evtmock "github.com/bililive-go/bililive-go/src/pkg/events/mock"
+	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 	"github.com/bililive-go/bililive-go/src/types"
+	"github.com/sirupsen/logrus"
 )
 
 func TestManagerAddAndRemoveListener(t *testing.T) {
@@ -88,14 +91,65 @@ func TestReplaceListenerUsesSynchronousHandoverAndInitialInfo(t *testing.T) {
 	oldLive := livemock.NewMockLive(ctrl)
 	oldLive.EXPECT().GetLiveId().Return(types.LiveID("old"))
 	newLive := livemock.NewMockLive(ctrl)
-	newLive.EXPECT().GetLiveId().Return(types.LiveID("new")).Times(2)
+	newLive.EXPECT().GetLiveId().Return(types.LiveID("new"))
+	inst := &instance.Instance{}
+	inst.Lives.Set("new", newLive)
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
 
 	m := &manager{savers: map[types.LiveID]Listener{"old": oldListener}}
 	backup := newListener
 	newListener = func(context.Context, live.Live) Listener { return newListenerMock }
 	defer func() { newListener = backup }()
 
-	assert.NoError(t, m.replaceListener(context.Background(), oldLive, newLive, info))
+	assert.NoError(t, m.replaceListener(ctx, oldLive, newLive, info))
 	assert.Same(t, newListenerMock, m.savers["new"])
 	assert.NotContains(t, m.savers, types.LiveID("old"))
+}
+
+func TestReplaceListenerRejectsExpiredInitializingResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	newLive := livemock.NewMockLive(ctrl)
+	newLive.EXPECT().GetLiveId().Return(types.LiveID("new"))
+	ctx := context.WithValue(context.Background(), instance.Key, &instance.Instance{})
+	m := &manager{savers: map[types.LiveID]Listener{"old": NewMockListener(ctrl)}}
+
+	assert.ErrorIs(t, m.replaceListener(ctx, nil, newLive, &live.Info{}), ErrInitializingResultExpired)
+}
+
+func TestInitializingFinishedIgnoresRoomRemovedDuringInitialization(t *testing.T) {
+	previousConfig := configs.GetCurrentConfig()
+	configs.SetCurrentConfig(configs.NewConfig())
+	t.Cleanup(func() { configs.SetCurrentConfig(previousConfig) })
+
+	ctrl := gomock.NewController(t)
+	oldLive := livemock.NewMockLive(ctrl)
+	originalLive := livemock.NewMockLive(ctrl)
+	oldID := types.LiveID("initializing-id")
+	rawURL := "https://example.com/room"
+	oldLive.EXPECT().GetLiveId().Return(oldID)
+	oldLive.EXPECT().Close()
+	originalLive.EXPECT().GetLogger().Return(livelogger.New(0, logrus.Fields{"test": t.Name()}))
+	originalLive.EXPECT().GetRawUrl().Return(rawURL)
+
+	inst := &instance.Instance{}
+	inst.Lives.Set(oldID, oldLive)
+	ctx := context.WithValue(context.Background(), instance.Key, inst)
+	m := &manager{savers: make(map[types.LiveID]Listener)}
+
+	var registered *events.EventListener
+	ed := evtmock.NewMockDispatcher(ctrl)
+	ed.EXPECT().AddEventListener(RoomInitializingFinished, gomock.Any()).Do(
+		func(_ events.EventType, listener *events.EventListener) { registered = listener },
+	)
+	m.registryListener(ctx, ed)
+	assert.NotNil(t, registered)
+
+	assert.NotPanics(t, func() {
+		registered.Handler(events.NewEvent(RoomInitializingFinished, live.InitializingFinishedParam{
+			InitializingLive: oldLive,
+			Live:             originalLive,
+			Info:             &live.Info{},
+		}))
+	})
+	assert.False(t, inst.Lives.Has(oldID), "迟到回调不应把已删除房间留在 LiveMap")
 }

--- a/src/live/douyu/douyu.go
+++ b/src/live/douyu/douyu.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -49,7 +50,16 @@ func (b *builder) Build(url *url.URL) (live.Live, error) {
 }
 
 var (
-	cryptoJS        []byte
+	cryptoJS   []byte
+	cryptoJSMu sync.Mutex
+	// cryptoJSCDNURLs 为可替换变量，便于测试全部 CDN 不可用与后续重试。
+	cryptoJSCDNURLs = []string{
+		"https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js",
+		"https://cdn.jsdelivr.net/npm/crypto-js@3.1.9-1/crypto-js.min.js",
+		"https://cdn.staticfile.org/crypto-js/3.1.9-1/crypto-js.min.js",
+		"https://cdn.bootcdn.net/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js",
+	}
+
 	douyuRoomIDRegs = []string{
 		`\$ROOM\.room_id\s*=\s*(\d+)`,
 		`room_id\s*=\s*(\d+)`,
@@ -103,42 +113,50 @@ func render(tmpl *template.Template, data any) (string, error) {
 	return buf.String(), nil
 }
 
-func (l *Live) loadCryptoJS() {
-	var (
-		resp *requests.Response
-		body []byte
-		err  error
-	)
-	cdnUrls := [...]string{"https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js",
-		"https://cdn.jsdelivr.net/npm/crypto-js@3.1.9-1/crypto-js.min.js",
-		"https://cdn.staticfile.org/crypto-js/3.1.9-1/crypto-js.min.js",
-		"https://cdn.bootcdn.net/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js"}
+func (l *Live) loadCryptoJS() ([]byte, error) {
+	cryptoJSMu.Lock()
+	defer cryptoJSMu.Unlock()
+	if len(cryptoJS) > 0 {
+		return cryptoJS, nil
+	}
 
-	for _, url := range cdnUrls {
-		resp, err = l.RequestSession.Get(url)
+	var lastErr error
+	for _, cdnURL := range cryptoJSCDNURLs {
+		resp, err := l.RequestSession.Get(cdnURL)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("unexpected HTTP status %d", resp.StatusCode)
 			continue
 		}
-		body, err = resp.Bytes()
+		body, err := resp.Bytes()
 		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(body) == 0 {
+			lastErr = errors.New("empty response body")
 			continue
 		}
 		cryptoJS = body
-		return
+		return cryptoJS, nil
 	}
-	panic(fmt.Errorf("failed to load CryptoJS, please check network"))
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to load CryptoJS from all configured CDNs: %w", lastErr)
+	}
+	return nil, errors.New("failed to load CryptoJS: no CDN configured")
 }
 
 func (l *Live) getEngineWithCryptoJS() (*otto.Otto, error) {
-	if cryptoJS == nil {
-		l.loadCryptoJS()
+	script, err := l.loadCryptoJS()
+	if err != nil {
+		return nil, err
 	}
 	engine := otto.New()
-	if _, err := engine.Eval(cryptoJS); err != nil {
+	if _, err := engine.Eval(script); err != nil {
 		return nil, err
 	}
 	return engine, nil

--- a/src/live/douyu/douyu_test.go
+++ b/src/live/douyu/douyu_test.go
@@ -1,0 +1,59 @@
+package douyu
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bililive-go/bililive-go/src/live/internal"
+)
+
+func TestGetEngineWithCryptoJSReturnsErrorAndCanRetry(t *testing.T) {
+	var available atomic.Bool
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		if !available.Load() {
+			http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = writer.Write([]byte(`var CryptoJS = {};`))
+	}))
+	defer server.Close()
+
+	cryptoJSMu.Lock()
+	previousScript := cryptoJS
+	previousURLs := cryptoJSCDNURLs
+	cryptoJS = nil
+	cryptoJSCDNURLs = []string{server.URL}
+	cryptoJSMu.Unlock()
+	t.Cleanup(func() {
+		cryptoJSMu.Lock()
+		cryptoJS = previousScript
+		cryptoJSCDNURLs = previousURLs
+		cryptoJSMu.Unlock()
+	})
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("解析测试服务器 URL 失败: %v", err)
+	}
+	l := &Live{BaseLive: internal.NewBaseLive(parsedURL)}
+
+	if _, err = l.getEngineWithCryptoJS(); err == nil {
+		t.Fatal("所有 CryptoJS CDN 不可用时应返回错误，而不是 panic")
+	}
+
+	available.Store(true)
+	if _, err = l.getEngineWithCryptoJS(); err != nil {
+		t.Fatalf("CDN 恢复后应能重试成功: %v", err)
+	}
+	if _, err = l.getEngineWithCryptoJS(); err != nil {
+		t.Fatalf("缓存的 CryptoJS 应可继续使用: %v", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("成功后应使用缓存，期望 2 次请求，实际 %d 次", got)
+	}
+}

--- a/src/pkg/sentry/sentry.go
+++ b/src/pkg/sentry/sentry.go
@@ -4,12 +4,14 @@ package sentry
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -28,6 +30,10 @@ var sensitiveKeywords = []string{
 
 // 敏感 URL 参数正则表达式
 var sensitiveURLPattern = regexp.MustCompile(`[?&](token|key|secret|password|auth|access_token|session)[=][^&]*`)
+
+// 完整 URL 往往包含直播间 ID、用户配置或临时鉴权参数。错误遥测不需要这些信息，
+// 因此统一移除，既保护隐私，也避免相同错误按不同房间 URL 分裂成大量 issue。
+var fullURLPattern = regexp.MustCompile(`(?i)\bhttps?://[^\s<>"']+`)
 
 // Init 初始化 Sentry SDK
 // dsn 为 Sentry DSN，留空则禁用
@@ -90,6 +96,7 @@ func RecoverWithContext(ctx context.Context) {
 	if err == nil {
 		return
 	}
+	logRecoveredPanic(err)
 
 	// 尝试上报给 Sentry，但即使失败也不应该再次 panic
 	if IsInitialized() {
@@ -101,7 +108,7 @@ func RecoverWithContext(ctx context.Context) {
 			hub.RecoverWithContext(ctx, err)
 		}
 	}
-	// 不重新 panic，让 goroutine 优雅退出
+	// 不重新 panic；本地日志已经保留脱敏后的错误信息。
 }
 
 // Recover 用于 goroutine 的 panic 恢复（无 context 版本）
@@ -112,6 +119,7 @@ func Recover() {
 	if err == nil {
 		return
 	}
+	logRecoveredPanic(err)
 
 	// 尝试上报给 Sentry，但即使失败也不应该再次 panic
 	if IsInitialized() {
@@ -120,7 +128,11 @@ func Recover() {
 			hub.Recover(err)
 		}
 	}
-	// 不重新 panic，让 goroutine 优雅退出
+	// 不重新 panic；本地日志已经保留脱敏后的错误信息。
+}
+
+func logRecoveredPanic(value interface{}) {
+	logrus.WithField("panic", sanitizeString(fmt.Sprint(value))).Error("goroutine panic recovered")
 }
 
 // CaptureException 捕获异常
@@ -170,6 +182,10 @@ func GoWithContext(ctx context.Context, f func(context.Context)) {
 
 // beforeSendHook 在发送事件前清理敏感数据
 func beforeSendHook(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	// 主机名和 SDK 自动补充的用户字段会识别具体部署，只保留匿名设备 ID。
+	event.ServerName = ""
+	event.User = sentry.User{ID: event.User.ID}
+
 	// 清理异常消息中的敏感数据
 	if event.Message != "" {
 		event.Message = sanitizeString(event.Message)
@@ -196,6 +212,15 @@ func beforeSendHook(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 	// 清理 Extra 数据
 	event.Extra = sanitizeMap(event.Extra)
 
+	// 清理 Breadcrumb 中可能出现的直播间 URL 和敏感字段。
+	for _, breadcrumb := range event.Breadcrumbs {
+		if breadcrumb == nil {
+			continue
+		}
+		breadcrumb.Message = sanitizeString(breadcrumb.Message)
+		breadcrumb.Data = sanitizeMap(breadcrumb.Data)
+	}
+
 	// 清理 Contexts 数据
 	for key, ctxData := range event.Contexts {
 		sanitizedCtx := make(map[string]interface{})
@@ -213,10 +238,27 @@ func beforeSendHook(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 
 	// 清理 Tags 中可能的敏感数据
 	event.Tags = sanitizeTags(event.Tags)
+	delete(event.Tags, "server_name")
 
 	// 清理请求数据
 	if event.Request != nil {
 		event.Request = sanitizeRequest(event.Request)
+	}
+
+	// sentry-go 默认把 Recover 捕获的 panic 标记为 fatal/unhandled，但这些包装器
+	// 已经阻止 panic 逃出 goroutine，应按已处理错误上报，避免误报整个进程崩溃。
+	if hint != nil && hint.RecoveredException != nil {
+		event.Level = sentry.LevelError
+		if event.Tags == nil {
+			event.Tags = make(map[string]string)
+		}
+		event.Tags["panic_handled"] = "true"
+		for i := range event.Exception {
+			if event.Exception[i].Mechanism == nil {
+				event.Exception[i].Mechanism = &sentry.Mechanism{Type: "generic"}
+			}
+			event.Exception[i].Mechanism.Handled = sentry.Pointer(true)
+		}
 	}
 
 	return event
@@ -225,6 +267,9 @@ func beforeSendHook(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 // sanitizeString 清理字符串中的敏感数据
 func sanitizeString(s string) string {
 	result := s
+
+	// 先移除完整 URL，防止直播间地址和查询参数进入遥测。
+	result = fullURLPattern.ReplaceAllString(result, "[REDACTED_URL]")
 
 	// 清理 URL 中的敏感参数
 	result = sensitiveURLPattern.ReplaceAllString(result, "$1=[REDACTED]")
@@ -304,27 +349,20 @@ func sanitizeRequest(req *sentry.Request) *sentry.Request {
 
 	// 清理 URL
 	if req.URL != "" {
-		req.URL = sensitiveURLPattern.ReplaceAllString(req.URL, "$1=[REDACTED]")
+		req.URL = sanitizeString(req.URL)
 	}
 
-	// 清理查询字符串
+	// URL 已整体移除，单独的查询字符串也没有排障价值，避免遗漏未知敏感参数。
 	if req.QueryString != "" {
-		req.QueryString = sensitizeQueryString(req.QueryString)
+		req.QueryString = "[REDACTED]"
 	}
 
 	// 清理敏感请求头
 	if req.Headers != nil {
-		sensitiveHeaders := []string{"authorization", "cookie", "x-api-key", "x-auth-token"}
-		for _, header := range sensitiveHeaders {
-			if _, exists := req.Headers[header]; exists {
+		for header := range req.Headers {
+			switch strings.ToLower(header) {
+			case "authorization", "proxy-authorization", "cookie", "x-api-key", "x-auth-token", "x-forwarded-for", "x-real-ip":
 				req.Headers[header] = "[REDACTED]"
-			}
-			// 也检查首字母大写版本（如 Authorization, Cookie 等）
-			if len(header) > 0 {
-				headerCapitalized := strings.ToUpper(header[:1]) + header[1:]
-				if _, exists := req.Headers[headerCapitalized]; exists {
-					req.Headers[headerCapitalized] = "[REDACTED]"
-				}
 			}
 		}
 	}
@@ -340,16 +378,6 @@ func sanitizeRequest(req *sentry.Request) *sentry.Request {
 	}
 
 	return req
-}
-
-// sensitizeQueryString 清理查询字符串中的敏感参数
-func sensitizeQueryString(qs string) string {
-	result := qs
-	for _, keyword := range sensitiveKeywords {
-		pattern := regexp.MustCompile(`(?i)(` + regexp.QuoteMeta(keyword) + `)=([^&]*)`)
-		result = pattern.ReplaceAllString(result, "$1=[REDACTED]")
-	}
-	return result
 }
 
 // isSensitiveKey 检查键名是否为敏感键

--- a/src/pkg/sentry/sentry_test.go
+++ b/src/pkg/sentry/sentry_test.go
@@ -1,0 +1,93 @@
+package sentry
+
+import (
+	"testing"
+
+	sentrysdk "github.com/getsentry/sentry-go"
+)
+
+func TestBeforeSendHookRemovesDeploymentAndRoomPII(t *testing.T) {
+	event := &sentrysdk.Event{
+		Message:    "failed room https://live.douyin.com/123456?token=secret",
+		ServerName: "users-private-hostname",
+		User: sentrysdk.User{
+			ID:        "anonymous-device-id",
+			Email:     "person@example.com",
+			IPAddress: "192.0.2.1",
+			Username:  "local-user",
+			Name:      "Local User",
+			Data:      map[string]string{"home": "/home/local-user"},
+		},
+		Tags: map[string]string{
+			"server_name": "users-private-hostname",
+			"room":        "https://live.douyin.com/123456",
+		},
+		Exception: []sentrysdk.Exception{{
+			Value: "request https://www.douyu.com/987654 failed",
+		}},
+		Breadcrumbs: []*sentrysdk.Breadcrumb{{
+			Message: "opening https://example.com/private-room",
+			Data:    map[string]interface{}{"url": "https://example.com/private-room"},
+		}},
+		Request: &sentrysdk.Request{
+			URL:         "https://localhost/api/room/123?unknown_private_value=yes",
+			QueryString: "unknown_private_value=yes",
+			Headers: map[string]string{
+				"AUTHORIZATION": "Bearer secret",
+				"X-Real-IP":     "192.0.2.1",
+			},
+		},
+	}
+
+	result := beforeSendHook(event, nil)
+	if result.ServerName != "" {
+		t.Errorf("server name 未清除: %q", result.ServerName)
+	}
+	if result.User.ID != "anonymous-device-id" || result.User.Email != "" || result.User.IPAddress != "" ||
+		result.User.Username != "" || result.User.Name != "" || result.User.Data != nil {
+		t.Errorf("用户字段未按预期仅保留匿名 ID: %#v", result.User)
+	}
+	if _, ok := result.Tags["server_name"]; ok {
+		t.Error("server_name tag 未清除")
+	}
+	assertDoesNotContainURL(t, result.Message)
+	assertDoesNotContainURL(t, result.Exception[0].Value)
+	assertDoesNotContainURL(t, result.Tags["room"])
+	assertDoesNotContainURL(t, result.Breadcrumbs[0].Message)
+	assertDoesNotContainURL(t, result.Breadcrumbs[0].Data["url"].(string))
+	assertDoesNotContainURL(t, result.Request.URL)
+	if result.Request.QueryString != "[REDACTED]" {
+		t.Errorf("查询字符串未整体清理: %q", result.Request.QueryString)
+	}
+	if result.Request.Headers["AUTHORIZATION"] != "[REDACTED]" || result.Request.Headers["X-Real-IP"] != "[REDACTED]" {
+		t.Errorf("大小写不规则的敏感请求头未清理: %#v", result.Request.Headers)
+	}
+}
+
+func TestBeforeSendHookMarksRecoveredPanicHandled(t *testing.T) {
+	unhandled := false
+	event := &sentrysdk.Event{
+		Level: sentrysdk.LevelFatal,
+		Exception: []sentrysdk.Exception{{
+			Mechanism: &sentrysdk.Mechanism{Type: "generic", Handled: &unhandled},
+		}},
+	}
+
+	result := beforeSendHook(event, &sentrysdk.EventHint{RecoveredException: "panic"})
+	if result.Level != sentrysdk.LevelError {
+		t.Errorf("已恢复 panic 应标记为 error，实际 %q", result.Level)
+	}
+	if result.Tags["panic_handled"] != "true" {
+		t.Errorf("缺少 panic_handled tag: %#v", result.Tags)
+	}
+	if result.Exception[0].Mechanism.Handled == nil || !*result.Exception[0].Mechanism.Handled {
+		t.Error("已恢复 panic 的 mechanism 应标记为 handled")
+	}
+}
+
+func assertDoesNotContainURL(t *testing.T, value string) {
+	t.Helper()
+	if fullURLPattern.MatchString(value) {
+		t.Errorf("字符串仍包含完整 URL: %q", value)
+	}
+}

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -437,7 +437,9 @@ func (r *recorder) tryRecord(ctx context.Context) {
 
 	buf := new(bytes.Buffer)
 	if err = tmpl.Execute(buf, info); err != nil {
-		r.getLogger().WithError(err).Error("failed to render filename, recording aborted")
+		r.getLogger().WithError(err).Error("failed to render filename, stopping recorder (check out_put_tmpl)")
+		// 模板错误不会随重试恢复，结束本轮监听，避免每 5 秒重复上报同一错误。
+		r.ed.DispatchEvent(events.NewEvent(listeners.LiveEnd, r.Live))
 		return
 	}
 	// 使用层级配置的 OutPutPath

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/bililive-go/bililive-go/src/configs"
 	"github.com/bililive-go/bililive-go/src/instance"
+	"github.com/bililive-go/bililive-go/src/listeners"
 	"github.com/bililive-go/bililive-go/src/live"
 	livemock "github.com/bililive-go/bililive-go/src/live/mock"
 	"github.com/bililive-go/bililive-go/src/notify"
 	"github.com/bililive-go/bililive-go/src/pipeline"
 	"github.com/bililive-go/bililive-go/src/pkg/events"
+	evtmock "github.com/bililive-go/bililive-go/src/pkg/events/mock"
 	"github.com/bililive-go/bililive-go/src/pkg/livelogger"
 	"github.com/bililive-go/bililive-go/src/types"
 )
@@ -43,12 +45,18 @@ func TestTryRecordStopsWithoutPanicWhenFilenameRenderFails(t *testing.T) {
 	if err := cache.Set(l, &live.Info{Live: l}); err != nil {
 		t.Fatalf("写入直播信息缓存失败: %v", err)
 	}
-	r := &recorder{Live: l, cache: cache}
+	ed := evtmock.NewMockDispatcher(ctrl)
+	ed.EXPECT().DispatchEvent(gomock.Any()).Do(func(event *events.Event) {
+		if event.Type != listeners.LiveEnd || event.Object != l {
+			t.Errorf("模板渲染失败应派发当前直播间的 LiveEnd，实际事件: %#v", event)
+		}
+	})
+	r := &recorder{Live: l, cache: cache, ed: ed}
 
 	r.tryRecord(context.Background())
 
 	logs := logger.GetLogs()
-	if !strings.Contains(logs, "failed to render filename, recording aborted") {
+	if !strings.Contains(logs, "failed to render filename, stopping recorder") {
 		t.Fatalf("未记录文件名渲染失败日志: %s", logs)
 	}
 	if !strings.Contains(logs, "render failed") {

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -930,15 +930,29 @@ func removeLive(writer http.ResponseWriter, r *http.Request) {
 func removeLiveImpl(ctx context.Context, live live.Live) error {
 	inst := instance.GetInstance(ctx)
 	liveId := live.GetLiveId()
+	rawURL := live.GetRawUrl()
 	lm := inst.ListenerManager.(listeners.Manager)
-	if lm.HasListener(ctx, liveId) {
-		if err := lm.RemoveListener(ctx, liveId); err != nil {
-			return err
+	if _, err := configs.RemoveLiveRoomByUrl(rawURL); err != nil {
+		return err
+	}
+	// 初始化完成事件可能正在把临时 LiveID 替换为平台 LiveID。
+	// 按原始 URL 原子删除，确保并发交接后的对象也不会残留在 map 中。
+	removedLives := inst.Lives.DeleteByRawURL(rawURL)
+	liveIDs := map[types.LiveID]struct{}{liveId: {}}
+	for _, removedLive := range removedLives {
+		liveIDs[removedLive.GetLiveId()] = struct{}{}
+	}
+	// LiveMap 已先删除，初始化交接即使正等待 manager 锁，也会因状态过期而退出。
+	// 若交接已经完成，这里会通过新 LiveID 关闭刚创建的 listener。
+	for id := range liveIDs {
+		if lm.HasListener(ctx, id) {
+			if err := lm.RemoveListener(ctx, id); err != nil {
+				return err
+			}
 		}
 	}
-	inst.Lives.Delete(liveId)
-	if _, err := configs.RemoveLiveRoomByUrl(live.GetRawUrl()); err != nil {
-		return err
+	for _, removedLive := range removedLives {
+		removedLive.Close()
 	}
 	// 广播直播间列表变更事件
 	GetSSEHub().BroadcastListChange(liveId, "room_removed", map[string]interface{}{


### PR DESCRIPTION
## 背景

根据最近 30 天 production 环境的 Sentry 事件，集中修复会造成进程级误报、重复事件和隐私信息泄露的几类问题。

## 变更内容

- 修复直播间删除与初始化完成回调之间的竞态
  - 不再因配置已删除而 `panic`
  - 通过对象身份校验原子交接 LiveMap，避免迟到回调复活已删除房间
  - 删除时按原始 URL 清理临时/平台 LiveID，并防止 listener 交接后残留
- 修复斗鱼 CryptoJS CDN 全部不可用时的 panic
  - 改为返回可重试错误
  - 增加并发安全缓存，避免并发重复加载与数据竞争
- 修复无效 `out_put_tmpl` 每 5 秒重复触发同一错误
  - 模板渲染失败后派发 `LiveEnd`，结束当前录制循环
- 收紧 Sentry 上报内容和严重级别
  - 清理完整直播间 URL、请求查询串、主机名及非匿名用户字段
  - 对大小写不规则的敏感请求头同样脱敏
  - 将已 recover 的 goroutine panic 标记为 handled/error，而不是进程崩溃级 fatal
  - recover 后保留脱敏的本地错误日志

对应本次排查中的 GO-B / GO-5、GO-C，以及错误事件重复上报和隐私字段问题。

## 验证

- `make build-web dev`
- `make lint`
- `make test`
- 新增初始化迟到回调、LiveMap 条件替换、CryptoJS 失败重试、Sentry 脱敏和模板错误终止测试
