### PR TITLE
fix: 阻止 Windows 创建资源管理器无法处理的超长录制路径

### DIFF
--- a/src/live/info.go
+++ b/src/live/info.go
@@ -63,6 +63,8 @@ type Info struct {
 	NotifyOnly           bool // 仅开播提醒模式
 	// 最近一次 API 请求的错误信息（用于前端显示错误提示）
 	LastError string
+	// 当前阻止录制启动的永久性错误（例如 Windows 输出路径过长）
+	RecordingError string
 	// 可用流列表（最近一次获取的）
 	AvailableStreams []*AvailableStreamInfo
 	// 可用流更新时间
@@ -93,6 +95,7 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 		NotifyOnly                bool                   `json:"notify_only"`
 		NickName                  string                 `json:"nick_name"`
 		LastError                 string                 `json:"last_error,omitempty"`
+		RecordingError            string                 `json:"recording_error,omitempty"`
 		AvailableStreams          []*AvailableStreamInfo `json:"available_streams,omitempty"`
 		AvailableStreamsUpdatedAt int64                  `json:"available_streams_updated_at,omitempty"`
 	}{
@@ -110,6 +113,7 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 		NotifyOnly:                i.NotifyOnly,
 		NickName:                  i.Live.GetOptions().NickName,
 		LastError:                 i.LastError,
+		RecordingError:            i.RecordingError,
 		AvailableStreams:          i.AvailableStreams,
 		AvailableStreamsUpdatedAt: i.AvailableStreamsUpdatedAt,
 	}

--- a/src/live/info_test.go
+++ b/src/live/info_test.go
@@ -1,0 +1,35 @@
+package live
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bililive-go/bililive-go/src/types"
+)
+
+type infoMarshalLive struct{ Live }
+
+func (l *infoMarshalLive) GetLiveId() types.LiveID     { return "marshal-test" }
+func (l *infoMarshalLive) GetRawUrl() string           { return "https://example.com/room" }
+func (l *infoMarshalLive) GetPlatformCNName() string   { return "测试平台" }
+func (l *infoMarshalLive) GetLastStartTime() time.Time { return time.Time{} }
+func (l *infoMarshalLive) GetOptions() *Options        { return &Options{} }
+
+func TestInfoMarshalJSONIncludesRecordingError(t *testing.T) {
+	data, err := json.Marshal(&Info{
+		Live:           &infoMarshalLive{},
+		RecordingError: "输出文件完整路径过长",
+	})
+	if err != nil {
+		t.Fatalf("序列化直播信息失败: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(data, &response); err != nil {
+		t.Fatalf("解析直播信息失败: %v", err)
+	}
+	if response["recording_error"] != "输出文件完整路径过长" {
+		t.Fatalf("响应未包含录制错误: %#v", response)
+	}
+}

--- a/src/pkg/utils/path.go
+++ b/src/pkg/utils/path.go
@@ -26,6 +26,9 @@ func ValidateOutputFilePath(filePath string) error {
 }
 
 func validateWindowsCompatibleFilePath(filePath string) error {
+	if filepath.IsAbs(filePath) {
+		return validateWindowsCompatibleAbsoluteFilePath(filePath)
+	}
 	absolutePath, err := filepath.Abs(filePath)
 	if err != nil {
 		return fmt.Errorf("无法解析输出文件绝对路径: %w", err)
@@ -71,7 +74,16 @@ func validateWindowsCompatibleAbsoluteFilePath(filePath string) error {
 func windowsUTF16Length(value string) int {
 	length := 0
 	for _, r := range value {
-		length += utf16.RuneLen(r)
+		length += windowsUTF16RuneLength(r)
 	}
 	return length
+}
+
+func windowsUTF16RuneLength(r rune) int {
+	runeLength := utf16.RuneLen(r)
+	if runeLength < 1 {
+		// 非法代理项不能让总长度倒退；按一个 UTF-16 码元保守计数。
+		return 1
+	}
+	return runeLength
 }

--- a/src/pkg/utils/path.go
+++ b/src/pkg/utils/path.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode/utf16"
+)
+
+const (
+	// Windows 传统 MAX_PATH 为 260，其中包含结尾的 NUL。
+	windowsMaxFilePathLength = 259
+	// 创建目录时需要为 8.3 文件名预留 12 个字符。
+	windowsMaxDirPathLength   = 247
+	windowsMaxComponentLength = 255
+)
+
+// ValidateOutputFilePath 在 Windows 上检查输出文件路径是否能被资源管理器等
+// 仍受传统 MAX_PATH 限制的程序可靠处理。其他平台不施加 Windows 路径限制。
+func ValidateOutputFilePath(filePath string) error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	return validateWindowsCompatibleFilePath(filePath)
+}
+
+func validateWindowsCompatibleFilePath(filePath string) error {
+	absolutePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("无法解析输出文件绝对路径: %w", err)
+	}
+	return validateWindowsCompatibleAbsoluteFilePath(absolutePath)
+}
+
+func validateWindowsCompatibleAbsoluteFilePath(filePath string) error {
+	cleanPath := filepath.Clean(filePath)
+
+	for _, component := range strings.FieldsFunc(cleanPath, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if length := windowsUTF16Length(component); length > windowsMaxComponentLength {
+			return fmt.Errorf(
+				"输出路径中的单个名称过长（%d 个字符，Windows 兼容上限为 %d），请缩短输出模板",
+				length,
+				windowsMaxComponentLength,
+			)
+		}
+	}
+
+	if length := windowsUTF16Length(cleanPath); length > windowsMaxFilePathLength {
+		return fmt.Errorf(
+			"输出文件完整路径过长（%d 个字符，Windows 兼容上限为 %d），请缩短输出目录或输出模板",
+			length,
+			windowsMaxFilePathLength,
+		)
+	}
+
+	directoryPath := filepath.Dir(cleanPath)
+	if length := windowsUTF16Length(directoryPath); length > windowsMaxDirPathLength {
+		return fmt.Errorf(
+			"输出文件夹路径过长（%d 个字符，Windows 兼容上限为 %d），请缩短输出目录或输出模板",
+			length,
+			windowsMaxDirPathLength,
+		)
+	}
+
+	return nil
+}
+
+func windowsUTF16Length(value string) int {
+	length := 0
+	for _, r := range value {
+		length += utf16.RuneLen(r)
+	}
+	return length
+}

--- a/src/pkg/utils/path_test.go
+++ b/src/pkg/utils/path_test.go
@@ -16,6 +16,18 @@ func TestValidateWindowsCompatibleAbsoluteFilePath(t *testing.T) {
 			path: "/recordings/平台/主播/2026-08-29 03-29-00.flv",
 		},
 		{
+			name: "单个名称恰好达到上限",
+			path: "/" + strings.Repeat("a", windowsMaxComponentLength),
+		},
+		{
+			name: "完整文件路径恰好达到上限",
+			path: "/" + strings.Repeat("a/", 120) + strings.Repeat("b", 18),
+		},
+		{
+			name: "文件夹路径恰好达到上限",
+			path: "/" + strings.Repeat("a/", 122) + "bb/x.flv",
+		},
+		{
 			name:        "单个名称超过上限",
 			path:        "/recordings/" + strings.Repeat("a", windowsMaxComponentLength+1) + ".flv",
 			errorSubstr: "单个名称过长",
@@ -51,5 +63,17 @@ func TestValidateWindowsCompatibleAbsoluteFilePath(t *testing.T) {
 func TestWindowsUTF16Length(t *testing.T) {
 	if got := windowsUTF16Length("中文😀"); got != 4 {
 		t.Fatalf("UTF-16 长度期望为 4，实际为 %d", got)
+	}
+
+	// utf16.RuneLen 对代理项返回 -1，长度统计必须进行下限保护。
+	if got := windowsUTF16RuneLength(rune(0xd800)); got != 1 {
+		t.Fatalf("非法代理项应按一个 UTF-16 码元计数，实际为 %d", got)
+	}
+}
+
+func TestValidateOutputFilePathOnCurrentPlatform(t *testing.T) {
+	err := ValidateOutputFilePath("recording.flv")
+	if err != nil {
+		t.Fatalf("普通输出路径不应校验失败: %v", err)
 	}
 }

--- a/src/pkg/utils/path_test.go
+++ b/src/pkg/utils/path_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateWindowsCompatibleAbsoluteFilePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		errorSubstr string
+	}{
+		{
+			name: "普通路径",
+			path: "/recordings/平台/主播/2026-08-29 03-29-00.flv",
+		},
+		{
+			name:        "单个名称超过上限",
+			path:        "/recordings/" + strings.Repeat("a", windowsMaxComponentLength+1) + ".flv",
+			errorSubstr: "单个名称过长",
+		},
+		{
+			name:        "完整文件路径超过上限",
+			path:        "/" + strings.Repeat("a/", 120) + strings.Repeat("b", 19),
+			errorSubstr: "输出文件完整路径过长",
+		},
+		{
+			name:        "文件夹路径超过上限",
+			path:        "/" + strings.Repeat("a/", 124) + "x.flv",
+			errorSubstr: "输出文件夹路径过长",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWindowsCompatibleAbsoluteFilePath(tt.path)
+			if tt.errorSubstr == "" {
+				if err != nil {
+					t.Fatalf("普通路径不应校验失败: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.errorSubstr) {
+				t.Fatalf("期望错误包含 %q，实际为 %v", tt.errorSubstr, err)
+			}
+		})
+	}
+}
+
+func TestWindowsUTF16Length(t *testing.T) {
+	if got := windowsUTF16Length("中文😀"); got != 4 {
+		t.Fatalf("UTF-16 长度期望为 4，实际为 %d", got)
+	}
+}

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -49,7 +49,10 @@ const (
 	stopped
 )
 
-const soopRetryWarnInterval = time.Minute
+const (
+	soopRetryWarnInterval       = time.Minute
+	bililiveRecorderPart0Suffix = "_PART000"
+)
 
 // for test
 var (
@@ -171,6 +174,16 @@ func findBililiveRecorderOutputFiles(expectedFileName string) []string {
 	}
 
 	return validFiles
+}
+
+func replaceOutputFileExtension(fileName, extension string) string {
+	currentExtension := filepath.Ext(fileName)
+	return strings.TrimSuffix(fileName, currentExtension) + extension
+}
+
+func bililiveRecorderPart0FileName(fileName string) string {
+	extension := filepath.Ext(fileName)
+	return strings.TrimSuffix(fileName, extension) + bililiveRecorderPart0Suffix + extension
 }
 
 // resolveParserName 根据下载器类型返回实际使用的 parser 名称
@@ -362,6 +375,9 @@ type recorder struct {
 	lastRetryLogKey         string
 	lastRetryLogAt          time.Time
 	suppressedRetryLogCount int
+
+	recordingErrorMu sync.RWMutex
+	recordingError   string
 }
 
 func NewRecorder(ctx context.Context, live live.Live) (Recorder, error) {
@@ -444,19 +460,39 @@ func (r *recorder) tryRecord(ctx context.Context) {
 	}
 	// 使用层级配置的 OutPutPath
 	fileName := filepath.Join(resolvedConfig.OutPutPath, buf.String())
-	if err = validateOutputFilePath(fileName); err != nil {
-		r.getLogger().WithError(err).Error("输出文件路径不兼容 Windows，已取消本次录制")
-		return
-	}
-	outputPath, _ := filepath.Split(fileName)
 
 	// TODO 根据配置选择最佳流
 	streamInfo := r.selectPreferredStream(streamInfos)
+	url := streamInfo.Url
+
+	if strings.Contains(url.Path, "m3u8") {
+		fileName = replaceOutputFileExtension(fileName, ".ts")
+	}
+
+	if info.AudioOnly {
+		fileName = replaceOutputFileExtension(fileName, ".aac")
+	}
+
+	// 使用层级配置的下载器类型
+	downloaderType := resolvedConfig.Feature.GetEffectiveDownloaderType()
+	effectiveParserName := resolveParserName(downloaderType, strings.Contains(url.Path, ".flv"), nil)
+	pathToValidate := fileName
+	if downloaderType == configs.DownloaderBililiveRecorder {
+		// BililiveRecorder 首个实际落盘文件会追加 _PART000，必须校验真实候选路径。
+		pathToValidate = bililiveRecorderPart0FileName(fileName)
+	}
+	if err = validateOutputFilePath(pathToValidate); err != nil {
+		if r.setRecordingError(err) {
+			r.getLogger().WithError(err).Error("输出文件路径不兼容 Windows，已取消本次录制")
+		} else {
+			r.getLogger().WithError(err).Debug("输出文件路径仍不兼容 Windows，继续跳过本次录制")
+		}
+		return
+	}
+	r.clearRecordingError()
 	r.saveCurrentStreamInfo(streamInfo)
 	// 更新可用流信息到 info（用于API展示）
 	r.updateAvailableStreams(ctx, info, streamInfos)
-
-	url := streamInfo.Url
 
 	// 保存原始流 URL 和 Headers（供前端调试展示）
 	r.currentFileLock.Lock()
@@ -464,14 +500,7 @@ func (r *recorder) tryRecord(ctx context.Context) {
 	r.currentStreamHeaders = streamInfo.HeadersForDownloader
 	r.currentFileLock.Unlock()
 
-	if strings.Contains(url.Path, "m3u8") {
-		fileName = fileName[:len(fileName)-4] + ".ts"
-	}
-
-	if info.AudioOnly {
-		fileName = fileName[:strings.LastIndex(fileName, ".")] + ".aac"
-	}
-
+	outputPath, _ := filepath.Split(fileName)
 	if err = mkdir(outputPath); err != nil {
 		r.getLogger().WithError(err).Errorf("failed to create output path[%s]", outputPath)
 		return
@@ -480,8 +509,6 @@ func (r *recorder) tryRecord(ctx context.Context) {
 		"timeout_in_us": strconv.Itoa(resolvedConfig.TimeoutInUs),
 		"audio_only":    strconv.FormatBool(info.AudioOnly),
 	}
-	// 使用层级配置的下载器类型
-	downloaderType := resolvedConfig.Feature.GetEffectiveDownloaderType()
 
 	// 如果启用了 FLV 代理分段且使用 FFmpeg 下载器，传递配置
 	if resolvedConfig.Feature.EnableFlvProxySegment && downloaderType == configs.DownloaderFFmpeg {
@@ -496,7 +523,7 @@ func (r *recorder) tryRecord(ctx context.Context) {
 	// 直接否决。只有当前直播间实际取不到 FFmpeg 且后台仍在 checking/downloading
 	// 时才等待；终态后仍取不到则直接返回，不再连接上游 / 启动 StreamProbe，避免
 	// FFmpeg 缺失或下载失败时每 5 秒重试都触碰直播源、触发平台限流。
-	if resolveParserName(downloaderType, strings.Contains(url.Path, ".flv"), nil) == ffmpeg.Name {
+	if effectiveParserName == ffmpeg.Name {
 		_, ffmpegPathErr := utils.GetFFmpegPathForLive(ctx, r.Live)
 		ffmpegState := tools.GetFFmpegStatus().State
 		if ffmpegPathErr != nil && resolvedConfig.FfmpegPath != "" {
@@ -1527,6 +1554,33 @@ func (r *recorder) getCurrentFilePath() string {
 	return r.currentFilePath
 }
 
+// RecordingError 返回当前阻止录制启动的永久性错误，供 API 向前端展示。
+func (r *recorder) RecordingError() string {
+	r.recordingErrorMu.RLock()
+	defer r.recordingErrorMu.RUnlock()
+	return r.recordingError
+}
+
+// setRecordingError 保存错误，并返回错误内容是否发生变化。
+func (r *recorder) setRecordingError(err error) bool {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+
+	r.recordingErrorMu.Lock()
+	defer r.recordingErrorMu.Unlock()
+	if r.recordingError == message {
+		return false
+	}
+	r.recordingError = message
+	return true
+}
+
+func (r *recorder) clearRecordingError() {
+	r.setRecordingError(nil)
+}
+
 func (r *recorder) GetStatus() (map[string]interface{}, error) {
 	var status map[string]interface{}
 
@@ -1543,6 +1597,9 @@ func (r *recorder) GetStatus() (map[string]interface{}, error) {
 	}
 	if status == nil {
 		status = make(map[string]interface{})
+	}
+	if recordingError := r.RecordingError(); recordingError != "" {
+		status["recording_error"] = recordingError
 	}
 
 	// 添加文件路径和文件大小信息

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -74,6 +74,8 @@ var (
 			os.Remove(file)
 		}
 	}
+
+	validateOutputFilePath = utils.ValidateOutputFilePath
 )
 
 // videoExtensions 用于匹配弹幕文件对应的视频文件
@@ -442,6 +444,10 @@ func (r *recorder) tryRecord(ctx context.Context) {
 	}
 	// 使用层级配置的 OutPutPath
 	fileName := filepath.Join(resolvedConfig.OutPutPath, buf.String())
+	if err = validateOutputFilePath(fileName); err != nil {
+		r.getLogger().WithError(err).Error("输出文件路径不兼容 Windows，已取消本次录制")
+		return
+	}
 	outputPath, _ := filepath.Split(fileName)
 
 	// TODO 根据配置选择最佳流

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/bluele/gcache"
@@ -63,10 +64,13 @@ func TestTryRecordStopsBeforeCreatingInvalidOutputPath(t *testing.T) {
 	previousMkdir := mkdir
 	cfg := configs.NewConfig()
 	cfg.OutputTmpl = `recording.flv`
+	cfg.Feature.DownloaderType = configs.DownloaderBililiveRecorder
 	configs.SetCurrentConfig(cfg)
 
 	mkdirCalled := false
-	validateOutputFilePath = func(string) error {
+	validatedPath := ""
+	validateOutputFilePath = func(path string) error {
+		validatedPath = path
 		return errors.New("输出文件完整路径过长")
 	}
 	mkdir = func(string) error {
@@ -85,19 +89,23 @@ func TestTryRecordStopsBeforeCreatingInvalidOutputPath(t *testing.T) {
 	streamURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/stream.flv"}
 
 	l.EXPECT().GetRawUrl().Return("https://example.com/room").AnyTimes()
-	l.EXPECT().GetStreamInfos().Return([]*live.StreamUrlInfo{{Url: streamURL}}, nil)
-	l.EXPECT().GetLogger().Return(logger)
+	l.EXPECT().GetStreamInfos().Return([]*live.StreamUrlInfo{{Url: streamURL}}, nil).Times(2)
+	l.EXPECT().GetLogger().Return(logger).AnyTimes()
 
 	cache := gcache.New(1).LRU().Build()
-	if err := cache.Set(l, &live.Info{Live: l}); err != nil {
+	if err := cache.Set(l, &live.Info{Live: l, AudioOnly: true}); err != nil {
 		t.Fatalf("写入直播信息缓存失败: %v", err)
 	}
-	r := &recorder{Live: l, cache: cache}
+	r := &recorder{Live: l, cache: cache, parserLock: new(sync.RWMutex)}
 
+	r.tryRecord(context.Background())
 	r.tryRecord(context.Background())
 
 	if mkdirCalled {
 		t.Fatal("路径校验失败后不应创建输出目录")
+	}
+	if !strings.HasSuffix(validatedPath, "recording_PART000.aac") {
+		t.Fatalf("应校验最终扩展名和 BililiveRecorder 分段后缀，实际路径为 %s", validatedPath)
 	}
 	logs := logger.GetLogs()
 	if !strings.Contains(logs, "输出文件路径不兼容 Windows，已取消本次录制") {
@@ -105,6 +113,62 @@ func TestTryRecordStopsBeforeCreatingInvalidOutputPath(t *testing.T) {
 	}
 	if !strings.Contains(logs, "输出文件完整路径过长") {
 		t.Fatalf("日志未保留路径校验错误: %s", logs)
+	}
+	if count := strings.Count(logs, "输出文件路径不兼容 Windows，已取消本次录制"); count != 1 {
+		t.Fatalf("相同永久错误应只记录一次 Error，实际记录 %d 次: %s", count, logs)
+	}
+	status, err := r.GetStatus()
+	if err != nil {
+		t.Fatalf("获取录制状态失败: %v", err)
+	}
+	if status["recording_error"] != "输出文件完整路径过长" {
+		t.Fatalf("前端状态未包含路径错误: %#v", status)
+	}
+}
+
+func TestReplaceOutputFileExtensionUsesFinalExtension(t *testing.T) {
+	tests := []struct {
+		name      string
+		fileName  string
+		extension string
+		want      string
+	}{
+		{name: "FLV 转 TS", fileName: "recording.flv", extension: ".ts", want: "recording.ts"},
+		{name: "短扩展名转 AAC", fileName: "recording.x", extension: ".aac", want: "recording.aac"},
+		{name: "无扩展名追加 AAC", fileName: "recording", extension: ".aac", want: "recording.aac"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := replaceOutputFileExtension(tt.fileName, tt.extension); got != tt.want {
+				t.Fatalf("替换扩展名结果期望 %q，实际为 %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBililiveRecorderPart0FileName(t *testing.T) {
+	got := bililiveRecorderPart0FileName("recording.flv")
+	if got != "recording_PART000.flv" {
+		t.Fatalf("首个分段文件名期望 recording_PART000.flv，实际为 %s", got)
+	}
+}
+
+func TestRecordingErrorState(t *testing.T) {
+	r := &recorder{}
+	err := errors.New("路径过长")
+	if !r.setRecordingError(err) {
+		t.Fatal("首次设置录制错误应报告状态变化")
+	}
+	if r.setRecordingError(err) {
+		t.Fatal("重复设置相同录制错误不应报告状态变化")
+	}
+	if got := r.RecordingError(); got != err.Error() {
+		t.Fatalf("录制错误期望 %q，实际为 %q", err, got)
+	}
+	r.clearRecordingError()
+	if got := r.RecordingError(); got != "" {
+		t.Fatalf("清除后录制错误应为空，实际为 %q", got)
 	}
 }
 

--- a/src/recorders/recorder_test.go
+++ b/src/recorders/recorder_test.go
@@ -2,6 +2,7 @@ package recorders
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"strings"
 	"testing"
@@ -53,6 +54,57 @@ func TestTryRecordStopsWithoutPanicWhenFilenameRenderFails(t *testing.T) {
 	}
 	if !strings.Contains(logs, "render failed") {
 		t.Fatalf("日志未保留原始模板错误: %s", logs)
+	}
+}
+
+func TestTryRecordStopsBeforeCreatingInvalidOutputPath(t *testing.T) {
+	previousConfig := configs.GetCurrentConfig()
+	previousValidator := validateOutputFilePath
+	previousMkdir := mkdir
+	cfg := configs.NewConfig()
+	cfg.OutputTmpl = `recording.flv`
+	configs.SetCurrentConfig(cfg)
+
+	mkdirCalled := false
+	validateOutputFilePath = func(string) error {
+		return errors.New("输出文件完整路径过长")
+	}
+	mkdir = func(string) error {
+		mkdirCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		configs.SetCurrentConfig(previousConfig)
+		validateOutputFilePath = previousValidator
+		mkdir = previousMkdir
+	})
+
+	ctrl := gomock.NewController(t)
+	l := livemock.NewMockLive(ctrl)
+	logger := livelogger.New(0, logrus.Fields{"test": t.Name()})
+	streamURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/stream.flv"}
+
+	l.EXPECT().GetRawUrl().Return("https://example.com/room").AnyTimes()
+	l.EXPECT().GetStreamInfos().Return([]*live.StreamUrlInfo{{Url: streamURL}}, nil)
+	l.EXPECT().GetLogger().Return(logger)
+
+	cache := gcache.New(1).LRU().Build()
+	if err := cache.Set(l, &live.Info{Live: l}); err != nil {
+		t.Fatalf("写入直播信息缓存失败: %v", err)
+	}
+	r := &recorder{Live: l, cache: cache}
+
+	r.tryRecord(context.Background())
+
+	if mkdirCalled {
+		t.Fatal("路径校验失败后不应创建输出目录")
+	}
+	logs := logger.GetLogs()
+	if !strings.Contains(logs, "输出文件路径不兼容 Windows，已取消本次录制") {
+		t.Fatalf("未记录路径校验失败日志: %s", logs)
+	}
+	if !strings.Contains(logs, "输出文件完整路径过长") {
+		t.Fatalf("日志未保留路径校验错误: %s", logs)
 	}
 }
 

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -1452,6 +1452,15 @@ func previewOutputTmpl(writer http.ResponseWriter, r *http.Request) {
 	// 计算最终路径
 	absOutPutPath, _ := filepath.Abs(outPutPath)
 	previewPath := filepath.Join(absOutPutPath, buf.String())
+	if err := utils.ValidateOutputFilePath(previewPath); err != nil {
+		writeJSON(writer, map[string]interface{}{
+			"success":      false,
+			"error":        err.Error(),
+			"error_type":   "path_too_long",
+			"preview_path": previewPath,
+		})
+		return
+	}
 
 	writeJSON(writer, map[string]interface{}{
 		"success":       true,

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -43,6 +43,12 @@ import (
 	"github.com/bililive-go/bililive-go/src/types"
 )
 
+var validatePreviewOutputFilePath = utils.ValidateOutputFilePath
+
+type recordingErrorProvider interface {
+	RecordingError() string
+}
+
 // FIXME: remove this
 func parseInfo(ctx context.Context, l live.Live) *live.Info {
 	inst := instance.GetInstance(ctx)
@@ -62,7 +68,10 @@ func parseInfo(ctx context.Context, l live.Live) *live.Info {
 			Initializing: true,
 		}
 	} else {
-		info = obj.(*live.Info)
+		// API 状态字段只写入副本，避免修改缓存中可能被其他 goroutine 读取的 Info。
+		cachedInfo := obj.(*live.Info)
+		infoCopy := *cachedInfo
+		info = &infoCopy
 	}
 
 	info.Listening = inst.ListenerManager.(listeners.Manager).HasListener(ctx, l.GetLiveId())
@@ -70,14 +79,21 @@ func parseInfo(ctx context.Context, l live.Live) *live.Info {
 	// HasRecorder=true 但输出文件没有数据时，说明在重试（获取流 URL、连接失败等）
 	// 前端应显示"录制准备中"而非"录制中"，避免用户误以为正在正常录制
 	//
-	// 注意：info 是从缓存获取的共享对象，必须先重置两个互斥字段，
-	// 否则前一次调用的残留值会导致 recording=true + recording_preparing=true 同时返回
+	// 每次从当前 Recorder 状态重新计算这些临时 API 字段。
 	info.Recording = false
 	info.RecordingPreparing = false
+	info.RecordingError = ""
 	recorderMgr := inst.RecorderManager.(recorders.Manager)
 	if recorderMgr.HasRecorder(ctx, l.GetLiveId()) {
-		if recorder, err := recorderMgr.GetRecorder(ctx, l.GetLiveId()); err == nil && recorder.IsRecording() {
-			info.Recording = true
+		if recorder, err := recorderMgr.GetRecorder(ctx, l.GetLiveId()); err == nil {
+			if recorder.IsRecording() {
+				info.Recording = true
+			} else {
+				info.RecordingPreparing = true
+			}
+			if provider, ok := recorder.(recordingErrorProvider); ok {
+				info.RecordingError = provider.RecordingError()
+			}
 		} else {
 			// 有 recorder 但尚未真正开始录制（例如流 URL 404 导致不断重试）
 			info.RecordingPreparing = true
@@ -1452,7 +1468,7 @@ func previewOutputTmpl(writer http.ResponseWriter, r *http.Request) {
 	// 计算最终路径
 	absOutPutPath, _ := filepath.Abs(outPutPath)
 	previewPath := filepath.Join(absOutPutPath, buf.String())
-	if err := utils.ValidateOutputFilePath(previewPath); err != nil {
+	if err := validatePreviewOutputFilePath(previewPath); err != nil {
 		writeJSON(writer, map[string]interface{}{
 			"success":      false,
 			"error":        err.Error(),

--- a/src/servers/handler_test.go
+++ b/src/servers/handler_test.go
@@ -1,8 +1,10 @@
 package servers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -69,4 +71,36 @@ func TestGetPlatformStatsReportsDisabledRateLimit(t *testing.T) {
 		assert.Equal(t, configs.PlatformKeyDouyin, response.Platforms[0].PlatformKey)
 		assert.Empty(t, response.Platforms[0].WarningMessage)
 	}
+}
+
+func TestPreviewOutputTmplReportsPathTooLong(t *testing.T) {
+	previousConfig := configs.GetCurrentConfig()
+	previousValidator := validatePreviewOutputFilePath
+	configs.SetCurrentConfig(configs.NewConfig())
+	validatePreviewOutputFilePath = func(string) error {
+		return errors.New("输出文件完整路径过长")
+	}
+	t.Cleanup(func() {
+		configs.SetCurrentConfig(previousConfig)
+		validatePreviewOutputFilePath = previousValidator
+	})
+
+	body := bytes.NewBufferString(`{"template":"recording.flv","out_put_path":"."}`)
+	request := httptest.NewRequest("POST", "/api/config/preview-template", body)
+	recorder := httptest.NewRecorder()
+
+	previewOutputTmpl(recorder, request)
+
+	assert.Equal(t, 200, recorder.Code)
+	var response struct {
+		Success     bool   `json:"success"`
+		Error       string `json:"error"`
+		ErrorType   string `json:"error_type"`
+		PreviewPath string `json:"preview_path"`
+	}
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.False(t, response.Success)
+	assert.Equal(t, "输出文件完整路径过长", response.Error)
+	assert.Equal(t, "path_too_long", response.ErrorType)
+	assert.NotEmpty(t, response.PreviewPath)
 }

--- a/src/webapp/src/component/live-list/index.tsx
+++ b/src/webapp/src/component/live-list/index.tsx
@@ -986,13 +986,18 @@ class LiveList extends React.Component<Props, IState> {
                         tags.push('仅提醒')
                     }
 
+                    const roomErrors = [
+                        item.last_error,
+                        item.recording_error ? `录制错误：${item.recording_error}` : ''
+                    ].filter(Boolean);
+
                     return {
                         key: index + 1,
                         name: item.nick_name || item.host_name,
                         room: {
                             roomName: item.room_name,
                             url: item.live_url,
-                            lastError: item.last_error
+                            lastError: roomErrors.join('\n') || undefined
                         },
                         address: item.platform_cn_name,
                         tags,
@@ -1586,6 +1591,15 @@ class LiveList extends React.Component<Props, IState> {
                                         {detail.recording ? '录制中' : detail.recording_preparing ? '录制准备中' : '未录制'}
                                     </Tag>
                                 </div>
+                                {detail.recorder_status?.recording_error && (
+                                    <Alert
+                                        message="录制启动失败"
+                                        description={detail.recorder_status.recording_error}
+                                        type="error"
+                                        showIcon
+                                        style={{ margin: '8px 12px' }}
+                                    />
+                                )}
                                 {/* 当前录制画质信息 */}
                                 {detail.recording && detail.recorder_status?.stream_quality && (
                                     <div style={configRowStyle}>


### PR DESCRIPTION
## 问题

Windows 版在输出模板渲染后的完整路径过长时，Go 文件 API 仍可能通过扩展长度路径成功创建目录和录制文件，但资源管理器等仍受传统 `MAX_PATH` 限制的程序无法正常访问或删除，表现为“文件夹不存在”的幽灵目录。

## 修复

- 新增 Windows 输出路径兼容性校验，按 UTF-16 长度检查完整文件路径、目录路径和单个路径组件
- 在创建输出目录前执行校验，超限时中止本次录制并输出可操作的错误提示
- 模板预览接口同步返回 `path_too_long` 错误，帮助用户提前缩短输出目录或模板
- 增加边界长度、中文/Emoji UTF-16 计数以及“校验失败后不创建目录”的回归测试
- 非 Windows 平台不施加 Windows 路径限制

## 验证

- [x] `make build-web dev`
- [x] `make dev`
- [x] `make lint`（0 issues）
- [x] `make test`
- [x] `PLATFORM=windows ARCH=amd64 make dev`