### PR TITLE
fix: 消除配置快照并发读写导致的 fatal 崩溃

### DIFF
--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -1170,27 +1170,21 @@ func (c *Config) RefreshLiveRoomIndexCache() {
 	}
 }
 
-func (c *Config) RemoveLiveRoomByUrl(url string) error {
-	c.RefreshLiveRoomIndexCache()
-	if index, ok := c.liveRoomIndexCache[url]; ok {
-		if index >= 0 && index < len(c.LiveRooms) && c.LiveRooms[index].Url == url {
-			c.LiveRooms = append(c.LiveRooms[:index], c.LiveRooms[index+1:]...)
-			delete(c.liveRoomIndexCache, url)
-			return nil
-		}
-	}
-	return errors.New("failed removing room: " + url)
-}
-
 func (c *Config) GetLiveRoomByUrl(url string) (*LiveRoom, error) {
-	room, err := c.getLiveRoomByUrlImpl(url)
-	if err != nil {
-		c.RefreshLiveRoomIndexCache()
-		if room, err = c.getLiveRoomByUrlImpl(url); err != nil {
-			return nil, err
+	// 配置快照是不可变的：所有写操作都走 Update 的“复制-修改-原子替换”路径，
+	// 并在替换前调用 RefreshLiveRoomIndexCache 维护索引缓存。因此这里只做只读查找，
+	// 绝不在共享快照上写 map/切片，否则会与其它 goroutine 的读发生并发读写，
+	// 触发 Go 运行时的 fatal error（concurrent map read and map write）。
+	if room, err := c.getLiveRoomByUrlImpl(url); err == nil {
+		return room, nil
+	}
+	// 索引缓存未命中时回退到只读线性扫描，作为兜底（例如未经 Refresh 的手工构造配置）。
+	for i := range c.LiveRooms {
+		if c.LiveRooms[i].Url == url {
+			return &c.LiveRooms[i], nil
 		}
 	}
-	return room, nil
+	return nil, errors.New("room " + url + " doesn't exist.")
 }
 
 func (c Config) getLiveRoomByUrlImpl(url string) (*LiveRoom, error) {

--- a/src/configs/config_test.go
+++ b/src/configs/config_test.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/bililive-go/bililive-go/src/pkg/ratelimit"
@@ -119,6 +120,40 @@ func TestPlatformRateLimitRemainsDisabledAfterConfigUpdate(t *testing.T) {
 	if limits := limiter.GetAllPlatformLimits(); len(limits) != 0 {
 		t.Fatalf("临时配置更新后平台限流应保持关闭，实际限制：%v", limits)
 	}
+}
+
+// TestGetLiveRoomByUrlConcurrent 保证在共享的不可变配置快照上并发查询房间时不会
+// 触发 Go 运行时的 "concurrent map read and map write" fatal error。
+// 回归此前的 bug：GetLiveRoomByUrl 在缓存未命中时会调用 RefreshLiveRoomIndexCache
+// 写入共享快照的 map，与其它 goroutine 的读并发时导致崩溃。
+// 使用 -race 运行可进一步检测数据竞争。
+func TestGetLiveRoomByUrlConcurrent(t *testing.T) {
+	cfg := NewConfig()
+	cfg.LiveRooms = []LiveRoom{
+		{Url: "https://live.bilibili.com/1", IsListening: true},
+		{Url: "https://live.bilibili.com/2", IsListening: true},
+	}
+	cfg.RefreshLiveRoomIndexCache()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				// 交替命中缓存与未命中（触发原先的写-回退路径）。
+				if (i+j)%2 == 0 {
+					room, err := cfg.GetLiveRoomByUrl("https://live.bilibili.com/1")
+					assert.NoError(t, err)
+					assert.Equal(t, "https://live.bilibili.com/1", room.Url)
+				} else {
+					_, err := cfg.GetLiveRoomByUrl("https://live.bilibili.com/does-not-exist")
+					assert.Error(t, err)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestBackwardsCompatibility(t *testing.T) {

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -952,8 +952,9 @@ func getConfig(writer http.ResponseWriter, r *http.Request) {
 }
 
 func putConfig(writer http.ResponseWriter, r *http.Request) {
+	// 直接序列化当前快照即可；索引缓存不参与序列化，且共享快照不可变，
+	// 不能在此调用 RefreshLiveRoomIndexCache 写它的 map。
 	config := configs.GetCurrentConfig()
-	config.RefreshLiveRoomIndexCache()
 	if err := config.Marshal(); err != nil {
 		writeJsonWithStatusCode(writer, http.StatusBadRequest, commonResp{
 			ErrNo:  http.StatusBadRequest,
@@ -1002,7 +1003,8 @@ func putRawConfig(writer http.ResponseWriter, r *http.Request) {
 		return
 	}
 	oldConfig := configs.GetCurrentConfig()
-	oldConfig.RefreshLiveRoomIndexCache()
+	// 共享快照不可变：其索引缓存在生成时已由 Update 维护好，
+	// 这里只做只读查找，不能再调用 RefreshLiveRoomIndexCache 写它的 map。
 	// 继承原配置的文件路径
 	newConfig.File = oldConfig.File
 	// 预先将旧配置中的 LiveId 迁移到新配置（相同 URL）


### PR DESCRIPTION
## 问题

用户反馈「点击开始录制后一段时间报错崩溃」。goroutine dump 显示的是 Go 运行时的 **fatal error**（非普通 panic，无法 recover，整个进程直接退出）：

```
internal/runtime/maps.fatal(...)               → concurrent map read and map write
  configs.Config.getLiveRoomByUrlImpl   config.go
  configs.(*Config).GetLiveRoomByUrl    config.go
  servers.parseInfo                     handler.go
  servers.getAllLives.func1             handler.go   ← 前端轮询直播间列表的接口
```

## 根因

配置采用「不可变快照」架构：所有写操作走 `Update` 的复制-修改-原子替换（`atomic.Value`），替换前统一调用 `RefreshLiveRoomIndexCache` 维护索引缓存；读者拿到只读快照。前提是**已存入的快照绝不能再被就地修改**。

但有三处代码违反了该约定，在共享快照上写 `liveRoomIndexCache` 这个 map：

1. `GetLiveRoomByUrl` 缓存未命中时调用 `RefreshLiveRoomIndexCache()` 写共享 map。该函数被列表接口、录制、监听、通知等大量 goroutine 高频并发调用——一个在写、另一个在读同一 map，触发 fatal。录制中前端持续轮询 `getAllLives`，并发量一上来即崩，正对应用户现象。
2. `putConfig`（handler.go）
3. `putRawConfig`（handler.go）

## 改动

- **`GetLiveRoomByUrl` 改为纯只读**：命中索引缓存直接返回；未命中回退到只读线性扫描做兜底，不再写共享快照的 map。快照的缓存本就在生成时由 `Update` 维护好，原「刷新后重试」既多余又危险。
- **移除 `putConfig` / `putRawConfig` 中对共享快照的 `RefreshLiveRoomIndexCache()` 调用**：`Marshal` 不序列化该缓存，后续查找也已是只读。
- **删除死方法 `(*Config).RemoveLiveRoomByUrl`**：无任何调用者，且同样就地修改快照（实际使用的是走 `Update` 的同名包级函数）。
- **新增并发回归测试 `TestGetLiveRoomByUrlConcurrent`**：64 goroutine × 500 次交替命中/未命中并发查询共享快照；修复前会触发运行时并发 map 检测，修复后稳定通过。

## 验证

- `go build ./...` / `go vet` 通过
- `go test ./src/configs/... ./src/servers/...` 全部通过
- 新增回归测试 `-count=3` 稳定通过

> 注：CI 环境无 gcc，`-race` 无法启用，但 Go 运行时对并发 map 读写的 fatal 检测不依赖 `-race`，回归测试在普通模式下同样有效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)